### PR TITLE
Patch 01: Add dark premium design system shell

### DIFF
--- a/src/components/Badge.astro
+++ b/src/components/Badge.astro
@@ -1,5 +1,13 @@
 ---
-// Insignia simple para tags/stack
-const { label } = Astro.props;
+// Insignia simple para tags/stack compatible con el tema oscuro V2
+const { label, tone = 'default' } = Astro.props;
+const tones = {
+  default: 'border-line bg-surface-glass text-muted-bright',
+  cyan: 'border-cyan-electric/30 bg-cyan-electric/10 text-cyan-100',
+  violet: 'border-violet-electric/30 bg-violet-electric/10 text-violet-100',
+  success: 'border-brand-success/30 bg-brand-success/10 text-emerald-100',
+  warning: 'border-brand-warning/30 bg-brand-warning/10 text-amber-100'
+};
+const classes = tones[tone] ?? tones.default;
 ---
-<span class="inline-flex items-center rounded-full bg-gray-100 px-2.5 py-0.5 text-xs font-medium text-gray-700 border">{label}</span>
+<span class={`inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-medium shadow-sm backdrop-blur ${classes}`}>{label}</span>

--- a/src/components/Container.astro
+++ b/src/components/Container.astro
@@ -1,0 +1,6 @@
+---
+const { class: className = '' } = Astro.props;
+---
+<div class={`mx-auto w-full max-w-content px-4 sm:px-6 lg:px-8 ${className}`}>
+  <slot />
+</div>

--- a/src/components/GlowCard.astro
+++ b/src/components/GlowCard.astro
@@ -1,0 +1,11 @@
+---
+const { as = 'div', class: className = '' } = Astro.props;
+const Tag = as;
+---
+<Tag class={`group relative overflow-hidden rounded-3xl border border-line bg-surface-glow p-5 shadow-premium backdrop-blur transition duration-300 hover:-translate-y-0.5 hover:border-line-strong hover:shadow-premium-hover ${className}`}>
+  <div class="pointer-events-none absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-cyan-electric/50 to-transparent opacity-70"></div>
+  <div class="pointer-events-none absolute -right-14 -top-14 h-32 w-32 rounded-full bg-cyan-electric/10 blur-3xl transition duration-300 group-hover:bg-cyan-electric/20"></div>
+  <div class="relative">
+    <slot />
+  </div>
+</Tag>

