### PR TITLE
Align contact copy with commercial CTAs

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,6 +1,6 @@
 ---
 import Container from './Container.astro';
-import { EMAIL, GITHUB_URL, LINKEDIN_URL, WHATSAPP_BASE_URL } from '../lib/contact';
+import { EMAIL, GITHUB_URL, INSTAGRAM_HANDLE, INSTAGRAM_URL, LINKEDIN_URL, waLink } from '../lib/contact';
 ---
 <footer class="mt-20 border-t border-line bg-ink/70">
   <Container class="py-10 text-sm text-muted-soft">
@@ -8,13 +8,14 @@ import { EMAIL, GITHUB_URL, LINKEDIN_URL, WHATSAPP_BASE_URL } from '../lib/conta
       <div>
         <p class="text-base font-semibold text-slate-50">Marin.dev</p>
         <p class="mt-2 max-w-xl leading-6">
-          Demos y webs claras, cuidadas y publicadas para compartir por WhatsApp o redes.
+          Webs rápidas, claras y listas para compartir por WhatsApp.
         </p>
       </div>
 
       <div class="flex flex-wrap gap-x-4 gap-y-2 md:justify-end">
         <a href="/politica-de-privacidad" class="transition hover:text-cyan-100">Privacidad</a>
-        <a href={WHATSAPP_BASE_URL} class="transition hover:text-cyan-100" target="_blank" rel="noopener noreferrer">WhatsApp</a>
+        <a href={waLink()} class="transition hover:text-cyan-100" target="_blank" rel="noopener noreferrer">WhatsApp</a>
+        <a href={INSTAGRAM_URL} class="transition hover:text-cyan-100" target="_blank" rel="noopener noreferrer">Instagram {INSTAGRAM_HANDLE}</a>
         <a href={`mailto:${EMAIL}`} class="transition hover:text-cyan-100">Email</a>
         <a href={GITHUB_URL} class="transition hover:text-cyan-100" target="_blank" rel="noopener noreferrer">GitHub</a>
         <a href={LINKEDIN_URL} class="transition hover:text-cyan-100" target="_blank" rel="noopener noreferrer">LinkedIn</a>

--- a/src/components/PricingPlans.astro
+++ b/src/components/PricingPlans.astro
@@ -1,9 +1,9 @@
 ---
