### PR TITLE
Homepage: add ConversionFlow, make ContactCTA configurable and refine components/content

### DIFF
--- a/src/components/ContactCTA.astro
+++ b/src/components/ContactCTA.astro
@@ -1,21 +1,42 @@
 ---
 import { waLink, AUDIT_WHATSAPP_MESSAGE } from '../lib/contact';
+
+const {
+  eyebrow = 'Último paso',
+  title = 'Mandame tu web o Instagram y te digo qué mejoraría.',
+  description = 'Te respondo con ideas concretas: qué mejorar, qué mostrar primero y qué demo o web tendría más sentido para recibir consultas al momento.',
+  primaryLabel = 'Mandame mi web o Instagram',
+  primaryMessage = AUDIT_WHATSAPP_MESSAGE,
+  secondaryLabel,
+  secondaryHref,
+} = Astro.props;
 ---
 <section class="py-16 text-center md:py-24">
   <div class="relative overflow-hidden rounded-[2rem] border border-line bg-surface-glow p-8 shadow-premium backdrop-blur md:p-12">
     <div class="absolute inset-x-10 -top-20 h-40 rounded-full bg-cyan-electric/20 blur-3xl" aria-hidden="true"></div>
+    <div class="absolute -bottom-24 right-0 h-44 w-44 rounded-full bg-brand-violet/20 blur-3xl" aria-hidden="true"></div>
     <div class="relative mx-auto max-w-3xl">
-      <p class="text-sm font-semibold uppercase tracking-[0.22em] text-cyan-electric">Último paso</p>
-      <h2 class="mt-4 text-3xl font-semibold tracking-tight text-slate-50 md:text-5xl">Mandame tu web o Instagram y te digo qué mejoraría.</h2>
-      <p class="mt-4 text-base leading-7 text-muted-soft">Te respondo con ideas concretas: qué mejorar, qué mostrar primero y qué demo o web tendría más sentido para recibir consultas al momento.</p>
-      <a
-        href={waLink(AUDIT_WHATSAPP_MESSAGE)}
-        target="_blank"
-        rel="noopener noreferrer"
-        class="mt-8 inline-flex items-center justify-center rounded-2xl bg-brand-gradient px-6 py-3 text-sm font-semibold text-white shadow-glow transition hover:-translate-y-0.5 hover:shadow-premium-hover"
-      >
-        Mandame mi web o Instagram
-      </a>
+      <p class="text-sm font-semibold uppercase tracking-[0.22em] text-cyan-electric">{eyebrow}</p>
+      <h2 class="mt-4 text-3xl font-semibold tracking-tight text-slate-50 md:text-5xl">{title}</h2>
+      <p class="mt-4 text-base leading-7 text-muted-soft">{description}</p>
+      <div class="mt-8 flex flex-col items-center justify-center gap-3 sm:flex-row">
+        <a
+          href={waLink(primaryMessage)}
+          target="_blank"
+          rel="noopener noreferrer"
+          class="inline-flex items-center justify-center rounded-2xl bg-brand-gradient px-6 py-3 text-sm font-semibold text-white shadow-glow transition hover:-translate-y-0.5 hover:shadow-premium-hover"
+        >
+          {primaryLabel}
+        </a>
+        {secondaryLabel && secondaryHref && (
+          <a
+            href={secondaryHref}
+            class="inline-flex items-center justify-center rounded-2xl border border-line bg-surface-glass px-6 py-3 text-sm font-semibold text-slate-50 transition hover:-translate-y-0.5 hover:border-line-strong hover:text-cyan-electric"
+          >
+            {secondaryLabel}
+          </a>
+        )}
+      </div>
     </div>
   </div>
 </section>

