### PR TITLE
fix: correct broken asset links

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -32,13 +32,11 @@
   z-index: -1;
 }
 
-/* Estilos generales del body: fuente, color de texto y fondo con imagen */
+/* Estilos generales del body: fuente, color de texto y fondo */
 body {
     font-family: var(--font-main);
     color: var(--color-text);
-    background-image: url('../images/background_1.jpg');
-    background-size: cover;
-    background-position: center;
+    background-color: var(--color-bg);
     min-height: 100vh;
 }
 
@@ -98,9 +96,9 @@ header nav ul li a {
 }
 
 /* Hero Section */
-/* Sección principal con imagen de fondo y texto centrado */
+/* Sección principal con fondo de color y texto centrado */
 #hero {
-    background: url('../images/background_1.jpg') no-repeat center center/cover;
+    background-color: var(--color-bg);
     height: 60vh;
     min-height: 20rem;
     display: flex;

--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
 <!-- Sección de video de fondo en la landing page -->
 <section class="landing">
   <video autoplay muted loop playsinline class="background-video">
-    <source src="/images/Eclipse_small.mp4" type="video/mp4">
+    <source src="images/Eclipse_small.mp4" type="video/mp4">
     Tu navegador no soporta videos HTML5.
   </video>
 </section>
@@ -119,7 +119,7 @@
         <div class="container">
             <p>&copy; 2023 Esoteria. Todos los derechos reservados.</p>
             <ul class="social-links">
-                <li><a href="096999999">Whatsapp</a></li>
+                <li><a href="https://wa.me/096999999">Whatsapp</a></li>
                 <li><a href="https://www.instagram.com/ocultalunaris/">Instagram</a></li>
             </ul>
         </div>


### PR DESCRIPTION
## Summary
- replace missing background image with color fallback
- point video source and WhatsApp link to valid URLs

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a8dbd0cb088328963f131982471170