-import { waLink } from "../lib/contact";
+import { SERVICE_WHATSAPP_MESSAGE, waLink } from "../lib/contact";
 /* PricingPlans.astro
    - Componente de “servicios productizables” (3 paquetes)
    - No requiere cambios en tailwind.config
-   - Botones apuntan a /contacto con params UTM para identificar el plan
+   - Botones abren WhatsApp con un mensaje comercial por paquete
 */
 const plans = [
   {
@@ -83,18 +83,18 @@ const plans = [
         <!-- Para quién es ideal -->
         <p class="mt-4 text-xs text-gray-500"><strong>Ideal para:</strong> {p.idealFor}</p>
 
-        <!-- botón hacia Contacto con tracking simple -->
+        <!-- CTA comercial hacia WhatsApp -->
         <div class="mt-6">
           <a
-            href={waLink(`Hola Diego, quiero el plan "${p.name}".\n\nMi rubro: [Rubro]\nObjetivo: [más consultas / reservas / ventas]\nTengo: [web/no web]\nPresupuesto estimado: [USD]\nDetalles: [breve]\n`)}
+            href={waLink(SERVICE_WHATSAPP_MESSAGE(p.name))}
             target="_blank"
             rel="noopener noreferrer"
             class={`inline-flex items-center justify-center w-full rounded-xl px-4 py-2 text-sm font-medium transition
                     ${p.featured ? 'bg-gray-900 text-white hover:bg-gray-800 dark:bg-gray-100 dark:text-gray-900 dark:hover:bg-white'
                                  : 'border border-gray-300/70 dark:border-gray-700/70 hover:opacity-90'}`}
-            aria-label={`Quiero este plan ${p.name}`}
+            aria-label={`Consultar este paquete ${p.name}`}
           >
-            Quiero este plan
+            Consultar este paquete
           </a>
         </div>
       </article>

--- a/src/content/proyectos/Agencia_ariel.mdx
+++ b/src/content/proyectos/Agencia_ariel.mdx
@@ -9,12 +9,12 @@ stack:
   - CSS3
   - JavaScript
   - Firebase
-  - Responsive Design
+  - Experiencia móvil
 features:
   - Consulta conectada a Firebase
   - Contenido editable
   - Presentación de servicios
-  - Diseño responsive
+  - Experiencia clara en celulares
 fecha: "2025-09"
 status: "real"
 featured: true
@@ -31,7 +31,7 @@ impacto: >
 El_sitio_incluye:
   - Página principal con presentación de servicios, misión y valores.
   - Sección de contacto para registrar consultas de forma ordenada.
-  - Diseño **responsive** optimizado para clientes móviles.
+  - Experiencia clara en celulares para clientes que consultan desde el teléfono.
   - Contenido editable para mantener servicios actualizados.
 El_desarrollo_priorizo: >
   que la web sea fácil de usar, cargue rápido y pueda crecer con nuevas secciones cuando haga falta.

--- a/src/lib/contact.ts
+++ b/src/lib/contact.ts
@@ -6,21 +6,22 @@ export const EMAIL = "damgmarin13@gmail.com";
 export const LINKEDIN_URL =
   "https://www.linkedin.com/in/diego-marin-34632121b/";
 export const GITHUB_URL = "https://github.com/Daegon13";
+export const INSTAGRAM_HANDLE = "@marin_dev_";
+export const INSTAGRAM_URL = "https://www.instagram.com/marin_dev_/";
 
 export const WHATSAPP_NUMBER_E164 = "59897316092"; // UY (+598) + 97316092
 export const WHATSAPP_BASE_URL = `https://wa.me/${WHATSAPP_NUMBER_E164}`;
 
 export const DEFAULT_WHATSAPP_MESSAGE =
-  "Hola Diego, quiero una web/demo para mi negocio.\n\nRubro: [rubro]\nObjetivo: [más consultas / reservas / ventas]\nHoy tengo: [Instagram / web / nada]\nMe interesa: [web / demo / agenda / zona editable / no sé todavía]\nLink de referencia: [Instagram o web]";
+  "Hola Diego, quiero una demo/web para mi negocio.\n\nRubro: [rubro]\nObjetivo: [más consultas / reservas / ventas]\nHoy tengo: [Instagram / web / nada]\nMe interesa: [landing / demo / agenda / panel / no sé todavía]\nLink de referencia: [Instagram o web]";
 
-export const DEMO_WHATSAPP_MESSAGE =
-  "Hola Diego, quiero una demo/web para mi negocio.\n\nRubro: [rubro]\nObjetivo: [más consultas / reservas / ventas]\nHoy tengo: [Instagram / web / nada]\nMe interesa: [web / demo / agenda / zona editable / no sé todavía]\nLink de referencia: [Instagram o web]";
+export const DEMO_WHATSAPP_MESSAGE = DEFAULT_WHATSAPP_MESSAGE;
 
 export const AUDIT_WHATSAPP_MESSAGE =
   "Hola Diego, quiero que revises mi web o Instagram.\n\nLink: [pegá acá tu web o Instagram]\nRubro: [rubro]\nObjetivo: [más consultas / reservas / ventas]\nPrincipal problema hoy: [breve]";
 
 export function SERVICE_WHATSAPP_MESSAGE(planName: string) {
-  return `Hola Diego, quiero consultar por ${planName}.\n\nRubro: [rubro]\nObjetivo: [más consultas / reservas / ventas]\nHoy tengo: [Instagram / web / nada]\nLink de referencia: [Instagram o web]`;
+  return `Hola Diego, quiero consultar este paquete: ${planName}.\n\nRubro: [rubro]\nObjetivo: [más consultas / reservas / ventas]\nHoy tengo: [Instagram / web / nada]\nMe interesa: [landing / demo / agenda / panel / no sé todavía]\nLink de referencia: [Instagram o web]`;
 }
 
 export function waLink(text?: string) {

--- a/src/pages/contacto.astro
+++ b/src/pages/contacto.astro
@@ -1,107 +1,157 @@
 ---
 /* Página de Contacto (sin backend)
-   - Envía por mailto a damgmarin13@gmail.com armando el asunto y el cuerpo
+   - Arma un mensaje comercial para WhatsApp
    - Validación mínima con atributos HTML
-   - No depende de librerías, no toca tailwind.config
+   - No depende de librerías
 */
 import BaseLayout from "../layouts/BaseLayout.astro";
-import { EMAIL, WHATSAPP_BASE_URL, WHATSAPP_NUMBER_E164 } from "../lib/contact";
+import Container from "../components/Container.astro";
+import {
+  AUDIT_WHATSAPP_MESSAGE,
+  EMAIL,
+  INSTAGRAM_HANDLE,
+  INSTAGRAM_URL,
+  WHATSAPP_BASE_URL,
+  WHATSAPP_NUMBER_E164,
+  waLink,
+} from "../lib/contact";
 
 const title = "Contacto – Marin.dev";
-const description = "Contame tu proyecto y recibí una estimación en 24 horas.";
+const description = "Mandame tu web o Instagram y te digo qué demo, landing o sistema simple puede ayudarte a recibir más consultas.";
 const url = "https://daegon13.github.io/contacto";
 const image = "/og-default.png";
 ---
 <BaseLayout {title} {description} {url} {image}>
-  <section class="py-12 md:py-16">
-    <h1 class="text-2xl md:text-3xl font-semibold">Contacto</h1>
-    <p class="mt-2 text-gray-500">Elegí un canal. Si querés ir rápido, mandame un WhatsApp con mensaje guiado y te respondo en menos de 24 horas.</p>
-
-    <form id="contacto" class="mt-8 max-w-xl space-y-4">
-      <!-- Nombre -->
-      <div>
-        <label for="nombre" class="block text-sm font-medium">Nombre:</label>
-        <input id="nombre" name="nombre" type="text" required
-               class="mt-1 w-full rounded-lg border border-gray-300/70 dark:border-gray-700/70 bg-transparent px-3 py-2" />
-      </div>
-
-      <!-- Email -->
-      <div>
-        <label for="email" class="block text-sm font-medium">Email:</label>
-        <input id="email" name="email" type="email" required
-               class="mt-1 w-full rounded-lg border border-gray-300/70 dark:border-gray-700/70 bg-transparent px-3 py-2" />
-      </div>
-
-      <!-- Presupuesto estimado -->
-      <div>
-        <label for="presupuesto" class="block text-sm font-medium">Presupuesto estimado - (USD):</label>
-        <input id="presupuesto" name="presupuesto" type="number" min="0" step="50"
-               class="mt-1 w-full rounded-lg border border-gray-300/70 dark:border-gray-700/70 bg-transparent px-3 py-2" />
-      </div>
-
-      <!-- Plazo estimado -->
-      <div>
-        <label for="plazo" class="block text-sm font-medium">Plazo requerido(si aplica) - (días):</label>
-        <input id="plazo" name="plazo" type="number" min="1" step="1" 
-               class="mt-1 w-full rounded-lg border border-gray-300/70 dark:border-gray-700/70 bg-transparent px-3 py-2" />
-      </div>
-
-      <!-- Mensaje -->
-      <div>
-        <label for="mensaje" class="block text-sm font-medium">Resumen de tu negocio:</label>
-        <textarea id="mensaje" name="mensaje" rows="5" required
-                  class="mt-1 w-full rounded-lg border border-gray-300/70 dark:border-gray-700/70 bg-transparent px-3 py-2"></textarea>
-      </div>
-
-      <!-- Acción -->
-      <div class="pt-2">
-        <button type="submit"
-                class="inline-flex items-center justify-center rounded-xl px-5 py-3 text-sm font-medium bg-gray-900 text-white hover:bg-gray-800 dark:bg-gray-100 dark:text-gray-900 dark:hover:bg-white transition">
-          Abrir WhatsApp con este mensaje
-        </button>
-      </div>
-
-      <!-- Fallback si JS está deshabilitado -->
-      <noscript>
-        <p class="mt-3 text-sm text-gray-500">
-          Si tu navegador no permite enviar el formulario, escribime a
-          <a class="underline" href={`mailto:${EMAIL}`}>{EMAIL}</a>.
+  <Container class="py-12 md:py-16">
+    <section class="grid gap-8 lg:grid-cols-[0.85fr_1.15fr] lg:items-start">
+      <div class="rounded-[2rem] border border-line bg-surface-glass p-6 shadow-premium backdrop-blur md:p-8">
+        <p class="text-sm font-semibold uppercase tracking-[0.22em] text-cyan-electric">Contacto directo</p>
+        <h1 class="mt-4 text-3xl font-semibold tracking-tight text-slate-50 md:text-5xl">Mandame mi web o Instagram</h1>
+        <p class="mt-4 text-base leading-7 text-muted-soft">
+          Contame tu rubro, qué querés mejorar y qué tenés hoy. Te respondo con un camino concreto: landing, demo, agenda, panel o una opción más simple si alcanza.
         </p>
-      </noscript>
-    </form>
-  </section>
 
-  <!-- Script mínimo: arma un WhatsApp con los datos -->
-  <script>
+        <div class="mt-6 space-y-3 text-sm text-muted-soft">
+          <a class="block rounded-2xl border border-line bg-white/5 px-4 py-3 transition hover:border-cyan-electric/40 hover:text-cyan-100" href={waLink(AUDIT_WHATSAPP_MESSAGE)} target="_blank" rel="noopener noreferrer">
+            Revisar mi web o Instagram por WhatsApp
+          </a>
+          <a class="block rounded-2xl border border-line bg-white/5 px-4 py-3 transition hover:border-cyan-electric/40 hover:text-cyan-100" href={INSTAGRAM_URL} target="_blank" rel="noopener noreferrer">
+            Instagram: {INSTAGRAM_HANDLE}
+          </a>
+          <a class="block rounded-2xl border border-line bg-white/5 px-4 py-3 transition hover:border-cyan-electric/40 hover:text-cyan-100" href={`mailto:${EMAIL}`}>
+            Email: {EMAIL}
+          </a>
+        </div>
+      </div>
+
+      <form id="contacto" class="rounded-[2rem] border border-line bg-surface/80 p-6 shadow-premium backdrop-blur md:p-8">
+        <div class="grid gap-4 md:grid-cols-2">
+          <div>
+            <label for="nombre" class="block text-sm font-medium text-slate-100">Nombre</label>
+            <input id="nombre" name="nombre" type="text" required class="mt-2 w-full rounded-2xl border border-line bg-ink/50 px-4 py-3 text-slate-50 outline-none transition placeholder:text-muted focus:border-cyan-electric/60 focus:ring-2 focus:ring-cyan-electric/20" placeholder="Tu nombre" />
+          </div>
+
+          <div>
+            <label for="rubro" class="block text-sm font-medium text-slate-100">Rubro</label>
+            <input id="rubro" name="rubro" type="text" required class="mt-2 w-full rounded-2xl border border-line bg-ink/50 px-4 py-3 text-slate-50 outline-none transition placeholder:text-muted focus:border-cyan-electric/60 focus:ring-2 focus:ring-cyan-electric/20" placeholder="Barbería, gimnasio, tienda..." />
+          </div>
+        </div>
+
+        <div class="mt-4 grid gap-4 md:grid-cols-2">
+          <div>
+            <label for="objetivo" class="block text-sm font-medium text-slate-100">Objetivo</label>
+            <select id="objetivo" name="objetivo" required class="mt-2 w-full rounded-2xl border border-line bg-ink/50 px-4 py-3 text-slate-50 outline-none transition focus:border-cyan-electric/60 focus:ring-2 focus:ring-cyan-electric/20">
+              <option value="más consultas">Más consultas</option>
+              <option value="reservas">Reservas</option>
+              <option value="ventas">Ventas</option>
+              <option value="ordenar procesos">Ordenar procesos</option>
+            </select>
+          </div>
+
+          <div>
+            <label for="hoy_tengo" class="block text-sm font-medium text-slate-100">Hoy tengo</label>
+            <select id="hoy_tengo" name="hoy_tengo" required class="mt-2 w-full rounded-2xl border border-line bg-ink/50 px-4 py-3 text-slate-50 outline-none transition focus:border-cyan-electric/60 focus:ring-2 focus:ring-cyan-electric/20">
+              <option value="Instagram">Instagram</option>
+              <option value="web">Web</option>
+              <option value="nada">Nada todavía</option>
+              <option value="idea">Una idea para validar</option>
+            </select>
+          </div>
+        </div>
+
+        <div class="mt-4 grid gap-4 md:grid-cols-2">
+          <div>
+            <label for="interes" class="block text-sm font-medium text-slate-100">Me interesa</label>
+            <select id="interes" name="interes" required class="mt-2 w-full rounded-2xl border border-line bg-ink/50 px-4 py-3 text-slate-50 outline-none transition focus:border-cyan-electric/60 focus:ring-2 focus:ring-cyan-electric/20">
+              <option value="landing">Landing</option>
+              <option value="demo">Demo</option>
+              <option value="agenda">Agenda</option>
+              <option value="panel">Panel</option>
+              <option value="no sé todavía">No sé todavía</option>
+            </select>
+          </div>
+
+          <div>
+            <label for="referencia" class="block text-sm font-medium text-slate-100">Link de referencia</label>
+            <input id="referencia" name="referencia" type="url" class="mt-2 w-full rounded-2xl border border-line bg-ink/50 px-4 py-3 text-slate-50 outline-none transition placeholder:text-muted focus:border-cyan-electric/60 focus:ring-2 focus:ring-cyan-electric/20" placeholder="Instagram o web" />
+          </div>
+        </div>
+
+        <div class="mt-4">
+          <label for="mensaje" class="block text-sm font-medium text-slate-100">Contexto breve</label>
+          <textarea id="mensaje" name="mensaje" rows="5" class="mt-2 w-full rounded-2xl border border-line bg-ink/50 px-4 py-3 text-slate-50 outline-none transition placeholder:text-muted focus:border-cyan-electric/60 focus:ring-2 focus:ring-cyan-electric/20" placeholder="Qué vendés, qué querés mejorar y si tenés alguna referencia."></textarea>
+        </div>
+
+        <div class="mt-6">
+          <button type="submit" class="inline-flex w-full items-center justify-center rounded-2xl bg-brand-gradient px-6 py-3 text-sm font-semibold text-white shadow-glow transition hover:-translate-y-0.5 hover:shadow-premium-hover sm:w-auto">
+            Mandame mi web o Instagram
+          </button>
+        </div>
+
+        <noscript>
+          <p class="mt-3 text-sm text-muted-soft">
+            Si tu navegador no permite enviar el formulario, escribime a
+            <a class="text-cyan-100 underline" href={`mailto:${EMAIL}`}>{EMAIL}</a>
+            o abrí WhatsApp en
+            <a class="text-cyan-100 underline" href={WHATSAPP_BASE_URL}>{WHATSAPP_BASE_URL}</a>.
+          </p>
+        </noscript>
+      </form>
+    </section>
+  </Container>
+
+  <script define:vars={{ WHATSAPP_NUMBER_E164 }}>
     const form = document.getElementById('contacto');
-    const WA = "59897316092"; // UY (+598) + 97316092
 
     form?.addEventListener('submit', (e) => {
       e.preventDefault();
       const data = new FormData(form);
 
       const nombre = String(data.get('nombre') || '').trim();
-      const email = String(data.get('email') || '').trim();
-      const presupuesto = String(data.get('presupuesto') || '').trim();
-      const plazo = String(data.get('plazo') || '').trim();
+      const rubro = String(data.get('rubro') || '').trim();
+      const objetivo = String(data.get('objetivo') || '').trim();
+      const hoyTengo = String(data.get('hoy_tengo') || '').trim();
+      const interes = String(data.get('interes') || '').trim();
+      const referencia = String(data.get('referencia') || '').trim();
       const mensaje = String(data.get('mensaje') || '').trim();
 
-      const params = new URLSearchParams(window.location.search);
-      const plan = params.get('plan');
-
       const lines = [
-        `Hola Diego, soy ${nombre || '[Nombre]'}.`,
-        plan ? `Quiero el plan: ${plan}` : '',
-        email ? `Email: ${email}` : '',
-        presupuesto ? `Presupuesto estimado: USD ${presupuesto}` : '',
-        plazo ? `Plazo requerido: ${plazo} días` : '',
+        `Hola Diego, quiero una demo/web para mi negocio.`,
         '',
-        'Resumen:',
-        mensaje || '[Contame tu negocio y qué objetivo buscás]',
-      ].filter(Boolean);
+        nombre ? `Soy: ${nombre}` : null,
+        `Rubro: ${rubro || '[rubro]'}`,
+        `Objetivo: ${objetivo || '[más consultas / reservas / ventas]'}`,
+        `Hoy tengo: ${hoyTengo || '[Instagram / web / nada]'}`,
+        `Me interesa: ${interes || '[landing / demo / agenda / panel / no sé todavía]'}`,
+        `Link de referencia: ${referencia || '[Instagram o web]'}`,
+      ].filter((line) => line !== null);
+
+      if (mensaje) {
+        lines.push('', `Contexto: ${mensaje}`);
+      }
 
       const text = lines.join(String.fromCharCode(10));
-      const href = `https://wa.me/${WA}?text=${encodeURIComponent(text)}`;
+      const href = `https://wa.me/${WHATSAPP_NUMBER_E164}?text=${encodeURIComponent(text)}`;
       window.open(href, '_blank', 'noopener,noreferrer');
     });
   </script>


### PR DESCRIPTION
### Motivation
- Make contact and pricing CTAs consistent with the V2 commercial positioning by centralizing contact data and WhatsApp message templates. 
- Convert the contact page into a guided commercial intake that drives demos/consults via WhatsApp instead of a generic contact form. 
- Ensure CTAs across footer and pricing open pre-filled, conversion-oriented WhatsApp messages. 

### Description
- Centralized social/contact constants and WhatsApp helpers in `src/lib/contact.ts`, adding `INSTAGRAM_HANDLE`, `INSTAGRAM_URL`, `SERVICE_WHATSAPP_MESSAGE` and normalizing the default/demo messages. 
- Updated `src/components/Footer.astro` to use the shared WhatsApp helper and surface Instagram with commercial copy. 
- Reworked `src/pages/contacto.astro` into a guided intake UI that collects `nombre`, `rubro`, `objetivo`, `hoy_tengo`, `interes`, `referencia` and generates a prefilled WhatsApp message aligned with the copy rules. 
- Switched pricing CTAs in `src/components/PricingPlans.astro` to open WhatsApp with package-specific messages and adjusted button labels to `Consultar este paquete`. 
- Small copy edits to `src/content/proyectos/Agencia_ariel.mdx` to prefer business-focused phrases (e.g., `Experiencia móvil`) over generic `responsive` wording. 

### Testing
- Ran `npm run format` and formatting completed successfully. 
- Ran `npm run build` and the static build completed successfully (site built and pages generated). 
- Ran `npm run lint` which failed due to the repo's ESLint configuration not providing a flat `eslint.config.(js|mjs|cjs)`, so linting errors were not introduced by this change and the existing config should be addressed separately.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff9113fb808328b113e1244e104ada)