--- a/src/components/ConversionFlow.astro
+++ b/src/components/ConversionFlow.astro
@@ -1,0 +1,37 @@
+---
+import GlowCard from './GlowCard.astro';
+import SectionHeader from './SectionHeader.astro';
+import { conversionFlow } from '../data/conversionFlow';
+---
+<section class="py-14 md:py-20" aria-label="Flujo de conversión comercial">
+  <div class="grid gap-8 lg:grid-cols-[0.9fr_1.1fr] lg:items-start">
+    <div class="lg:sticky lg:top-24">
+      <SectionHeader
+        eyebrow="Criterio CRO simple"
+        title="Cómo convierto una visita en una consulta más clara."
+        description="No se trata de llenar la home de secciones: cada bloque debe bajar fricción, responder dudas y acercar al visitante a una acción concreta."
+      />
+      <div class="mt-6 rounded-3xl border border-cyan-electric/20 bg-cyan-electric/10 p-5 text-sm leading-6 text-cyan-50">
+        <strong class="text-slate-50">Resultado buscado:</strong> una web que puedas mandar por WhatsApp, usar como link principal y mostrar como demo comercial sin parecer improvisada.
+      </div>
+    </div>
+
+    <div class="grid gap-4">
+      {conversionFlow.map((item) => (
+        <GlowCard class="relative overflow-hidden">
+          <div class="absolute -right-8 -top-10 h-28 w-28 rounded-full bg-cyan-electric/10 blur-2xl" aria-hidden="true"></div>
+          <div class="relative flex flex-col gap-4 sm:flex-row sm:items-start">
+            <span class="inline-flex h-11 w-11 shrink-0 items-center justify-center rounded-2xl border border-cyan-electric/25 bg-cyan-electric/10 text-sm font-bold text-cyan-electric">
+              {item.step}
+            </span>
+            <div>
+              <p class="text-xs font-semibold uppercase tracking-[0.18em] text-brand-success">{item.signal}</p>
+              <h3 class="mt-2 text-xl font-semibold tracking-tight text-slate-50">{item.title}</h3>
+              <p class="mt-3 text-sm leading-6 text-muted-soft">{item.description}</p>
+            </div>
+          </div>
+        </GlowCard>
+      ))}
+    </div>
+  </div>
+</section>

--- a/src/components/FeaturedCases.astro
+++ b/src/components/FeaturedCases.astro
@@ -9,32 +9,38 @@ const { projects = [] } = Astro.props;
     <SectionHeader
       eyebrow="Casos destacados"
       title="Proyectos presentados como prueba comercial."
-      description="Seleccionados por claridad de negocio, capacidad demostrable y facilidad para entender el problema que resuelven."
+      description="Proyectos elegidos para mostrar rubro, problema, solución y una próxima acción clara: ver la demo, entender el caso o pedir algo parecido."
     />
     <a href="/proyectos" class="inline-flex w-fit items-center gap-2 rounded-2xl border border-line bg-surface-glass px-5 py-3 text-sm font-semibold text-cyan-electric transition hover:-translate-y-0.5 hover:border-line-strong">
       Ver portfolio completo <span aria-hidden="true">→</span>
     </a>
   </div>
 
-  <div class="mt-8 grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
-    {projects.map((p) => (
-      <ProjectCard
-        title={p.data.title}
-        resumen={p.data.resumen}
-        stack={p.data.stack}
-        slug={p.slug}
-        cover={p.data.cover}
-        resultado={p.data.resultado}
-        problema={p.data.problema}
-        solucion={p.data.solucion}
-        tipo={p.data.tipo}
-        sector={p.data.sector}
-        status={p.data.status}
-        features={p.data.features}
-        impacto={p.data.impacto}
-        ctaLabel={p.data.ctaLabel}
-        priority={p.data.priority}
-      />
-    ))}
-  </div>
+  {projects.length > 0 ? (
+    <div class="mt-8 grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+      {projects.map((p) => (
+        <ProjectCard
+          title={p.data.title}
+          resumen={p.data.resumen}
+          stack={p.data.stack}
+          slug={p.slug}
+          cover={p.data.cover}
+          resultado={p.data.resultado}
+          problema={p.data.problema}
+          solucion={p.data.solucion}
+          tipo={p.data.tipo}
+          sector={p.data.sector}
+          status={p.data.status}
+          features={p.data.features}
+          impacto={p.data.impacto}
+          ctaLabel={p.data.ctaLabel}
+          priority={p.data.priority}
+        />
+      ))}
+    </div>
+  ) : (
+    <div class="mt-8 rounded-3xl border border-line bg-surface-glass p-8 text-sm leading-6 text-muted-soft">
+      Todavía no hay casos destacados cargados, pero el portfolio queda preparado para mostrarlos apenas se marque un proyecto como destacado.
+    </div>
+  )}
 </section>

