### PR TITLE
Polish premium dark shell navigation

### DIFF
--- a/src/components/FAQs.astro
+++ b/src/components/FAQs.astro
@@ -36,7 +36,7 @@ const faqs = [
           <span class="text-sm md:text-base font-medium">{item.q}</span>
           <span class="ml-4 shrink-0 inline-flex h-6 w-6 items-center justify-center rounded-lg border border-gray-300/70 dark:border-gray-700/70">
             <!-- ícono +/− simple -->
-            <svg class="transition group-open:rotate-45" width="14" height="14" viewBox="0 0 24 24" fill="none">
+            <svg class="size-3.5 transition group-open:rotate-45" viewBox="0 0 24 24" fill="none">
               <path d="M12 5v14M5 12h14" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
             </svg>
           </span>

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,18 +1,32 @@
 ---
-import { EMAIL, GITHUB_URL, LINKEDIN_URL, WHATSAPP_BASE_URL } from "../lib/contact";
+import Container from './Container.astro';
+import { EMAIL, GITHUB_URL, LINKEDIN_URL, WHATSAPP_BASE_URL } from '../lib/contact';
 ---
-<footer class="mt-16 border-t">
-  <div class="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8 py-10 text-sm text-gray-600">
-    <div class="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4">
-      <p>© {new Date().getFullYear()} Diego Marin. Todos los derechos reservados.</p>
+<footer class="mt-20 border-t border-line bg-ink/70">
+  <Container class="py-10 text-sm text-muted-soft">
+    <div class="grid gap-8 md:grid-cols-[1.2fr_1fr] md:items-center">
+      <div>
+        <p class="text-base font-semibold text-slate-50">Marin.dev</p>
+        <p class="mt-2 max-w-xl leading-6">
+          Demos web, landings y sistemas simples con estética premium, foco comercial y deploy listo para compartir.
+        </p>
+      </div>
 
-      <div class="flex flex-wrap gap-x-4 gap-y-2">
-        <a href="/politica-de-privacidad" class="hover:text-brand">Política de privacidad</a>
-        <a href={WHATSAPP_BASE_URL} class="hover:text-brand" target="_blank" rel="noopener noreferrer">WhatsApp</a>
-        <a href={`mailto:${EMAIL}`} class="hover:text-brand">{EMAIL}</a>
-        <a href={GITHUB_URL} class="hover:text-brand" target="_blank" rel="noopener noreferrer">GitHub</a>
-        <a href={LINKEDIN_URL} class="hover:text-brand" target="_blank" rel="noopener noreferrer">LinkedIn</a>
+      <div class="flex flex-wrap gap-x-4 gap-y-2 md:justify-end">
+        <a href="/politica-de-privacidad" class="transition hover:text-cyan-100">Privacidad</a>
+        <a href={WHATSAPP_BASE_URL} class="transition hover:text-cyan-100" target="_blank" rel="noopener noreferrer">WhatsApp</a>
+        <a href={`mailto:${EMAIL}`} class="transition hover:text-cyan-100">Email</a>
+        <a href={GITHUB_URL} class="transition hover:text-cyan-100" target="_blank" rel="noopener noreferrer">GitHub</a>
+        <a href={LINKEDIN_URL} class="transition hover:text-cyan-100" target="_blank" rel="noopener noreferrer">LinkedIn</a>
       </div>
     </div>
-  </div>
+
+    <div class="mt-8 flex flex-col gap-3 border-t border-line pt-6 text-xs text-muted sm:flex-row sm:items-center sm:justify-between">
+      <p>© {new Date().getFullYear()} Diego Marin. Todos los derechos reservados.</p>
+      <p class="inline-flex items-center gap-2">
+        <span class="h-2 w-2 rounded-full bg-brand-success shadow-[0_0_18px_rgba(52,211,153,0.55)]"></span>
+        Sitio estático, rápido y mantenible.
+      </p>
+    </div>
+  </Container>
 </footer>

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -24,7 +24,7 @@ import { EMAIL, GITHUB_URL, LINKEDIN_URL, WHATSAPP_BASE_URL } from '../lib/conta
     <div class="mt-8 flex flex-col gap-3 border-t border-line pt-6 text-xs text-muted sm:flex-row sm:items-center sm:justify-between">
       <p>© {new Date().getFullYear()} Diego Marin. Todos los derechos reservados.</p>
       <p class="inline-flex items-center gap-2">
-        <span class="h-2 w-2 rounded-full bg-brand-success shadow-[0_0_18px_rgba(52,211,153,0.55)]"></span>
+        <span class="size-2 rounded-full bg-brand-success shadow-[0_0_1.125rem_rgba(52,211,153,0.55)]"></span>
         Sitio estático, rápido y mantenible.
       </p>
     </div>

--- a/src/components/GlowCard.astro
+++ b/src/components/GlowCard.astro
@@ -3,7 +3,7 @@ const { as = 'div', class: className = '' } = Astro.props;
 const Tag = as;
 ---
 <Tag class={`group relative overflow-hidden rounded-3xl border border-line bg-surface-glow p-5 shadow-premium backdrop-blur transition duration-300 hover:-translate-y-0.5 hover:border-line-strong hover:shadow-premium-hover ${className}`}>
-  <div class="pointer-events-none absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-cyan-electric/50 to-transparent opacity-70"></div>
+  <div class="pointer-events-none absolute inset-x-0 top-0 h-[0.0625rem] bg-gradient-to-r from-transparent via-cyan-electric/50 to-transparent opacity-70"></div>
   <div class="pointer-events-none absolute -right-14 -top-14 h-32 w-32 rounded-full bg-cyan-electric/10 blur-3xl transition duration-300 group-hover:bg-cyan-electric/20"></div>
   <div class="relative">
     <slot />

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -1,13 +1,7 @@
 ---
-import { waLink, DEFAULT_WHATSAPP_MESSAGE } from "../lib/contact";
-/* NAVBAR RESPONSIVE—FIXES MOVIL
-   Cambios clave:
-   1) Overlay full viewport con opacidad transicionada (nada de hidden que rompe stacking).
-   2) Panel usa h-dvh (altura dinámica móvil) + safe-area top/bottom.
-   3) Bloqueo de scroll del documento cuando el menú está abierto.
-   4) Sincronización de estados: aria-expanded, mostrar/ocultar hamburguesa según estado.
-   5) Colores explícitos en los links para buen contraste en dark y light.
-*/
+import Container from './Container.astro';
+import { waLink, DEFAULT_WHATSAPP_MESSAGE } from '../lib/contact';
+
 const links = [
   { href: '/', label: 'Inicio' },
   { href: '/proyectos', label: 'Proyectos' },
@@ -19,24 +13,30 @@ const links = [
 
 const current = Astro.url.pathname;
 ---
-<nav class="sticky top-0 z-50 w-full border-b bg-white/80 backdrop-blur supports-[backdrop-filter]:bg-white/60 dark:bg-[#0b1220]/80 dark:supports-[backdrop-filter]:bg-[#0b1220]/60">
-  <div class="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8 h-14 flex items-center justify-between">
-        <!-- Marca -->
-    <a href="/" class="font-semibold flex items-center gap-2 text-gray-900 dark:text-white">
-      <img src="/logo.png" alt="Marin.dev" class="h-6 w-6 rounded-full object-cover" loading="eager" decoding="async" />
-      <span>Marin.dev</span>
+<nav class="sticky top-0 z-50 w-full border-b border-line bg-ink/80 shadow-soft backdrop-blur-xl supports-[backdrop-filter]:bg-ink/60">
+  <Container class="flex h-16 items-center justify-between">
+    <a href="/" class="group flex items-center gap-3 font-semibold text-slate-50" aria-label="Marin.dev inicio">
+      <span class="relative grid h-9 w-9 place-items-center overflow-hidden rounded-2xl border border-line bg-surface-glass shadow-premium">
+        <span class="absolute inset-0 bg-brand-gradient opacity-20 transition group-hover:opacity-35"></span>
+        <img src="/logo.png" alt="" class="relative h-7 w-7 rounded-xl object-cover" loading="eager" decoding="async" />
+      </span>
+      <span class="leading-tight">
+        <span class="block text-sm tracking-wide">Marin.dev</span>
+        <span class="hidden text-[11px] font-medium uppercase tracking-[0.22em] text-muted sm:block">Digital studio</span>
+      </span>
     </a>
 
-    <!-- Desktop nav -->
-    <ul class="hidden md:flex items-center gap-5 text-sm">
+    <ul class="hidden items-center gap-1 rounded-full border border-line bg-surface-glass p-1 text-sm shadow-soft backdrop-blur md:flex">
       {links.map((l) => {
         const isActive = current === l.href || (l.href !== '/' && current.startsWith(l.href));
         return (
           <li>
             <a
               href={l.href}
-              class={`hover:text-brand transition ${
-                isActive ? 'text-brand font-medium' : 'text-gray-800 dark:text-gray-200'
+              class={`inline-flex rounded-full px-3.5 py-2 transition ${
+                isActive
+                  ? 'bg-cyan-electric/10 text-cyan-100 shadow-[inset_0_0_0_1px_rgba(34,211,238,0.22)]'
+                  : 'text-muted-soft hover:bg-white/5 hover:text-slate-50'
               }`}
               aria-current={isActive ? 'page' : undefined}
             >
@@ -47,66 +47,64 @@ const current = Astro.url.pathname;
       })}
     </ul>
 
-    <!-- CTA discreto en desktop -->
     <div class="hidden md:block">
-      <a href={waLink(DEFAULT_WHATSAPP_MESSAGE)} class="text-sm font-medium hover:text-brand" target="_blank" rel="noopener noreferrer">Cotizar por WhatsApp</a>
+      <a
+        href={waLink(DEFAULT_WHATSAPP_MESSAGE)}
+        class="inline-flex items-center justify-center rounded-full bg-brand-gradient px-4 py-2 text-sm font-semibold text-slate-950 shadow-glow transition hover:-translate-y-0.5 hover:shadow-premium-hover"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        Pedir demo
+      </a>
     </div>
 
-    <!-- Botón hamburguesa (solo móvil) -->
     <button
       id="nav-toggle"
-      class="md:hidden inline-flex items-center justify-center rounded-lg p-2 border border-gray-300/70 dark:border-gray-700/70"
+      class="inline-flex items-center justify-center rounded-2xl border border-line bg-surface-glass p-2.5 text-slate-100 shadow-soft backdrop-blur transition hover:border-line-strong hover:bg-white/5 md:hidden"
       aria-label="Abrir menú"
       aria-controls="mobile-menu"
       aria-expanded="false"
       data-open="false"
     >
-      <!-- Ícono hamburguesa -->
-      <svg id="icon-open" width="20" height="20" viewBox="0 0 24 24" fill="none" class="text-gray-800 dark:text-gray-200">
-        <path d="M4 7h16M4 12h16M4 17h16" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+      <svg id="icon-open" width="20" height="20" viewBox="0 0 24 24" fill="none">
+        <path d="M4 7h16M4 12h16M4 17h16" stroke="currentColor" stroke-width="2" stroke-linecap="round" />
       </svg>
-      <!-- Ícono cerrar (se oculta por defecto) -->
-      <svg id="icon-close" width="20" height="20" viewBox="0 0 24 24" fill="none" class="hidden text-gray-800 dark:text-gray-200">
-        <path d="M6 6l12 12M18 6L6 18" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+      <svg id="icon-close" width="20" height="20" viewBox="0 0 24 24" fill="none" class="hidden">
+        <path d="M6 6l12 12M18 6L6 18" stroke="currentColor" stroke-width="2" stroke-linecap="round" />
       </svg>
     </button>
-  </div>
+  </Container>
 
-  <!-- Overlay de fondo: ocupa SIEMPRE el viewport, pero deshabilitado por opacidad/pointer-events -->
   <div
     id="mobile-overlay"
-    class="md:hidden fixed inset-0 z-40 opacity-0 pointer-events-none transition-opacity duration-200 bg-black/40"
+    class="fixed inset-0 z-40 bg-ink/75 opacity-0 backdrop-blur-sm transition-opacity duration-200 pointer-events-none md:hidden"
     aria-hidden="true"
   ></div>
 
-  <!-- Panel móvil: h-dvh para cubrir alto real; safe-area padding para no chocar barra del sistema -->
   <aside
-  id="mobile-menu"
-  class="md:hidden fixed top-0 right-0 z-50 h-dvh w-[min(20rem,92vw)] translate-x-full bg-white dark:bg-[#0b1220] border-l border-gray-200/70 dark:border-gray-700/70 shadow-xl transition-transform duration-200"
-  tabindex="-1"
-  aria-hidden="true"
->
-
-    <!-- Header del panel -->
-    <div class="h-14 px-4 flex items-center justify-between border-b border-gray-200/70 dark:border-gray-700/70 pt-[env(safe-area-inset-top)]">
-      <span class="font-semibold">Menú</span>
-      <button id="nav-close" class="inline-flex items-center justify-center rounded-lg p-2" aria-label="Cerrar menú">
-        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" class="text-gray-800 dark:text-gray-200">
-          <path d="M6 6l12 12M18 6L6 18" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+    id="mobile-menu"
+    class="fixed right-0 top-0 z-50 h-dvh w-[min(21rem,92vw)] translate-x-full border-l border-line bg-surface/95 shadow-premium backdrop-blur-xl transition-transform duration-200 md:hidden"
+    tabindex="-1"
+    aria-hidden="true"
+  >
+    <div class="flex h-16 items-center justify-between border-b border-line px-4 pt-[env(safe-area-inset-top)]">
+      <span class="text-sm font-semibold uppercase tracking-[0.18em] text-muted-soft">Menú</span>
+      <button id="nav-close" class="inline-flex items-center justify-center rounded-xl border border-line bg-white/5 p-2 text-slate-100" aria-label="Cerrar menú">
+        <svg width="20" height="20" viewBox="0 0 24 24" fill="none">
+          <path d="M6 6l12 12M18 6L6 18" stroke="currentColor" stroke-width="2" stroke-linecap="round" />
         </svg>
       </button>
     </div>
 
-    <!-- Links -->
-    <ul class="p-4 space-y-2 pb-[calc(env(safe-area-inset-bottom)+16px)]">
+    <ul class="space-y-2 p-4 pb-[calc(env(safe-area-inset-bottom)+16px)]">
       {links.map((l) => {
         const isActive = current === l.href || (l.href !== '/' && current.startsWith(l.href));
         return (
           <li>
             <a
               href={l.href}
-              class={`block rounded-lg px-3 py-2 text-sm hover:bg-gray-100 dark:hover:bg-white/10 ${
-                isActive ? 'text-brand font-medium' : 'text-gray-900 dark:text-gray-100'
+              class={`block rounded-2xl px-4 py-3 text-sm transition ${
+                isActive ? 'bg-cyan-electric/10 font-semibold text-cyan-100' : 'text-muted-soft hover:bg-white/5 hover:text-slate-50'
               }`}
               aria-current={isActive ? 'page' : undefined}
             >
@@ -115,91 +113,84 @@ const current = Astro.url.pathname;
           </li>
         );
       })}
-      <li class="pt-2">
-        <a href="/contacto" class="block rounded-lg px-3 py-2 text-sm font-medium bg-gray-900 text-white hover:bg-gray-800 dark:bg-gray-100 dark:text-gray-900 dark:hover:bg-white text-center">
-          Pedir estimación
+      <li class="pt-3">
+        <a
+          href={waLink(DEFAULT_WHATSAPP_MESSAGE)}
+          class="block rounded-2xl bg-brand-gradient px-4 py-3 text-center text-sm font-semibold text-slate-950 shadow-glow"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Pedir demo por WhatsApp
         </a>
       </li>
     </ul>
   </aside>
 
-  <!-- Lógica de apertura/cierre y focus -->
   <script>
-  const $toggle = document.getElementById('nav-toggle');
-  const $iconOpen = document.getElementById('icon-open');
-  const $iconClose = document.getElementById('icon-close');
-  const $menu = document.getElementById('mobile-menu');
-  const $overlay = document.getElementById('mobile-overlay');
-  const $close = document.getElementById('nav-close');
+    const $toggle = document.getElementById('nav-toggle');
+    const $iconOpen = document.getElementById('icon-open');
+    const $iconClose = document.getElementById('icon-close');
+    const $menu = document.getElementById('mobile-menu');
+    const $overlay = document.getElementById('mobile-overlay');
+    const $close = document.getElementById('nav-close');
 
-  let scrollY = 0;
+    let scrollY = 0;
 
-  const lockBody = () => {
-    // Guardamos la posición vertical actual
-    scrollY = window.scrollY || window.pageYOffset || 0;
-    // Fijamos el body: esto evita que el viewport “se corra” al abrir el panel
-    const b = document.body.style;
-    b.position = 'fixed';
-    b.top = `-${scrollY}px`;
-    b.left = '0';
-    b.right = '0';
-    b.width = '100%';
-    b.overflow = 'hidden';
-  };
+    const lockBody = () => {
+      scrollY = window.scrollY || window.pageYOffset || 0;
+      const b = document.body.style;
+      b.position = 'fixed';
+      b.top = `-${scrollY}px`;
+      b.left = '0';
+      b.right = '0';
+      b.width = '100%';
+      b.overflow = 'hidden';
+    };
 
-  const unlockBody = () => {
-    const b = document.body.style;
-    b.position = '';
-    b.top = '';
-    b.left = '';
-    b.right = '';
-    b.width = '';
-    b.overflow = '';
-    // Restauramos la posición exacta anterior
-    window.scrollTo(0, scrollY);
-  };
+    const unlockBody = () => {
+      const b = document.body.style;
+      b.position = '';
+      b.top = '';
+      b.left = '';
+      b.right = '';
+      b.width = '';
+      b.overflow = '';
+      window.scrollTo(0, scrollY);
+    };
 
-  const setState = (open) => {
-    // Panel
-    $menu?.classList.toggle('translate-x-full', !open);
-    $menu?.setAttribute('aria-hidden', String(!open));
+    const setState = (open) => {
+      $menu?.classList.toggle('translate-x-full', !open);
+      $menu?.setAttribute('aria-hidden', String(!open));
+      $overlay?.classList.toggle('opacity-0', !open);
+      $overlay?.classList.toggle('pointer-events-none', !open);
+      $toggle?.setAttribute('aria-expanded', String(open));
+      $toggle?.setAttribute('data-open', String(open));
+      $iconOpen?.classList.toggle('hidden', open);
+      $iconClose?.classList.toggle('hidden', !open);
 
-    // Overlay
-    $overlay?.classList.toggle('opacity-0', !open);
-    $overlay?.classList.toggle('pointer-events-none', !open);
+      if (open) lockBody(); else unlockBody();
 
-    // Botón / iconos
-    $toggle?.setAttribute('aria-expanded', String(open));
-    $toggle?.setAttribute('data-open', String(open));
-    $iconOpen?.classList.toggle('hidden', open);
-    $iconClose?.classList.toggle('hidden', !open);
+      if (open) {
+        const firstLink = $menu?.querySelector('a');
+        firstLink && firstLink.focus({ preventScroll: true });
+      } else {
+        $toggle?.focus({ preventScroll: true });
+      }
+    };
 
-    // Lock/unlock body
-    if (open) lockBody(); else unlockBody();
+    const open = () => setState(true);
+    const close = () => setState(false);
 
-    // Enfoque accesible sin desplazar el viewport
-    if (open) {
-      const firstLink = $menu?.querySelector('a');
-      firstLink && firstLink.focus({ preventScroll: true });
-    } else {
-      $toggle?.focus({ preventScroll: true });
-    }
-  };
-
-  const open = () => setState(true);
-  const close = () => setState(false);
-
-  $toggle?.addEventListener('click', () => {
-    const isOpen = $toggle?.getAttribute('data-open') === 'true';
-    isOpen ? close() : open();
-  });
-  $close?.addEventListener('click', close);
-  $overlay?.addEventListener('click', close);
-  window.addEventListener('keydown', (e) => { if (e.key === 'Escape') close(); });
-  $menu?.addEventListener('click', (e) => {
-    const t = e.target;
-    if (t && t.tagName === 'A') close();
-  });
-</script>
-
+    $toggle?.addEventListener('click', () => {
+      const isOpen = $toggle?.getAttribute('data-open') === 'true';
+      isOpen ? close() : open();
+    });
+    $close?.addEventListener('click', close);
+    $overlay?.addEventListener('click', close);
+    window.addEventListener('keydown', (e) => { if (e.key === 'Escape') close(); });
+    $menu?.addEventListener('click', (e) => {
+      const t = e.target;
+      if (t && t.tagName === 'A') close();
+    });
+  </script>
 </nav>

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -22,7 +22,7 @@ const current = Astro.url.pathname;
       </span>
       <span class="leading-tight">
         <span class="block text-sm tracking-wide">Marin.dev</span>
-        <span class="hidden text-[11px] font-medium uppercase tracking-[0.22em] text-muted sm:block">Digital studio</span>
+        <span class="hidden text-xs font-medium uppercase tracking-[0.22em] text-muted sm:block">Digital studio</span>
       </span>
     </a>
 
@@ -35,7 +35,7 @@ const current = Astro.url.pathname;
               href={l.href}
               class={`inline-flex rounded-full px-3.5 py-2 transition ${
                 isActive
-                  ? 'bg-cyan-electric/10 text-cyan-100 shadow-[inset_0_0_0_1px_rgba(34,211,238,0.22)]'
+                  ? 'bg-cyan-electric/10 text-cyan-100 ring-1 ring-cyan-electric/20'
                   : 'text-muted-soft hover:bg-white/5 hover:text-slate-50'
               }`}
               aria-current={isActive ? 'page' : undefined}
@@ -66,10 +66,10 @@ const current = Astro.url.pathname;
       aria-expanded="false"
       data-open="false"
     >
-      <svg id="icon-open" width="20" height="20" viewBox="0 0 24 24" fill="none">
+      <svg id="icon-open" class="size-5" viewBox="0 0 24 24" fill="none">
         <path d="M4 7h16M4 12h16M4 17h16" stroke="currentColor" stroke-width="2" stroke-linecap="round" />
       </svg>
-      <svg id="icon-close" width="20" height="20" viewBox="0 0 24 24" fill="none" class="hidden">
+      <svg id="icon-close" class="hidden size-5" viewBox="0 0 24 24" fill="none">
         <path d="M6 6l12 12M18 6L6 18" stroke="currentColor" stroke-width="2" stroke-linecap="round" />
       </svg>
     </button>
@@ -90,13 +90,13 @@ const current = Astro.url.pathname;
     <div class="flex h-16 items-center justify-between border-b border-line px-4 pt-[env(safe-area-inset-top)]">
       <span class="text-sm font-semibold uppercase tracking-[0.18em] text-muted-soft">Menú</span>
       <button id="nav-close" class="inline-flex items-center justify-center rounded-xl border border-line bg-white/5 p-2 text-slate-100" aria-label="Cerrar menú">
-        <svg width="20" height="20" viewBox="0 0 24 24" fill="none">
+        <svg class="size-5" viewBox="0 0 24 24" fill="none">
           <path d="M6 6l12 12M18 6L6 18" stroke="currentColor" stroke-width="2" stroke-linecap="round" />
         </svg>
       </button>
     </div>
 
-    <ul class="space-y-2 p-4 pb-[calc(env(safe-area-inset-bottom)+16px)]">
+    <ul class="space-y-2 p-4 pb-[calc(env(safe-area-inset-bottom)+1rem)]">
       {links.map((l) => {
         const isActive = current === l.href || (l.href !== '/' && current.startsWith(l.href));
         return (
@@ -138,9 +138,11 @@ const current = Astro.url.pathname;
 
     const lockBody = () => {
       scrollY = window.scrollY || window.pageYOffset || 0;
+      const rootFontSize = parseFloat(getComputedStyle(document.documentElement).fontSize) || 16;
+      const scrollOffsetRem = scrollY / rootFontSize;
       const b = document.body.style;
       b.position = 'fixed';
-      b.top = `-${scrollY}px`;
+      b.top = `-${scrollOffsetRem}rem`;
       b.left = '0';
       b.right = '0';
       b.width = '100%';

--- a/src/components/ProjectCard.astro
+++ b/src/components/ProjectCard.astro
@@ -25,7 +25,7 @@ const { title, resumen, stack = [], slug, cover = '/og-default.png', resultado =
         <div class="flex items-start justify-between gap-3">
       <h3 class="text-base font-semibold group-hover:text-brand">{title}</h3>
       {resultado && (
-        <span class="shrink-0 rounded-full border border-gray-200/70 px-2 py-0.5 text-[11px] text-gray-600">
+        <span class="shrink-0 rounded-full border border-gray-200/70 px-2 py-0.5 text-xs text-gray-600">
           {resultado}
         </span>
       )}

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -14,12 +14,12 @@
   }
 
   html {
-    min-width: 320px;
+    min-width: 20rem;
     background: var(--color-ink);
   }
 
   body {
-    min-width: 320px;
+    min-width: 20rem;
     overflow-x: hidden;
     background:
       radial-gradient(
@@ -47,8 +47,8 @@
   }
 
   :focus-visible {
-    outline: 2px solid var(--color-brand);
-    outline-offset: 3px;
+    outline: 0.125rem solid var(--color-brand);
+    outline-offset: 0.1875rem;
   }
 
   img,
@@ -72,9 +72,9 @@
     z-index: -2;
     pointer-events: none;
     background-image:
-      linear-gradient(rgba(148, 163, 184, 0.045) 1px, transparent 1px),
-      linear-gradient(90deg, rgba(148, 163, 184, 0.045) 1px, transparent 1px);
-    background-size: 48px 48px;
+      linear-gradient(rgba(148, 163, 184, 0.045) 0.0625rem, transparent 0.0625rem),
+      linear-gradient(90deg, rgba(148, 163, 184, 0.045) 0.0625rem, transparent 0.0625rem);
+    background-size: 3rem 3rem;
     mask-image: linear-gradient(
       to bottom,
       rgba(0, 0, 0, 0.65),

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -61,12 +61,12 @@ export default {
         "4xl": "2rem",
       },
       boxShadow: {
-        soft: "0 6px 30px -12px rgba(0,0,0,0.25)",
-        glow: "0 24px 80px -32px rgba(34, 211, 238, 0.45)",
+        soft: "0 0.375rem 1.875rem -0.75rem rgba(0,0,0,0.25)",
+        glow: "0 1.5rem 5rem -2rem rgba(34, 211, 238, 0.45)",
         premium:
-          "0 28px 90px -40px rgba(15, 23, 42, 0.95), 0 0 0 1px rgba(148, 163, 184, 0.10)",
+          "0 1.75rem 5.625rem -2.5rem rgba(15, 23, 42, 0.95), 0 0 0 0.0625rem rgba(148, 163, 184, 0.10)",
         "premium-hover":
-          "0 34px 110px -42px rgba(34, 211, 238, 0.35), 0 0 0 1px rgba(148, 163, 184, 0.18)",
+          "0 2.125rem 6.875rem -2.625rem rgba(34, 211, 238, 0.35), 0 0 0 0.0625rem rgba(148, 163, 184, 0.18)",
       },
       backgroundImage: {
         "radial-cyan":
@@ -74,7 +74,7 @@ export default {
         "radial-violet":
           "radial-gradient(circle at 85% 20%, rgba(139, 92, 246, 0.16), transparent 32%)",
         "premium-grid":
-          "linear-gradient(rgba(148, 163, 184, 0.055) 1px, transparent 1px), linear-gradient(90deg, rgba(148, 163, 184, 0.055) 1px, transparent 1px)",
+          "linear-gradient(rgba(148, 163, 184, 0.055) 0.0625rem, transparent 0.0625rem), linear-gradient(90deg, rgba(148, 163, 184, 0.055) 0.0625rem, transparent 0.0625rem)",
         "brand-gradient":
           "linear-gradient(135deg, #22D3EE 0%, #3B82F6 52%, #8B5CF6 100%)",
         "surface-glow":


### PR DESCRIPTION
### Motivation
- Align the site chrome with the V2 dark/premium visual system so the header and footer convey a boutique studio feel and stronger commercial positioning.
- Make primary CTAs clearer and more conversion-oriented by surfacing a “Pedir demo” WhatsApp CTA in desktop and mobile views.
- Improve mobile navigation UX while preserving existing accessibility and scroll-lock behavior.

### Description
- Restyled the global navigation in `src/components/Nav.astro` to use the V2 shell: added `Container` wrapper, gradient logo frame, glass/pill desktop nav, updated color tokens/classes and a prominent `Pedir demo` CTA linked to the centralized WhatsApp helper.
- Restyled the mobile drawer and overlay in `src/components/Nav.astro` to match the dark boutique aesthetic while keeping the existing JS for locking scroll, focus management and keyboard `Escape` close behavior.
- Refactored the footer in `src/components/Footer.astro` to a dark commercial closing strip with `Container` layout, centralized social/contact links sourced from `src/lib/contact.ts`, and a compact “Sitio estático, rápido y mantenible” status note.

### Testing
- Ran `npm run build` which completed successfully and produced the static output (10 pages built and sitemap created) ✅.
- Launched a local dev server with `npm run dev` to preview changes locally (server started) ✅.
- Attempted a visual screenshot with `npx playwright` but the run failed due to npm registry `403 Forbidden` when downloading Playwright, so automated screenshot capture could not be completed ⚠️.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff65eae8608328aa20514ebb0f3aad)