--- a/src/components/SectionHeader.astro
+++ b/src/components/SectionHeader.astro
@@ -1,0 +1,21 @@
+---
+const { eyebrow, title, description, align = 'left', class: className = '' } = Astro.props;
+const alignment = align === 'center' ? 'mx-auto text-center items-center' : 'items-start';
+---
+<header class={`flex max-w-3xl flex-col gap-3 ${alignment} ${className}`}>
+  {eyebrow && (
+    <p class="inline-flex w-fit items-center rounded-full border border-line bg-surface-glass px-3 py-1 text-xs font-semibold uppercase tracking-[0.22em] text-cyan-electric">
+      {eyebrow}
+    </p>
+  )}
+  {title && (
+    <h2 class="text-3xl font-semibold tracking-tight text-slate-50 sm:text-4xl lg:text-5xl">
+      {title}
+    </h2>
+  )}
+  {description && (
+    <p class="text-base leading-7 text-muted-soft sm:text-lg">
+      {description}
+    </p>
+  )}
+</header>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -15,7 +15,7 @@ const pathname = (typeof url === "string" && url) ? (url.startsWith("http") ? ne
 const canonical = new URL(pathname, site).href;
 const ogImage = image.startsWith("http") ? image : new URL(image, site).href;
 ---
-<html lang="es" class="scroll-smooth">
+<html lang="es" class="dark scroll-smooth">
   <head>
     <!-- Metadatos básicos -->
     <meta charset="utf-8" />
@@ -138,9 +138,9 @@ const ogImage = image.startsWith("http") ? image : new URL(image, site).href;
 
     <link rel="icon" href="/favicon.svg" />
   </head>
-  <body class="min-h-screen bg-white text-gray-900 antialiased overflow-x-hidden overscroll-contain">
+  <body class="theme-v2 v2-shell min-h-screen bg-ink text-slate-50 antialiased overflow-x-hidden overscroll-contain">
 
-    <a href="#contenido" class="sr-only focus:not-sr-only">Saltar al contenido</a>
+    <a href="#contenido" class="sr-only focus:not-sr-only focus:fixed focus:left-4 focus:top-4 focus:z-[100] focus:rounded-lg focus:bg-slate-50 focus:px-4 focus:py-2 focus:text-sm focus:font-semibold focus:text-ink">Saltar al contenido</a>
     <Nav />
     <main id="contenido" class="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
       <slot />

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -1,9 +1,151 @@
-/* src/styles/tailwind.css */
-/* ------------------------ */
-/* 1) Directivas de Tailwind: generan el CSS final */
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
 
-/* 2) Aquí puedes extender utilidades globales (opcional) */
-/* Ej.: .container custom, tipografías, etc. */
+@layer base {
+  :root {
+    color-scheme: dark;
+    --color-ink: #070a12;
+    --color-surface: #0d1222;
+    --color-line: rgba(148, 163, 184, 0.14);
+    --color-text: #f8fafc;
+    --color-muted: #94a3b8;
+    --color-brand: #22d3ee;
+  }
+
+  html {
+    min-width: 320px;
+    background: var(--color-ink);
+  }
+
+  body {
+    min-width: 320px;
+    overflow-x: hidden;
+    background:
+      radial-gradient(
+        circle at 14% 0%,
+        rgba(34, 211, 238, 0.18),
+        transparent 28rem
+      ),
+      radial-gradient(
+        circle at 86% 18%,
+        rgba(139, 92, 246, 0.13),
+        transparent 30rem
+      ),
+      linear-gradient(180deg, #050816 0%, #070a12 42%, #080b14 100%);
+    color: var(--color-text);
+    text-rendering: optimizeLegibility;
+  }
+
+  ::selection {
+    background: rgba(34, 211, 238, 0.3);
+    color: #f8fafc;
+  }
+
+  a {
+    text-underline-offset: 0.2em;
+  }
+
+  :focus-visible {
+    outline: 2px solid var(--color-brand);
+    outline-offset: 3px;
+  }
+
+  img,
+  svg,
+  video,
+  canvas {
+    max-width: 100%;
+  }
+}
+
+@layer components {
+  .v2-shell {
+    position: relative;
+    isolation: isolate;
+  }
+
+  .v2-shell::before {
+    content: "";
+    position: fixed;
+    inset: 0;
+    z-index: -2;
+    pointer-events: none;
+    background-image:
+      linear-gradient(rgba(148, 163, 184, 0.045) 1px, transparent 1px),
+      linear-gradient(90deg, rgba(148, 163, 184, 0.045) 1px, transparent 1px);
+    background-size: 48px 48px;
+    mask-image: linear-gradient(
+      to bottom,
+      rgba(0, 0, 0, 0.65),
+      transparent 72%
+    );
+  }
+
+  .v2-shell::after {
+    content: "";
+    position: fixed;
+    inset: 0;
+    z-index: -1;
+    pointer-events: none;
+    background:
+      radial-gradient(
+        circle at 20% 8%,
+        rgba(34, 211, 238, 0.16),
+        transparent 24rem
+      ),
+      radial-gradient(
+        circle at 78% 32%,
+        rgba(59, 130, 246, 0.1),
+        transparent 28rem
+      ),
+      radial-gradient(
+        circle at 50% 100%,
+        rgba(139, 92, 246, 0.08),
+        transparent 30rem
+      );
+  }
+
+  .prose-dark {
+    color: #cbd5e1;
+  }
+
+  .prose-dark :where(h1, h2, h3, h4, strong) {
+    color: #f8fafc;
+  }
+
+  .prose-dark :where(a) {
+    color: #67e8f9;
+  }
+}
+
+/* Compatibility layer: mantiene páginas existentes legibles mientras se rediseñan por patches. */
+.theme-v2 .text-gray-900,
+.theme-v2 .text-gray-800,
+.theme-v2 .text-gray-700 {
+  color: #f8fafc;
+}
+
+.theme-v2 .text-gray-600,
+.theme-v2 .text-gray-500 {
+  color: #cbd5e1;
+}
+
+.theme-v2 .border,
+.theme-v2 .border-gray-200\/70,
+.theme-v2 .border-gray-300\/70,
+.theme-v2 .border-gray-700\/70 {
+  border-color: rgba(148, 163, 184, 0.14);
+}
+
+.theme-v2 input,
+.theme-v2 textarea,
+.theme-v2 select {
+  background-color: rgba(15, 23, 42, 0.58);
+  color: #f8fafc;
+}
+
+.theme-v2 input::placeholder,
+.theme-v2 textarea::placeholder {
+  color: #94a3b8;
+}

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -1,23 +1,86 @@
-// Tailwind: tokens básicos sobrios (neutros + acento)
-import defaultTheme from 'tailwindcss/defaultTheme';
+// Tailwind: design tokens para Marin.dev V2 (oscuro premium + acentos comerciales)
+import defaultTheme from "tailwindcss/defaultTheme";
 
 export default {
-  content: ['./src/**/*.{astro,html,js,jsx,md,mdx,ts,tsx}'],
+  darkMode: "class",
+  content: ["./src/**/*.{astro,html,js,jsx,md,mdx,ts,tsx}"],
   theme: {
     extend: {
       colors: {
         brand: {
-          DEFAULT: '#2563EB', // azul sobrio
-          dark: '#1E40AF'
-        }
+          DEFAULT: "#22D3EE",
+          dark: "#0891B2",
+          blue: "#3B82F6",
+          violet: "#8B5CF6",
+          success: "#34D399",
+          warning: "#FBBF24",
+        },
+        ink: {
+          DEFAULT: "#070A12",
+          950: "#050816",
+          900: "#070A12",
+          850: "#080B14",
+          800: "#0B1020",
+        },
+        surface: {
+          DEFAULT: "#0D1222",
+          900: "#0D1222",
+          850: "#10172A",
+          800: "#111C31",
+          glass: "rgba(15, 23, 42, 0.72)",
+        },
+        line: {
+          DEFAULT: "rgba(148, 163, 184, 0.14)",
+          strong: "rgba(148, 163, 184, 0.24)",
+          glow: "rgba(34, 211, 238, 0.32)",
+        },
+        muted: {
+          DEFAULT: "#94A3B8",
+          soft: "#CBD5E1",
+          bright: "#E2E8F0",
+        },
+        cyan: {
+          electric: "#22D3EE",
+        },
+        violet: {
+          electric: "#8B5CF6",
+        },
+        blue: {
+          electric: "#3B82F6",
+        },
       },
       fontFamily: {
-        sans: ['Inter', ...defaultTheme.fontFamily.sans]
+        sans: ["Inter", ...defaultTheme.fontFamily.sans],
+      },
+      maxWidth: {
+        content: "72rem",
+        copy: "44rem",
+      },
+      borderRadius: {
+        "2.5xl": "1.25rem",
+        "4xl": "2rem",
       },
       boxShadow: {
-        soft: '0 6px 30px -12px rgba(0,0,0,0.25)'
-      }
-    }
+        soft: "0 6px 30px -12px rgba(0,0,0,0.25)",
+        glow: "0 24px 80px -32px rgba(34, 211, 238, 0.45)",
+        premium:
+          "0 28px 90px -40px rgba(15, 23, 42, 0.95), 0 0 0 1px rgba(148, 163, 184, 0.10)",
+        "premium-hover":
+          "0 34px 110px -42px rgba(34, 211, 238, 0.35), 0 0 0 1px rgba(148, 163, 184, 0.18)",
+      },
+      backgroundImage: {
+        "radial-cyan":
+          "radial-gradient(circle at 15% 10%, rgba(34, 211, 238, 0.20), transparent 30%)",
+        "radial-violet":
+          "radial-gradient(circle at 85% 20%, rgba(139, 92, 246, 0.16), transparent 32%)",
+        "premium-grid":
+          "linear-gradient(rgba(148, 163, 184, 0.055) 1px, transparent 1px), linear-gradient(90deg, rgba(148, 163, 184, 0.055) 1px, transparent 1px)",
+        "brand-gradient":
+          "linear-gradient(135deg, #22D3EE 0%, #3B82F6 52%, #8B5CF6 100%)",
+        "surface-glow":
+          "linear-gradient(180deg, rgba(15, 23, 42, 0.88), rgba(13, 18, 34, 0.78))",
+      },
+    },
   },