--- a/src/components/OutcomeGrid.astro
+++ b/src/components/OutcomeGrid.astro
@@ -4,17 +4,18 @@ import SectionHeader from './SectionHeader.astro';
 import { outcomes } from '../data/outcomes';
 ---
 
-<section class="py-14 md:py-20">
+<section id="que-resuelvo" class="scroll-mt-24 py-14 md:py-20">
   <SectionHeader
-    eyebrow="Qué construyo"
-    title="Webs y demos que explican tu negocio en pocos segundos."
-    description="Cada sección ayuda a entender qué ofrecés, resolver dudas y llevar a la persona a escribirte, reservar o comprar."
+    eyebrow="Qué resuelvo"
+    title="La web no solo tiene que verse bien: tiene que guiar a la consulta."
+    description="Trabajo la estructura, los mensajes y los llamados a la acción para que el visitante entienda rápido qué ofrecés, qué paso dar y por qué confiar."
   />
   <div class="mt-8 grid gap-5 sm:grid-cols-2 lg:grid-cols-4">
     {
       outcomes.map((item) => (
         <GlowCard class="h-full">
-          <h3 class="text-lg font-semibold text-slate-50">{item.title}</h3>
+          <p class="text-xs font-semibold uppercase tracking-[0.18em] text-cyan-electric">{item.goal}</p>
+          <h3 class="mt-3 text-lg font-semibold text-slate-50">{item.title}</h3>
           <p class="mt-3 text-sm leading-6 text-muted-soft">
             {item.description}
           </p>

--- a/src/components/ProjectLinkPreview.astro
+++ b/src/components/ProjectLinkPreview.astro
@@ -1,0 +1,61 @@
+---
+const {
+  title,
+  url = '',
+  cover = '/og-default.png',
+  slug = '',
+  eager = false,
+} = Astro.props;
+
+const hasPreviewUrl = typeof url === 'string' && url.length > 0;
+const hasCustomCover = cover && cover !== '/og-default.png';
+const previewHost = hasPreviewUrl ? new URL(url).host.replace(/^www\./, '') : `marin.dev/caso/${slug}`;
+---
+<div class="relative">
+  <div class="absolute -inset-4 rounded-[2rem] bg-cyan-electric/10 blur-3xl"></div>
+  <div class="relative overflow-hidden rounded-3xl border border-line bg-surface-glow p-3 shadow-premium">
+    <div class="flex items-center gap-2 border-b border-line px-2 pb-3">
+      <span class="h-2.5 w-2.5 rounded-full bg-red-400/80"></span>
+      <span class="h-2.5 w-2.5 rounded-full bg-amber-300/80"></span>
+      <span class="h-2.5 w-2.5 rounded-full bg-emerald-400/80"></span>
+      <span class="ml-2 truncate rounded-full border border-line bg-ink/60 px-3 py-1 text-xs text-muted">{previewHost}</span>
+    </div>
+
+    <div class="relative mt-3 aspect-[4/3] overflow-hidden rounded-2xl border border-line bg-ink">
+      {hasPreviewUrl ? (
+        <>
+          <iframe
+            src={url}
+            title={`Vista previa navegable de ${title}`}
+            class="h-full w-full bg-white"
+            loading={eager ? 'eager' : 'lazy'}
+            referrerpolicy="no-referrer"
+            sandbox="allow-scripts allow-same-origin allow-forms allow-popups"
+          ></iframe>
+          <div class="pointer-events-none absolute inset-x-0 bottom-0 h-20 bg-gradient-to-t from-ink/80 to-transparent"></div>
+          <a
+            href={url}
+            target="_blank"
+            rel="noopener noreferrer"
+            class="absolute bottom-4 left-4 inline-flex items-center gap-2 rounded-xl border border-line bg-ink/80 px-4 py-2 text-xs font-semibold text-slate-50 shadow-premium backdrop-blur transition hover:-translate-y-0.5 hover:border-cyan-electric/40 hover:text-cyan-electric"
+          >
+            Abrir demo real <span aria-hidden="true">↗</span>
+          </a>
+        </>
+      ) : hasCustomCover ? (
+        <img src={cover} alt={`Mockup o portada de ${title}`} class="h-full w-full object-cover" loading={eager ? 'eager' : 'lazy'} decoding="async" />
+      ) : (
+        <div class="relative flex h-full flex-col justify-between overflow-hidden p-5">
+          <div class="absolute inset-0 bg-premium-grid bg-[length:2rem_2rem] opacity-45"></div>
+          <div class="absolute -left-16 top-6 h-40 w-40 rounded-full bg-cyan-electric/20 blur-3xl"></div>
+          <div class="absolute -right-14 bottom-0 h-44 w-44 rounded-full bg-brand-violet/20 blur-3xl"></div>
+          <div class="relative rounded-2xl border border-line bg-surface-glass p-4 shadow-premium backdrop-blur">
+            <p class="text-xs font-semibold uppercase tracking-[0.2em] text-cyan-electric">Preview del caso</p>
+            <p class="mt-2 text-lg font-semibold leading-tight text-slate-50">{title}</p>
+          </div>
+          <p class="relative text-xs leading-5 text-muted-soft">Agregá un link de demo para generar una vista previa embebida sin cargar una galería manual.</p>
+        </div>
+      )}
+    </div>
+  </div>
+</div>

--- a/src/components/SocialProofStrip.astro
+++ b/src/components/SocialProofStrip.astro
@@ -1,14 +1,20 @@
 ---
 import { capabilityStrip } from '../data/site';
 ---
-<section class="py-4" aria-label="Capacidades comerciales">
+<section class="py-6 md:py-8" aria-label="Capacidades comerciales">
   <div class="rounded-3xl border border-line bg-surface-glass p-3 shadow-premium backdrop-blur">
-    <div class="grid gap-2 sm:grid-cols-2 lg:grid-cols-5">
-      {capabilityStrip.map((item) => (
-        <div class="flex items-center justify-center gap-2 rounded-2xl border border-line bg-ink/35 px-3 py-3 text-center text-sm font-semibold text-muted-bright">
-          <span class="h-2 w-2 rounded-full bg-cyan-electric" aria-hidden="true"></span>
-          {item}
-        </div>
+    <div class="grid gap-3 sm:grid-cols-2 lg:grid-cols-5">
+      {capabilityStrip.map((item, index) => (
+        <article class="group relative overflow-hidden rounded-2xl border border-line bg-ink/35 p-4 transition hover:-translate-y-0.5 hover:border-cyan-electric/35 hover:bg-ink/55">
+          <div class="absolute right-3 top-3 text-[2.5rem] font-black leading-none text-slate-50/[0.03]" aria-hidden="true">
+            0{index + 1}
+          </div>
+          <div class="relative">
+            <span class="inline-flex h-2.5 w-2.5 rounded-full bg-cyan-electric shadow-[0_0_18px_rgba(34,211,238,0.65)]" aria-hidden="true"></span>
+            <h2 class="mt-4 text-sm font-semibold text-slate-50">{item.title}</h2>
+            <p class="mt-2 text-xs leading-5 text-muted-soft">{item.description}</p>
+          </div>
+        </article>
       ))}
     </div>
   </div>

--- a/src/components/VerticalDemos.astro
+++ b/src/components/VerticalDemos.astro
@@ -3,6 +3,7 @@ import Badge from './Badge.astro';
 import GlowCard from './GlowCard.astro';
 import SectionHeader from './SectionHeader.astro';
 import { verticalDemos } from '../data/verticals';
+import { waLink } from '../lib/contact';
 ---
 <section class="py-14 md:py-20">
   <SectionHeader
@@ -27,6 +28,14 @@ import { verticalDemos } from '../data/verticals';
         <div class="mt-5 flex flex-wrap gap-2">
           {demo.features.map((feature) => <Badge label={feature} tone="cyan" />)}
         </div>
+        <a
+          href={waLink(`Hola Diego, quiero una demo para este rubro: ${demo.name}.\n\nObjetivo: [más consultas / reservas / ventas]\nHoy tengo: [Instagram / web / nada]\nLink de referencia: [Instagram o web]`)}
+          target="_blank"
+          rel="noopener noreferrer"
+          class="mt-6 inline-flex w-fit items-center gap-2 rounded-2xl border border-line bg-surface-glass px-4 py-2 text-sm font-semibold text-slate-50 transition hover:-translate-y-0.5 hover:border-cyan-electric/35 hover:text-cyan-electric"
+        >
+          Pedir demo de {demo.name} <span aria-hidden="true">→</span>
+        </a>
       </GlowCard>
     ))}
   </div>

--- a/src/data/conversionFlow.ts
+++ b/src/data/conversionFlow.ts
@@ -1,0 +1,30 @@
+export const conversionFlow = [
+  {
+    step: "01",
+    title: "Aterriza desde Instagram, Google o WhatsApp",
+    description:
+      "La primera pantalla deja claro qué hacés, para quién es y qué acción conviene tomar sin obligar a leer de más.",
+    signal: "Promesa + CTA",
+  },
+  {
+    step: "02",
+    title: "Entiende servicios, confianza y diferencial",
+    description:
+      "La página ordena servicios, pruebas, preguntas y beneficios para reducir dudas antes de escribirte.",
+    signal: "Confianza + claridad",
+  },
+  {
+    step: "03",
+    title: "Elige una acción guiada",
+    description:
+      "WhatsApp, reserva, pedido o consulta salen con un mensaje preparado para pedir la información correcta desde el primer contacto.",
+    signal: "WhatsApp / agenda",
+  },
+  {
+    step: "04",
+    title: "La demo valida qué construir después",
+    description:
+      "Con una versión navegable podés mostrar la idea, ajustar secciones y decidir si conviene landing, agenda o panel simple.",
+    signal: "Demo → siguiente hito",
+  },
+];

--- a/src/data/outcomes.ts
+++ b/src/data/outcomes.ts
@@ -1,20 +1,24 @@
 export const outcomes = [
   {
+    goal: "Consulta",
     title: "Más consultas claras",
     description:
       "Botones visibles, WhatsApp con mensaje preparado y secciones que responden las dudas más comunes antes del primer contacto.",
   },
   {
+    goal: "Confianza",
     title: "Más confianza para decidir",
     description:
-      "Una presentación cuidada, ejemplos reales y mensajes simples para que la persona entienda rápido por qué elegirte.",
+      "Una presentación cuidada, casos concretos y mensajes simples para que la persona entienda rápido por qué elegirte.",
   },
   {
+    goal: "Operación",
     title: "Reservas y pedidos más ordenados",
     description:
       "Agendas, listas de servicios y contenido editable para que cada consulta llegue con la información necesaria.",
   },
   {
+    goal: "Validación",
     title: "Una demo lista para mostrar",
     description:
       "Una página navegable para compartir por WhatsApp, probar la idea y mostrar cómo se vería tu negocio online.",

--- a/src/data/process.ts
+++ b/src/data/process.ts
@@ -1,26 +1,26 @@
 export const processSteps = [
   {
     step: "01",
-    title: "Me pasás tu Instagram o web",
+    title: "Me pasás tu Instagram, web o idea",
     description:
-      "Reviso qué vendés, qué querés lograr y qué datos necesita mandar una persona para consultarte mejor.",
+      "Reviso qué vendés, a quién le hablás y qué datos necesita mandar una persona para consultarte mejor.",
   },
   {
     step: "02",
-    title: "Ordeno la idea",
+    title: "Detecto fricción y oportunidad",
     description:
-      "Defino qué contar primero, qué dudas responder y qué botón conviene usar para recibir consultas al momento.",
+      "Marco qué no se entiende, qué dudas frenan la consulta y qué contenido conviene mostrar primero.",
   },
   {
     step: "03",
-    title: "Diseño una demo concreta",
+    title: "Diseño una demo o propuesta",
     description:
-      "Armo una versión visual y navegable para que puedas verla, compartirla y ajustar detalles antes de avanzar.",
+      "Armo una versión visual y navegable para validar mensaje, estructura, CTA y alcance antes de avanzar de más.",
   },
   {
     step: "04",
-    title: "La dejamos publicada",
+    title: "Construimos, deployamos y vendés",
     description:
-      "Entrego la web online, los accesos necesarios y una guía breve con próximos pasos simples.",
+      "Dejamos la web publicada, los accesos claros y un flujo simple para compartirla y recibir consultas.",
   },
 ];

--- a/src/data/site.ts
+++ b/src/data/site.ts
@@ -1,9 +1,24 @@
 export const capabilityStrip = [
-  "Demos por rubro",
-  "WhatsApp listo",
-  "Agenda y reservas",
-  "Textos editables",
-  "Web publicada",
+  {
+    title: "Repo + deploy",
+    description: "Código ordenado, web publicada y lista para compartir.",
+  },
+  {
+    title: "WhatsApp guiado",
+    description: "Botones con mensaje preparado para pedir datos útiles.",
+  },
+  {
+    title: "Agenda / reservas",
+    description: "Flujos simples para turnos, pedidos o consultas concretas.",
+  },
+  {
+    title: "Panel simple",
+    description: "Contenido editable o sistema liviano cuando el caso lo pide.",
+  },
+  {
+    title: "Entrega por hitos",
+    description: "Avances claros para validar copy, diseño y publicación.",
+  },
 ];
 
 export const heroSignals = [

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -9,7 +9,9 @@ import ProductizedServices from '../components/ProductizedServices.astro';
 import SocialProofStrip from '../components/SocialProofStrip.astro';
 import VerticalDemos from '../components/VerticalDemos.astro';
 import OutcomeGrid from '../components/OutcomeGrid.astro';
+import ConversionFlow from '../components/ConversionFlow.astro';
 import { getCollection } from 'astro:content';
+import { DEMO_WHATSAPP_MESSAGE } from '../lib/contact';
 
 let proyectos = await getCollection('proyectos');
 proyectos = proyectos.sort((a, b) => {
@@ -19,7 +21,8 @@ proyectos = proyectos.sort((a, b) => {
   const priorityDiff = (b.data.priority ?? 0) - (a.data.priority ?? 0);
   return priorityDiff || (a.data.fecha < b.data.fecha ? 1 : -1);
 });
-const destacados = proyectos.slice(0, 3);
+const destacados = proyectos.filter((p) => p.data.featured).slice(0, 6);
+const homeCases = destacados.length > 0 ? destacados : proyectos.slice(0, 6);
 
 ---
 <BaseLayout
@@ -30,11 +33,20 @@ const destacados = proyectos.slice(0, 3);
   <SocialProofStrip />
 
   <OutcomeGrid />
+  <ConversionFlow />
 
-  <FeaturedCases projects={destacados} />
+  <FeaturedCases projects={homeCases} />
   <VerticalDemos />
   <ProcessSteps />
   <ProductizedServices />
   <FAQs />
-  <ContactCTA />
+  <ContactCTA
+    eyebrow="Listo para empezar"
+    title="Mandame tu Instagram o web y armamos una demo con objetivo comercial."
+    description="Si tenés un negocio, una idea o un servicio que hoy depende de mensajes sueltos, puedo ayudarte a convertirlo en una experiencia clara para recibir consultas, reservas o ventas."
+    primaryLabel="Quiero una demo para mi negocio"
+    primaryMessage={DEMO_WHATSAPP_MESSAGE}
+    secondaryLabel="Ver casos primero"
+    secondaryHref="#casos"
+  />
 </BaseLayout>

--- a/src/pages/proyectos/[slug].astro
+++ b/src/pages/proyectos/[slug].astro
@@ -3,6 +3,7 @@ import BaseLayout from '../../layouts/BaseLayout.astro';
 import Badge from '../../components/Badge.astro';
 import Container from '../../components/Container.astro';
 import GlowCard from '../../components/GlowCard.astro';
+import ProjectLinkPreview from '../../components/ProjectLinkPreview.astro';
 import { waLink } from '../../lib/contact';
 import { getCollection } from 'astro:content';
 
@@ -95,18 +96,7 @@ const whatsappText = `Hola Diego, quiero algo parecido a ${title}.\n\nRubro: [ru
           </div>
         </div>
 
-        <div class="relative">
-          <div class="absolute -inset-4 rounded-[2rem] bg-cyan-electric/10 blur-3xl"></div>
-          <div class="relative overflow-hidden rounded-3xl border border-line bg-surface-glow p-3 shadow-premium">
-            <div class="flex items-center gap-2 border-b border-line px-2 pb-3">
-              <span class="h-2.5 w-2.5 rounded-full bg-red-400/80"></span>
-              <span class="h-2.5 w-2.5 rounded-full bg-amber-300/80"></span>
-              <span class="h-2.5 w-2.5 rounded-full bg-emerald-400/80"></span>
-              <span class="ml-2 truncate rounded-full border border-line bg-ink/60 px-3 py-1 text-xs text-muted">marin.dev/caso/{proyecto.slug}</span>
-            </div>
-            <img src={cover} alt={`Mockup o portada de ${title}`} class="mt-3 aspect-[4/3] w-full rounded-2xl object-cover" loading="eager" decoding="async" />
-          </div>
-        </div>
+        <ProjectLinkPreview title={title} url={demoUrl} cover={cover} slug={proyecto.slug} eager />
       </header>
 
       <section class="mt-12 grid gap-5 lg:grid-cols-3">


### PR DESCRIPTION
### Motivation
- Clarify and improve the homepage messaging and conversion path to increase inquiries and demo requests.
- Make the contact CTA reusable and configurable for different contexts (audit vs demo) with prepared WhatsApp messages.
- Present capabilities, outcomes and vertical demos with richer content and CTAs to guide visitors to concrete actions.

### Description
- Added a new `ConversionFlow` component and data file `src/data/conversionFlow.ts` to show a simple CRO-focused conversion checklist on the homepage.
- Converted `ContactCTA` to accept props (`eyebrow`, `title`, `description`, `primaryLabel`, `primaryMessage`, `secondaryLabel`, `secondaryHref`) and updated its markup to support a secondary CTA and dynamic WhatsApp message via `waLink`.
- Updated homepage logic in `src/pages/index.astro` to import `ConversionFlow`, use `DEMO_WHATSAPP_MESSAGE` for the CTA, change how featured projects are selected (`destacados` / `homeCases`) and render the configurable `ContactCTA`.
- Reworked multiple components and data files: `FeaturedCases` now handles empty lists with a placeholder, `OutcomeGrid` text and structure updated and given an id, `SocialProofStrip` redesigned with richer `capabilityStrip` objects in `src/data/site.ts`, `VerticalDemos` adds per-demo WhatsApp CTAs, and copy adjustments in `src/data/outcomes.ts` and `src/data/process.ts` for clearer messaging.

### Testing
- Ran a local site build with `npm run build` (Astro) and a smoke check of the dev server; the build completed successfully and pages render without runtime errors.
- Verified that WhatsApp links generate using `waLink` and that the `ContactCTA` variations render correctly for both primary and optional secondary actions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff9e46ee1c8328abbd970bd65ab382)