### PR TITLE
Refactor home into V2 component architecture

### DIFF
--- a/src/components/BrowserMockup.astro
+++ b/src/components/BrowserMockup.astro
@@ -5,15 +5,15 @@ const leads = [
   { label: 'Contenido editable', value: 'Panel', detail: 'Servicios, precios y FAQs' },
 ];
 ---
-<div class="relative mx-auto max-w-xl">
+<div class="relative mx-auto max-w-xl" role="group" aria-label="Mockup de dashboard comercial">
   <div class="absolute -inset-6 rounded-[2rem] bg-brand-gradient opacity-20 blur-3xl" aria-hidden="true"></div>
-  <div class="relative overflow-hidden rounded-3xl border border-line bg-surface-glow shadow-premium backdrop-blur">
-    <div class="flex items-center gap-2 border-b border-line bg-ink/55 px-4 py-3">
-      <span class="h-3 w-3 rounded-full bg-red-400/80"></span>
-      <span class="h-3 w-3 rounded-full bg-amber-300/80"></span>
-      <span class="h-3 w-3 rounded-full bg-emerald-300/80"></span>
-      <div class="ml-3 flex-1 rounded-full border border-line bg-ink/60 px-3 py-1 text-xs text-muted">marin.dev/demo-comercial</div>
-      <span class="rounded-full bg-brand-success/10 px-2.5 py-1 text-xs font-semibold text-emerald-100">Deploy activo</span>
+  <div class="relative min-w-0 overflow-hidden rounded-3xl border border-line bg-surface-glow shadow-premium backdrop-blur">
+    <div class="flex min-w-0 items-center gap-2 border-b border-line bg-ink/55 px-4 py-3">
+      <span class="h-3 w-3 shrink-0 rounded-full bg-red-400/80" aria-hidden="true"></span>
+      <span class="h-3 w-3 shrink-0 rounded-full bg-amber-300/80" aria-hidden="true"></span>
+      <span class="h-3 w-3 shrink-0 rounded-full bg-emerald-300/80" aria-hidden="true"></span>
+      <div class="ml-3 min-w-0 flex-1 truncate rounded-full border border-line bg-ink/60 px-3 py-1 text-xs text-muted">marin.dev/demo-comercial</div>
+      <span class="hidden shrink-0 rounded-full bg-brand-success/10 px-2.5 py-1 text-xs font-semibold text-emerald-100 sm:inline-flex">Deploy activo</span>
     </div>
 
     <div class="grid gap-4 p-4 sm:grid-cols-[1.1fr_0.9fr] sm:p-6">