-  plugins: []
+  plugins: [],
 };


### PR DESCRIPTION
### Motivation
- Establish a dark, premium visual foundation for the V2 redesign so subsequent patches can build on a consistent design system.
- Provide reusable primitives and tokens to support hero, portfolio and service work without changing page content yet.
- Keep compatibility with the existing site while shifting the global shell toward a studio-like aesthetic.

### Description
- Added extended Tailwind design tokens and dark-mode support in `tailwind.config.mjs` (ink/surface/line/muted palettes, cyan/blue/violet accents, shadows, radii, gradients and `darkMode: 'class'`).
- Replaced the global stylesheet `src/styles/tailwind.css` with a V2 shell that applies dark variables, radial glow backgrounds, subtle grid overlay, accessible `:focus-visible`/`::selection` rules, `prose-dark` helpers and a compatibility layer for current classes.
- Applied the V2 shell in `src/layouts/BaseLayout.astro` by enabling the dark root class and switching the `body` to the new `theme-v2 v2-shell` classes while improving the skip-link focus treatment.
- Added new reusable components `src/components/Container.astro`, `src/components/SectionHeader.astro`, and `src/components/GlowCard.astro`, and updated `src/components/Badge.astro` to support tone variants for the dark theme.

Files created/modified: `tailwind.config.mjs`, `src/styles/tailwind.css`, `src/layouts/BaseLayout.astro`, `src/components/Container.astro`, `src/components/SectionHeader.astro`, `src/components/GlowCard.astro`, `src/components/Badge.astro`.

### Testing
- Ran `npm run build` and the build completed successfully (static site generated; 10 pages built and `sitemap-index.xml` produced).
- Ran `npx prettier --write` for formatting which succeeded for JS/CSS files but failed to format `.astro` files due to no Prettier Astro parser configured in this repo, so `.astro` files remain unchanged by Prettier in this run.
- Verified there is no local browser/screenshot binary available in the environment so visual screenshots were not captured, and manual visual review in a browser is recommended for next patch.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fea7781e648328a4cb27283f5e3652)