@@ -40,7 +40,7 @@ const leads = [
                 <p class="text-xs font-semibold uppercase tracking-[0.18em] text-muted">{lead.label}</p>
                 <h4 class="mt-1 font-semibold text-slate-50">{lead.value}</h4>
               </div>
-              <span class={`mt-1 h-2.5 w-2.5 rounded-full ${index === 0 ? 'bg-cyan-electric' : index === 1 ? 'bg-brand-success' : 'bg-violet-electric'}`}></span>
+              <span class={`mt-1 h-2.5 w-2.5 rounded-full ${index === 0 ? 'bg-cyan-electric' : index === 1 ? 'bg-brand-success' : 'bg-violet-electric'}`} aria-hidden="true"></span>
             </div>
             <p class="mt-3 text-sm leading-5 text-muted-soft">{lead.detail}</p>
           </article>

--- a/src/components/BrowserMockup.astro
+++ b/src/components/BrowserMockup.astro
@@ -1,0 +1,51 @@
+---
+const leads = [
+  { label: 'Nueva consulta', value: 'WhatsApp', detail: 'Rubro: gimnasio · objetivo: reservas' },
+  { label: 'Reserva confirmada', value: 'Agenda', detail: 'Martes 18:30 · recordatorio listo' },
+  { label: 'Contenido editable', value: 'Panel', detail: 'Servicios, precios y FAQs' },
+];
+---
+<div class="relative mx-auto max-w-xl">
+  <div class="absolute -inset-6 rounded-[2rem] bg-brand-gradient opacity-20 blur-3xl" aria-hidden="true"></div>
+  <div class="relative overflow-hidden rounded-3xl border border-line bg-surface-glow shadow-premium backdrop-blur">
+    <div class="flex items-center gap-2 border-b border-line bg-ink/55 px-4 py-3">
+      <span class="h-3 w-3 rounded-full bg-red-400/80"></span>
+      <span class="h-3 w-3 rounded-full bg-amber-300/80"></span>
+      <span class="h-3 w-3 rounded-full bg-emerald-300/80"></span>
+      <div class="ml-3 flex-1 rounded-full border border-line bg-ink/60 px-3 py-1 text-xs text-muted">marin.dev/demo-comercial</div>
+      <span class="rounded-full bg-brand-success/10 px-2.5 py-1 text-xs font-semibold text-emerald-100">Deploy activo</span>
+    </div>
+
+    <div class="grid gap-4 p-4 sm:grid-cols-[1.1fr_0.9fr] sm:p-6">
+      <section class="rounded-2xl border border-line bg-ink/45 p-5">
+        <p class="text-xs font-semibold uppercase tracking-[0.22em] text-cyan-electric">Dashboard comercial</p>
+        <h3 class="mt-3 text-2xl font-semibold tracking-tight text-slate-50">Menos fricción → más consultas</h3>
+        <p class="mt-2 text-sm leading-6 text-muted-soft">Hero claro, servicios ordenados, agenda visible y WhatsApp con mensaje útil.</p>
+
+        <div class="mt-5 grid grid-cols-3 gap-2">
+          {['CTA', 'Agenda', 'Panel'].map((item) => (
+            <div class="rounded-2xl border border-line bg-surface-glass p-3 text-center">
+              <p class="text-lg font-semibold text-slate-50">✓</p>
+              <p class="text-xs text-muted-soft">{item}</p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section class="space-y-3">
+        {leads.map((lead, index) => (
+          <article class="rounded-2xl border border-line bg-surface-glass p-4 shadow-soft">
+            <div class="flex items-start justify-between gap-3">
+              <div>
+                <p class="text-xs font-semibold uppercase tracking-[0.18em] text-muted">{lead.label}</p>
+                <h4 class="mt-1 font-semibold text-slate-50">{lead.value}</h4>
+              </div>
+              <span class={`mt-1 h-2.5 w-2.5 rounded-full ${index === 0 ? 'bg-cyan-electric' : index === 1 ? 'bg-brand-success' : 'bg-violet-electric'}`}></span>
+            </div>
+            <p class="mt-3 text-sm leading-5 text-muted-soft">{lead.detail}</p>
+          </article>
+        ))}
+      </section>
+    </div>
+  </div>
+</div>

--- a/src/components/ContactCTA.astro
+++ b/src/components/ContactCTA.astro
@@ -1,0 +1,21 @@
+---
+import { waLink, AUDIT_WHATSAPP_MESSAGE } from '../lib/contact';
+---
+<section class="py-16 text-center md:py-24">
+  <div class="relative overflow-hidden rounded-[2rem] border border-line bg-surface-glow p-8 shadow-premium backdrop-blur md:p-12">
+    <div class="absolute inset-x-10 -top-20 h-40 rounded-full bg-cyan-electric/20 blur-3xl" aria-hidden="true"></div>
+    <div class="relative mx-auto max-w-3xl">
+      <p class="text-sm font-semibold uppercase tracking-[0.22em] text-cyan-electric">CTA final</p>
+      <h2 class="mt-4 text-3xl font-semibold tracking-tight text-slate-50 md:text-5xl">Mandame tu web o Instagram y te digo qué mejoraría.</h2>
+      <p class="mt-4 text-base leading-7 text-muted-soft">Te respondo con una mirada concreta: fricciones, oportunidades y qué demo o landing tendría más sentido para vender con menos vueltas.</p>
+      <a
+        href={waLink(AUDIT_WHATSAPP_MESSAGE)}
+        target="_blank"
+        rel="noopener noreferrer"
+        class="mt-8 inline-flex items-center justify-center rounded-2xl bg-brand-gradient px-6 py-3 text-sm font-semibold text-white shadow-glow transition hover:-translate-y-0.5 hover:shadow-premium-hover"
+      >
+        Mandame mi web o Instagram
+      </a>
+    </div>
+  </div>
+</section>

--- a/src/components/FeaturedCases.astro
+++ b/src/components/FeaturedCases.astro
@@ -1,0 +1,39 @@
+---
+import ProjectCard from './ProjectCard.astro';
+import SectionHeader from './SectionHeader.astro';
+
+const { projects = [] } = Astro.props;
+---
+<section id="casos" class="scroll-mt-24 py-14 md:py-20">
+  <div class="flex flex-col gap-6 md:flex-row md:items-end md:justify-between">
+    <SectionHeader
+      eyebrow="Casos destacados"
+      title="Proyectos presentados como prueba comercial."
+      description="Seleccionados por claridad de negocio, capacidad demostrable y facilidad para entender el problema que resuelven."
+    />
+    <a href="/proyectos" class="inline-flex w-fit items-center gap-2 rounded-2xl border border-line bg-surface-glass px-5 py-3 text-sm font-semibold text-cyan-electric transition hover:-translate-y-0.5 hover:border-line-strong">
+      Ver portfolio completo <span aria-hidden="true">→</span>
+    </a>
+  </div>
+
+  <div class="mt-8 grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+    {projects.map((p) => (
+      <ProjectCard
+        title={p.data.title}
+        resumen={p.data.resumen}
+        stack={p.data.stack}
+        slug={p.slug}
+        cover={p.data.cover}
+        resultado={p.data.resultado}
+        problema={p.data.problema}
+        solucion={p.data.solucion}
+        tipo={p.data.tipo}
+        sector={p.data.sector}
+        status={p.data.status}
+        features={p.data.features}
+        impacto={p.data.impacto}
+        ctaLabel={p.data.ctaLabel}
+      />
+    ))}
+  </div>
+</section>

--- a/src/components/HeroV2.astro
+++ b/src/components/HeroV2.astro
@@ -1,0 +1,45 @@
+---
+import BrowserMockup from './BrowserMockup.astro';
+import MetricPill from './MetricPill.astro';
+import { heroSignals } from '../data/site';
+import { waLink, DEMO_WHATSAPP_MESSAGE } from '../lib/contact';
+---
+<section class="relative overflow-hidden py-20 md:py-28">
+  <div class="absolute left-1/2 top-10 -z-10 h-72 w-72 -translate-x-1/2 rounded-full bg-cyan-electric/20 blur-3xl" aria-hidden="true"></div>
+  <div class="grid items-center gap-12 lg:grid-cols-[0.95fr_1.05fr]">
+    <div>
+      <p class="inline-flex rounded-full border border-cyan-electric/25 bg-cyan-electric/10 px-4 py-2 text-xs font-semibold uppercase tracking-[0.22em] text-cyan-100">
+        Marin.dev · demos, webs y sistemas comerciales
+      </p>
+      <h1 class="mt-6 max-w-4xl text-4xl font-semibold tracking-tight text-slate-50 sm:text-5xl lg:text-6xl">
+        Demos web y sistemas simples para negocios que quieren convertir visitas en consultas, reservas o ventas.
+      </h1>
+      <p class="mt-6 max-w-2xl text-base leading-8 text-muted-soft sm:text-lg">
+        Diseño y desarrollo landings, demos comerciales, agendas, paneles básicos e integraciones con WhatsApp para mostrar valor rápido y vender con menos fricción.
+      </p>
+
+      <div class="mt-8 flex flex-col gap-3 sm:flex-row">
+        <a
+          href={waLink(DEMO_WHATSAPP_MESSAGE)}
+          target="_blank"
+          rel="noopener noreferrer"
+          class="inline-flex items-center justify-center rounded-2xl bg-brand-gradient px-6 py-3 text-sm font-semibold text-white shadow-glow transition hover:-translate-y-0.5 hover:shadow-premium-hover"
+        >
+          Quiero una demo para mi negocio
+        </a>
+        <a
+          href="#casos"
+          class="inline-flex items-center justify-center rounded-2xl border border-line bg-surface-glass px-6 py-3 text-sm font-semibold text-slate-50 backdrop-blur transition hover:-translate-y-0.5 hover:border-line-strong"
+        >
+          Ver casos destacados
+        </a>
+      </div>
+
+      <div class="mt-8 flex flex-wrap gap-3">
+        {heroSignals.map((signal, index) => <MetricPill label={signal.label} value={signal.value} tone={index === 1 ? 'success' : 'cyan'} />)}
+      </div>
+    </div>
+
+    <BrowserMockup />
+  </div>
+</section>

--- a/src/components/MetricPill.astro
+++ b/src/components/MetricPill.astro
@@ -1,0 +1,9 @@
+---
+const { label, value, tone = 'cyan' } = Astro.props;
+const dotTone = tone === 'success' ? 'bg-brand-success' : tone === 'violet' ? 'bg-violet-electric' : 'bg-cyan-electric';
+---
+<div class="inline-flex items-center gap-3 rounded-full border border-line bg-surface-glass px-4 py-2 shadow-soft backdrop-blur">
+  <span class={`h-2 w-2 rounded-full ${dotTone} shadow-[0_0_1rem_currentColor]`} aria-hidden="true"></span>
+  <span class="text-xs font-semibold uppercase tracking-[0.18em] text-muted">{label}</span>
+  {value && <span class="text-sm font-semibold text-slate-50">{value}</span>}
+</div>

--- a/src/components/OutcomeGrid.astro
+++ b/src/components/OutcomeGrid.astro
@@ -1,0 +1,25 @@
+---
+import GlowCard from './GlowCard.astro';
+import SectionHeader from './SectionHeader.astro';
+import { outcomes } from '../data/outcomes';
+---
+
+<section class="py-14 md:py-20">
+  <SectionHeader
+    eyebrow="Qué construyo"
+    title="Piezas digitales con intención comercial, no decoración suelta."
+    description="Cada bloque tiene una tarea: explicar valor, reducir dudas, ordenar la acción y facilitar que el cliente escriba, reserve o compre."
+  />
+  <div class="mt-8 grid gap-5 sm:grid-cols-2 lg:grid-cols-4">
+    {
+      outcomes.map((item) => (
+        <GlowCard class="h-full">
+          <h3 class="text-lg font-semibold text-slate-50">{item.title}</h3>
+          <p class="mt-3 text-sm leading-6 text-muted-soft">
+            {item.description}
+          </p>
+        </GlowCard>
+      ))
+    }
+  </div>
+</section>

--- a/src/components/ProcessSteps.astro
+++ b/src/components/ProcessSteps.astro
@@ -1,0 +1,22 @@
+---
+import GlowCard from './GlowCard.astro';
+import SectionHeader from './SectionHeader.astro';
+import { processSteps } from '../data/process';
+---
+<section class="py-14 md:py-20">
+  <SectionHeader
+    eyebrow="Proceso"
+    title="De Instagram o idea suelta a demo lista para compartir."
+    description="Trabajo por pasos cortos para que el alcance sea claro, el avance se vea rápido y cada decisión empuje a consulta, reserva o venta."
+    align="center"
+  />
+  <div class="mt-10 grid gap-5 md:grid-cols-2 lg:grid-cols-4">
+    {processSteps.map((item) => (
+      <GlowCard class="h-full">
+        <span class="inline-flex h-10 w-10 items-center justify-center rounded-2xl bg-brand-gradient text-sm font-bold text-white">{item.step}</span>
+        <h3 class="mt-5 text-lg font-semibold text-slate-50">{item.title}</h3>
+        <p class="mt-3 text-sm leading-6 text-muted-soft">{item.description}</p>
+      </GlowCard>
+    ))}
+  </div>
+</section>

--- a/src/components/ProductizedServices.astro
+++ b/src/components/ProductizedServices.astro
@@ -1,0 +1,42 @@
+---
+import Badge from './Badge.astro';
+import GlowCard from './GlowCard.astro';
+import SectionHeader from './SectionHeader.astro';
+import { productizedServices } from '../data/services';
+import { waLink, SERVICE_WHATSAPP_MESSAGE } from '../lib/contact';
+---
+<section id="planes" class="scroll-mt-24 py-14 md:py-20">
+  <SectionHeader
+    eyebrow="Servicios productizados"
+    title="Puntos de partida claros, ajustables al negocio."
+    description="No se trata de sumar secciones porque sí: cada paquete ordena una necesidad comercial concreta."
+  />
+  <div class="mt-8 grid gap-6 lg:grid-cols-3">
+    {productizedServices.map((service) => (
+      <GlowCard class={`h-full ${service.featured ? 'border-cyan-electric/35' : ''}`}>
+        <div class="flex items-center justify-between gap-3">
+          <Badge label={service.tag} tone={service.featured ? 'success' : 'cyan'} />
+          {service.featured && <span class="text-xs font-semibold uppercase tracking-[0.18em] text-brand-success">Recomendado</span>}
+        </div>
+        <h3 class="mt-5 text-2xl font-semibold tracking-tight text-slate-50">{service.name}</h3>
+        <p class="mt-3 text-sm leading-6 text-muted-soft">{service.description}</p>
+        <ul class="mt-5 space-y-3 text-sm text-muted-soft">
+          {service.deliverables.map((item) => (
+            <li class="flex gap-3">
+              <span class="mt-2 h-1.5 w-1.5 shrink-0 rounded-full bg-cyan-electric" aria-hidden="true"></span>
+              <span>{item}</span>
+            </li>
+          ))}
+        </ul>
+        <a
+          href={waLink(SERVICE_WHATSAPP_MESSAGE(service.name))}
+          target="_blank"
+          rel="noopener noreferrer"
+          class="mt-6 inline-flex w-full items-center justify-center rounded-2xl border border-line bg-surface-glass px-5 py-3 text-sm font-semibold text-slate-50 transition hover:-translate-y-0.5 hover:border-line-strong hover:text-cyan-electric"
+        >
+          Consultar este paquete
+        </a>
+      </GlowCard>
+    ))}
+  </div>
+</section>

--- a/src/components/SocialProofStrip.astro
+++ b/src/components/SocialProofStrip.astro
@@ -1,0 +1,15 @@
+---
+import { capabilityStrip } from '../data/site';
+---
+<section class="py-4" aria-label="Capacidades comerciales">
+  <div class="rounded-3xl border border-line bg-surface-glass p-3 shadow-premium backdrop-blur">
+    <div class="grid gap-2 sm:grid-cols-2 lg:grid-cols-5">
+      {capabilityStrip.map((item) => (
+        <div class="flex items-center justify-center gap-2 rounded-2xl border border-line bg-ink/35 px-3 py-3 text-center text-sm font-semibold text-muted-bright">
+          <span class="h-2 w-2 rounded-full bg-cyan-electric" aria-hidden="true"></span>
+          {item}
+        </div>
+      ))}
+    </div>
+  </div>
+</section>

--- a/src/components/VerticalDemos.astro
+++ b/src/components/VerticalDemos.astro
@@ -1,0 +1,33 @@
+---
+import Badge from './Badge.astro';
+import GlowCard from './GlowCard.astro';
+import SectionHeader from './SectionHeader.astro';
+import { verticalDemos } from '../data/verticals';
+---
+<section class="py-14 md:py-20">
+  <SectionHeader
+    eyebrow="Demos por rubro"
+    title="Una demo concreta vende mejor que una explicación abstracta."
+    description="La idea es mostrarle al negocio una experiencia parecida a la que podría usar: con CTA, reservas, panel o flujo operativo según el rubro."
+  />
+  <div class="mt-8 grid gap-5 md:grid-cols-2">
+    {verticalDemos.map((demo) => (
+      <GlowCard>
+        <div class="flex flex-col gap-5 sm:flex-row sm:items-start sm:justify-between">
+          <div>
+            <p class="text-sm font-semibold text-cyan-electric">{demo.name}</p>
+            <h3 class="mt-2 text-xl font-semibold tracking-tight text-slate-50">Problema → solución visible</h3>
+          </div>
+          <span class="rounded-full border border-line bg-ink/45 px-3 py-1 text-xs font-semibold text-muted-bright">Demo comercial</span>
+        </div>
+        <div class="mt-5 grid gap-3 text-sm leading-6 text-muted-soft">
+          <p class="rounded-2xl border border-line bg-ink/35 p-3"><strong class="text-slate-50">Fricción:</strong> {demo.problem}</p>
+          <p class="rounded-2xl border border-line bg-ink/35 p-3"><strong class="text-slate-50">Demo:</strong> {demo.solution}</p>
+        </div>
+        <div class="mt-5 flex flex-wrap gap-2">
+          {demo.features.map((feature) => <Badge label={feature} tone="cyan" />)}
+        </div>
+      </GlowCard>
+    ))}
+  </div>
+</section>

--- a/src/data/outcomes.ts
+++ b/src/data/outcomes.ts
@@ -1,0 +1,22 @@
+export const outcomes = [
+  {
+    title: "Más consultas calificadas",
+    description:
+      "CTAs claros, WhatsApp con mensaje guiado y secciones que responden dudas antes del primer contacto.",
+  },
+  {
+    title: "Más confianza para decidir",
+    description:
+      "Estructura visual premium, casos de negocio y pruebas concretas en vez de una lista genérica de tecnologías.",
+  },
+  {
+    title: "Menos fricción operativa",
+    description:
+      "Agendas, paneles simples y flujos pensados para ordenar reservas, servicios o leads sin inflar el proyecto.",
+  },
+  {
+    title: "Demo lista para vender",
+    description:
+      "Una pieza navegable para validar propuesta, mostrar valor y compartir por WhatsApp antes de invertir de más.",
+  },
+];

--- a/src/data/process.ts
+++ b/src/data/process.ts
@@ -1,0 +1,26 @@
+export const processSteps = [
+  {
+    step: "01",
+    title: "Me pasás tu Instagram o web",
+    description:
+      "Reviso qué vendés, qué fricción tiene hoy el recorrido y qué debería preguntar el CTA.",
+  },
+  {
+    step: "02",
+    title: "Detecto oportunidad comercial",
+    description:
+      "Ordeno propuesta, secciones, mensajes y acciones para convertir visitas en consultas.",
+  },
+  {
+    step: "03",
+    title: "Diseño una demo concreta",
+    description:
+      "Armo una experiencia visual lista para mostrar, validar y ajustar antes de crecer el alcance.",
+  },
+  {
+    step: "04",
+    title: "Deploy, repo y siguientes mejoras",
+    description:
+      "Entrego el sitio publicado, código ordenado y una hoja simple de próximos pasos.",
+  },
+];

--- a/src/data/services.ts
+++ b/src/data/services.ts
@@ -1,0 +1,39 @@
+export const productizedServices = [
+  {
+    name: "Demo Comercial Express",
+    tag: "Validar rápido",
+    description:
+      "Una demo premium para transformar Instagram, una idea o un rubro en una pieza vendible.",
+    deliverables: [
+      "Hero + oferta",
+      "WhatsApp guiado",
+      "Mockup o flujo",
+      "Deploy compartible",
+    ],
+  },
+  {
+    name: "Landing de Conversión",
+    tag: "Más consultas",
+    description:
+      "Página enfocada en claridad, confianza, objeciones y CTA para negocios que ya venden.",
+    deliverables: [
+      "Copy comercial",
+      "Secciones CRO",
+      "SEO base",
+      "Performance",
+    ],
+    featured: true,
+  },
+  {
+    name: "Web con Agenda / Panel",
+    tag: "Operar mejor",
+    description:
+      "Sistema simple para mostrar servicios, ordenar reservas o editar contenido clave.",
+    deliverables: [
+      "Agenda simple",
+      "Panel básico",
+      "Integraciones",
+      "Documentación",
+    ],
+  },
+];

--- a/src/data/site.ts
+++ b/src/data/site.ts
@@ -1,0 +1,13 @@
+export const capabilityStrip = [
+  "Demos por rubro",
+  "WhatsApp guiado",
+  "Agenda y reservas",
+  "Panel simple",
+  "Repo + deploy",
+];
+
+export const heroSignals = [
+  { label: "Repo + deploy", value: "entrega lista" },
+  { label: "WhatsApp guiado", value: "consulta sin fricción" },
+  { label: "Por hitos", value: "alcance claro" },
+];

--- a/src/data/verticals.ts
+++ b/src/data/verticals.ts
@@ -1,0 +1,32 @@
+export const verticalDemos = [
+  {
+    name: "Veterinarias",
+    problem: "Consultas dispersas, urgencias y turnos por mensajes sueltos.",
+    solution:
+      "Demo con agenda, urgencias visibles y portal simple para mascotas.",
+    features: ["Agenda", "Urgencias", "WhatsApp", "Portal"],
+  },
+  {
+    name: "Barberías y estética",
+    problem:
+      "Instagram vende la estética, pero no ordena reservas ni servicios.",
+    solution:
+      "Landing visual con precios, disponibilidad y CTA directo a reserva.",
+    features: ["Reservas", "Servicios", "Galería", "CTA"],
+  },
+  {
+    name: "Gimnasios",
+    problem:
+      "Planes, horarios y beneficios quedan repartidos entre historias destacadas.",
+    solution:
+      "Página clara para comparar planes y pedir una clase o inscripción.",
+    features: ["Planes", "Horarios", "Prueba", "WhatsApp"],
+  },
+  {
+    name: "Restaurantes",
+    problem: "La carta, reservas y pedidos no siempre están a un toque.",
+    solution:
+      "Demo con carta ordenada, reserva/pedido y confianza para compartir.",
+    features: ["Carta", "Reservas", "Pedidos", "Ubicación"],
+  },
+];

--- a/src/lib/contact.ts
+++ b/src/lib/contact.ts
@@ -3,14 +3,25 @@
 export const SITE_URL = "https://daegon13.github.io";
 export const EMAIL = "damgmarin13@gmail.com";
 
-export const LINKEDIN_URL = "https://www.linkedin.com/in/diego-marin-34632121b/";
+export const LINKEDIN_URL =
+  "https://www.linkedin.com/in/diego-marin-34632121b/";
 export const GITHUB_URL = "https://github.com/Daegon13";
 
 export const WHATSAPP_NUMBER_E164 = "59897316092"; // UY (+598) + 97316092
 export const WHATSAPP_BASE_URL = `https://wa.me/${WHATSAPP_NUMBER_E164}`;
 
 export const DEFAULT_WHATSAPP_MESSAGE =
-  "Hola Diego, soy [Nombre]. Tengo un negocio de [Rubro]. Quiero lograr [Objetivo: más consultas / reservas / ventas]. Hoy tengo [web/no web]. Presupuesto estimado: [USD].";
+  "Hola Diego, quiero una web/demo para mi negocio.\n\nRubro: [rubro]\nObjetivo: [más consultas / reservas / ventas]\nHoy tengo: [Instagram / web / nada]\nMe interesa: [landing / demo / agenda / panel / no sé todavía]\nLink de referencia: [Instagram o web]";
+
+export const DEMO_WHATSAPP_MESSAGE =
+  "Hola Diego, quiero una demo/web para mi negocio.\n\nRubro: [rubro]\nObjetivo: [más consultas / reservas / ventas]\nHoy tengo: [Instagram / web / nada]\nMe interesa: [landing / demo / agenda / panel / no sé todavía]\nLink de referencia: [Instagram o web]";
+
+export const AUDIT_WHATSAPP_MESSAGE =
+  "Hola Diego, quiero que revises mi web o Instagram.\n\nLink: [pegá acá tu web o Instagram]\nRubro: [rubro]\nObjetivo: [más consultas / reservas / ventas]\nPrincipal problema hoy: [breve]";
+
+export function SERVICE_WHATSAPP_MESSAGE(planName: string) {
+  return `Hola Diego, quiero consultar por ${planName}.\n\nRubro: [rubro]\nObjetivo: [más consultas / reservas / ventas]\nHoy tengo: [Instagram / web / nada]\nLink de referencia: [Instagram o web]`;
+}
 
 export function waLink(text?: string) {
   const msg = (text ?? DEFAULT_WHATSAPP_MESSAGE).trim();

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,13 +1,17 @@
 ---
-// Home: hero directo + skills + proyectos destacados + CTA
 import BaseLayout from '../layouts/BaseLayout.astro';
-import ProjectCard from '../components/ProjectCard.astro';
-import PricingPlans from "../components/PricingPlans.astro";
+import ContactCTA from '../components/ContactCTA.astro';
+import FAQs from '../components/FAQs.astro';
+import FeaturedCases from '../components/FeaturedCases.astro';
+import HeroV2 from '../components/HeroV2.astro';
+import ProcessSteps from '../components/ProcessSteps.astro';
+import ProductizedServices from '../components/ProductizedServices.astro';
+import SocialProofStrip from '../components/SocialProofStrip.astro';
+import VerticalDemos from '../components/VerticalDemos.astro';
+import GlowCard from '../components/GlowCard.astro';
+import SectionHeader from '../components/SectionHeader.astro';
 import { getCollection } from 'astro:content';
-import FAQs from "../components/FAQs.astro";
-import { waLink, DEFAULT_WHATSAPP_MESSAGE } from "../lib/contact";
 
-// Cargar la colección de proyectos y ordenarlos por fecha descendente
 let proyectos = await getCollection('proyectos');
 proyectos = proyectos.sort((a, b) => {
   if (Boolean(a.data.featured) !== Boolean(b.data.featured)) {
@@ -17,112 +21,53 @@ proyectos = proyectos.sort((a, b) => {
   return priorityDiff || (a.data.fecha < b.data.fecha ? 1 : -1);
 });
 const destacados = proyectos.slice(0, 3);
+
+const outcomes = [
+  {
+    title: 'Más consultas calificadas',
+    description: 'CTAs claros, WhatsApp con mensaje guiado y secciones que responden dudas antes del primer contacto.',
+  },
+  {
+    title: 'Más confianza para decidir',
+    description: 'Estructura visual premium, casos de negocio y pruebas concretas en vez de una lista genérica de tecnologías.',
+  },
+  {
+    title: 'Menos fricción operativa',
+    description: 'Agendas, paneles simples y flujos pensados para ordenar reservas, servicios o leads sin inflar el proyecto.',
+  },
+  {
+    title: 'Demo lista para vender',
+    description: 'Una pieza navegable para validar propuesta, mostrar valor y compartir por WhatsApp antes de invertir de más.',
+  },
+];
 ---
-<BaseLayout title="Desarrollador Web Freelance" description="Soluciones rápidas, claras y a medida para tu negocio.">
-<section class="py-20 md:py-28 text-center">
-  <h1 class="text-4xl md:text-5xl font-bold tracking-tight">
-    Webs que convierten visitas en consultas (y te dejan listo para escalar)
-  </h1>
-  <p class="mt-4 text-base md:text-lg text-gray-600">
-    Landing, web corporativa o e-commerce con performance, SEO base y CTAs a WhatsApp. Entregables por escrito, cronograma claro y soporte post-lanzamiento.
-  </p>
+<BaseLayout
+  title="Marin.dev | Demos web y sistemas simples para vender mejor"
+  description="Demos web, landings y sistemas simples para negocios que quieren convertir visitas en consultas, reservas o ventas."
+>
+  <HeroV2 />
+  <SocialProofStrip />
 
-  <!-- CTAs -->
-  <div class="mt-8 flex flex-wrap items-center justify-center gap-4">
-    <a
-      href={waLink(DEFAULT_WHATSAPP_MESSAGE)}
-      target="_blank"
-      rel="noopener noreferrer"
-      class="inline-flex items-center justify-center rounded-xl px-5 py-3 text-sm font-medium bg-gray-900 text-white hover:bg-gray-800 dark:bg-gray-100 dark:text-gray-900 dark:hover:bg-white transition"
-    >
-      Cotizar por WhatsApp
-    </a>
-    <a
-      href="#planes"
-      class="inline-flex items-center justify-center rounded-xl px-5 py-3 text-sm font-medium border border-gray-300/70 dark:border-gray-700/70 hover:opacity-90 transition"
-    >
-      Ver paquetes y entregables
-    </a>
-    <a
-      href="/proyectos"
-      class="inline-flex items-center justify-center rounded-xl px-5 py-3 text-sm font-medium border border-gray-300/70 dark:border-gray-700/70 hover:opacity-90 transition"
-    >
-      Ver casos reales
-    </a>
-  </div>
-
-  <!-- Prueba social simple: no requiere íconos -->
-  <p class="mt-6 text-sm text-gray-500">
-    Propuesta en 24h • pagos por hitos • entrega con repo + deploy
-  </p>
-</section>
-
-  <!-- QUÉ RESUELVO: enfocado a negocio (CRO) -->
-  <section class="py-8">
-    <h2 class="text-xl font-semibold mb-6">Qué resuelvo (sin humo)</h2>
-    <div class="grid sm:grid-cols-2 lg:grid-cols-4 gap-4">
-      <div class="rounded-xl border p-4">
-        <h3 class="font-semibold">Más consultas</h3>
-        <p class="text-sm text-gray-600">CTAs claros, WhatsApp guiado y secciones que responden objeciones.</p>
-      </div>
-      <div class="rounded-xl border p-4">
-        <h3 class="font-semibold">Más confianza</h3>
-        <p class="text-sm text-gray-600">Estructura institucional + prueba social + mensajes de seguridad.</p>
-      </div>
-      <div class="rounded-xl border p-4">
-        <h3 class="font-semibold">Más velocidad</h3>
-        <p class="text-sm text-gray-600">Carga rápida y base SEO para que no dependas solo de ads.</p>
-      </div>
-      <div class="rounded-xl border p-4">
-        <h3 class="font-semibold">Menos fricción</h3>
-        <p class="text-sm text-gray-600">Formulario, integraciones y handoff prolijo (repo + deploy).</p>
-      </div>
+  <section class="py-14 md:py-20">
+    <SectionHeader
+      eyebrow="Qué construyo"
+      title="Piezas digitales con intención comercial, no decoración suelta."
+      description="Cada bloque tiene una tarea: explicar valor, reducir dudas, ordenar la acción y facilitar que el cliente escriba, reserve o compre."
+    />
+    <div class="mt-8 grid gap-5 sm:grid-cols-2 lg:grid-cols-4">
+      {outcomes.map((item) => (
+        <GlowCard class="h-full">
+          <h3 class="text-lg font-semibold text-slate-50">{item.title}</h3>
+          <p class="mt-3 text-sm leading-6 text-muted-soft">{item.description}</p>
+        </GlowCard>
+      ))}
     </div>
   </section>
 
-  <!-- PROYECTOS DESTACADOS: prioriza casos con mayor fuerza comercial -->
-  <section id="casos" class="py-12 scroll-mt-24">
-    <h2 class="text-xl font-semibold mb-2">Casos destacados</h2>
-    <p class="mb-6 max-w-2xl text-sm leading-6 text-muted-soft">Proyectos seleccionados por claridad comercial, capacidad demostrable y facilidad para entender el problema que resuelven.</p>
-    <div class="grid sm:grid-cols-2 lg:grid-cols-3 gap-6">
-      {
-        destacados.map((p) => {
-          return (
-            <ProjectCard
-              title={p.data.title}
-              resumen={p.data.resumen}
-              stack={p.data.stack}
-              slug={p.slug}
-              cover={p.data.cover}
-              resultado={p.data.resultado}
-              problema={p.data.problema}
-              solucion={p.data.solucion}
-              tipo={p.data.tipo}
-              sector={p.data.sector}
-              status={p.data.status}
-              features={p.data.features}
-              impacto={p.data.impacto}
-              ctaLabel={p.data.ctaLabel}
-            />
-          );
-        })
-      }
-    </div>
-  </section>
-
-  {/* Sección de planes anclada */}
-  <section id="planes" class="scroll-mt-24">
-    <PricingPlans />
-  </section>
-
+  <FeaturedCases projects={destacados} />
+  <VerticalDemos />
+  <ProcessSteps />
+  <ProductizedServices />
   <FAQs />
-
-  <!-- CTA FINAL: invita al contacto -->
-  <section class="py-16 text-center">
-    <div class="rounded-2xl border p-8">
-      <h3 class="text-lg font-semibold">¿Listo para empezar?</h3>
-      <p class="text-sm text-gray-600 mt-1">Tengo cupos limitados por mes. Contame tu idea y vemos el mejor camino.</p>
-      <a href={waLink("Hola Diego, quiero una propuesta.\n\nRubro: [Rubro]\nObjetivo: [más consultas / reservas / ventas]\nTengo: [web/no web]\nPresupuesto estimado: [USD]\nDetalles: [breve]\n")} target="_blank" rel="noopener noreferrer" class="inline-block mt-4 rounded-lg bg-brand px-5 py-2.5 text-white">Enviar mensaje guiado</a>
-    </div>
-  </section>
+  <ContactCTA />
 </BaseLayout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -8,8 +8,7 @@ import ProcessSteps from '../components/ProcessSteps.astro';
 import ProductizedServices from '../components/ProductizedServices.astro';
 import SocialProofStrip from '../components/SocialProofStrip.astro';
 import VerticalDemos from '../components/VerticalDemos.astro';
-import GlowCard from '../components/GlowCard.astro';
-import SectionHeader from '../components/SectionHeader.astro';
+import OutcomeGrid from '../components/OutcomeGrid.astro';
 import { getCollection } from 'astro:content';
 
 let proyectos = await getCollection('proyectos');
@@ -22,24 +21,6 @@ proyectos = proyectos.sort((a, b) => {
 });
 const destacados = proyectos.slice(0, 3);
 
-const outcomes = [
-  {
-    title: 'Más consultas calificadas',
-    description: 'CTAs claros, WhatsApp con mensaje guiado y secciones que responden dudas antes del primer contacto.',
-  },
-  {
-    title: 'Más confianza para decidir',
-    description: 'Estructura visual premium, casos de negocio y pruebas concretas en vez de una lista genérica de tecnologías.',
-  },
-  {
-    title: 'Menos fricción operativa',
-    description: 'Agendas, paneles simples y flujos pensados para ordenar reservas, servicios o leads sin inflar el proyecto.',
-  },
-  {
-    title: 'Demo lista para vender',
-    description: 'Una pieza navegable para validar propuesta, mostrar valor y compartir por WhatsApp antes de invertir de más.',
-  },
-];
 ---
 <BaseLayout
   title="Marin.dev | Demos web y sistemas simples para vender mejor"
@@ -48,21 +29,7 @@ const outcomes = [
   <HeroV2 />
   <SocialProofStrip />
 
-  <section class="py-14 md:py-20">
-    <SectionHeader
-      eyebrow="Qué construyo"
-      title="Piezas digitales con intención comercial, no decoración suelta."
-      description="Cada bloque tiene una tarea: explicar valor, reducir dudas, ordenar la acción y facilitar que el cliente escriba, reserve o compre."
-    />
-    <div class="mt-8 grid gap-5 sm:grid-cols-2 lg:grid-cols-4">
-      {outcomes.map((item) => (
-        <GlowCard class="h-full">
-          <h3 class="text-lg font-semibold text-slate-50">{item.title}</h3>
-          <p class="mt-3 text-sm leading-6 text-muted-soft">{item.description}</p>
-        </GlowCard>
-      ))}
-    </div>
-  </section>
+  <OutcomeGrid />
 
   <FeaturedCases projects={destacados} />
   <VerticalDemos />


### PR DESCRIPTION
### Motivation
- Move the home page to a V2 component architecture that communicates Marin.dev as a studio producing conversion-focused demos and simple systems rather than a generic freelance portfolio. 
- Prepare a reusable visual shell and content structure so future patches can iterate on hero, portfolio, services and contact flows without the index growing monolithic.
- Centralize contact/WhatsApp messaging so CTAs are consistent and easy to adjust. 

### Description
- Replaced the monolithic home with a componentized V2 layout and wiring in `src/pages/index.astro` using `HeroV2`, `SocialProofStrip`, `FeaturedCases`, `VerticalDemos`, `ProcessSteps`, `ProductizedServices`, `ContactCTA`, plus supporting components `BrowserMockup`, `MetricPill` and reuse of `GlowCard`/`SectionHeader`.
- Added data modules under `src/data/` (`site.ts`, `verticals.ts`, `process.ts`, `services.ts`) to keep the page lean and provide structured inputs for the new components.
- Centralized WhatsApp/contact flows in `src/lib/contact.ts` by expanding message presets (`DEMO_WHATSAPP_MESSAGE`, `AUDIT_WHATSAPP_MESSAGE`, and `SERVICE_WHATSAPP_MESSAGE`) and keeping `waLink()` as the single helper used by CTAs.
- Created `src/components/FeaturedCases.astro`, `HeroV2.astro`, `BrowserMockup.astro`, `MetricPill.astro`, `SocialProofStrip.astro`, `VerticalDemos.astro`, `ProcessSteps.astro`, `ProductizedServices.astro`, `ContactCTA.astro`; updated `src/pages/index.astro` to use them and kept `ProjectCard` compatibility for the portfolio.

### Testing
- Ran `npm run build` and a full static build completed successfully (`10 page(s) built`), so the site compiles. (Succeeded)
- Ran `npm run format` (Prettier) to normalize code style. (Succeeded)
- Ran `npm run lint` and it failed due to repository ESLint configuration missing a flat config file; error: `ESLint couldn't find an eslint.config.(js|mjs|cjs) file.` (Known repo issue, reported) (Failed)
- Attempted a programmatic screenshot with `npx playwright screenshot ...` but the attempt was blocked by registry policy (403) when fetching Playwright in this environment; so no visual snapshot was produced. (Blocked)

Files of note: `src/pages/index.astro`, `src/lib/contact.ts`, new components in `src/components/` and new data files in `src/data/`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff6e7dd30c8328bd14f01950148035)