### PR TITLE
Add project gallery thumbnails and wire them into project content

### DIFF
--- a/public/galeria/README.md
+++ b/public/galeria/README.md
@@ -1,0 +1,16 @@
+# Galería de miniaturas de proyectos
+
+Esta carpeta almacena las miniaturas locales usadas por las tarjetas y previews del portfolio.
+
+Convención:
+
+- Guardar cada miniatura como `/public/galeria/<slug-del-proyecto>.svg` o `.png`.
+- Conectar cada documento MDX con su miniatura mediante el campo `thumbnail` del frontmatter.
+- Mantener `cover` para imágenes externas, Open Graph heredado o previews alternativas; la UI prioriza `thumbnail` cuando existe.
+
+Ejemplo:
+
+```yaml
+cover: "/og-default.png"
+thumbnail: "/galeria/vetcare.svg"
+```

--- a/public/galeria/agencia_ariel.svg
+++ b/public/galeria/agencia_ariel.svg
@@ -1,0 +1,58 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="750" viewBox="0 0 1200 750" role="img" aria-labelledby="title desc">
+  <title id="title">Miniatura de Agencia Ariel</title>
+  <desc id="desc">Miniatura generada para la galería de proyectos de Marin.dev.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#050816"/>
+      <stop offset="0.55" stop-color="#0D1222"/>
+      <stop offset="1" stop-color="#080B14"/>
+    </linearGradient>
+    <radialGradient id="glowA" cx="22%" cy="18%" r="55%">
+      <stop offset="0" stop-color="#22D3EE" stop-opacity="0.55"/>
+      <stop offset="1" stop-color="#22D3EE" stop-opacity="0"/>
+    </radialGradient>
+    <radialGradient id="glowB" cx="78%" cy="72%" r="50%">
+      <stop offset="0" stop-color="#3B82F6" stop-opacity="0.38"/>
+      <stop offset="1" stop-color="#3B82F6" stop-opacity="0"/>
+    </radialGradient>
+    <pattern id="grid" width="42" height="42" patternUnits="userSpaceOnUse">
+      <path d="M 42 0 L 0 0 0 42" fill="none" stroke="#94A3B8" stroke-opacity="0.11" stroke-width="1"/>
+    </pattern>
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="28" stdDeviation="28" flood-color="#000000" flood-opacity="0.35"/>
+    </filter>
+  </defs>
+  <rect width="1200" height="750" fill="url(#bg)"/>
+  <rect width="1200" height="750" fill="url(#grid)" opacity="0.7"/>
+  <rect width="1200" height="750" fill="url(#glowA)"/>
+  <rect width="1200" height="750" fill="url(#glowB)"/>
+  <g filter="url(#shadow)">
+    <rect x="125" y="106" width="950" height="538" rx="36" fill="#0F172A" fill-opacity="0.78" stroke="#94A3B8" stroke-opacity="0.22"/>
+    <rect x="125" y="106" width="950" height="74" rx="36" fill="#111827" fill-opacity="0.82"/>
+    <circle cx="176" cy="143" r="10" fill="#F87171" fill-opacity="0.9"/>
+    <circle cx="211" cy="143" r="10" fill="#FBBF24" fill-opacity="0.9"/>
+    <circle cx="246" cy="143" r="10" fill="#34D399" fill-opacity="0.9"/>
+    <rect x="304" y="126" width="376" height="34" rx="17" fill="#020617" fill-opacity="0.78" stroke="#94A3B8" stroke-opacity="0.16"/>
+    <text x="327" y="148" fill="#94A3B8" font-family="Inter, Arial, sans-serif" font-size="15">marin.dev/proyectos/agencia_ariel</text>
+    <rect x="174" y="225" width="402" height="284" rx="28" fill="#020617" fill-opacity="0.58" stroke="#94A3B8" stroke-opacity="0.16"/>
+    <rect x="630" y="225" width="384" height="70" rx="22" fill="#020617" fill-opacity="0.5" stroke="#94A3B8" stroke-opacity="0.16"/>
+    <rect x="630" y="322" width="384" height="70" rx="22" fill="#020617" fill-opacity="0.5" stroke="#94A3B8" stroke-opacity="0.16"/>
+    <rect x="630" y="419" width="384" height="70" rx="22" fill="#020617" fill-opacity="0.5" stroke="#94A3B8" stroke-opacity="0.16"/>
+    <rect x="204" y="254" width="122" height="28" rx="14" fill="#22D3EE" fill-opacity="0.22" stroke="#22D3EE" stroke-opacity="0.4"/>
+    <text x="222" y="273" fill="#E0F2FE" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="700" letter-spacing="2">CASO</text>
+    <text x="204" y="345" fill="#F8FAFC" font-family="Inter, Arial, sans-serif" font-size="52" font-weight="800">Agencia Ariel</text>
+    <text x="204" y="397" fill="#CBD5E1" font-family="Inter, Arial, sans-serif" font-size="25" font-weight="600">Soluciones Logísticas</text>
+    <text x="204" y="456" fill="#94A3B8" font-family="Inter, Arial, sans-serif" font-size="18">Depósito · Transporte</text>
+    <circle cx="666" cy="260" r="12" fill="#22D3EE"/>
+    <rect x="694" y="246" width="230" height="14" rx="7" fill="#CBD5E1" fill-opacity="0.85"/>
+    <rect x="694" y="269" width="160" height="10" rx="5" fill="#94A3B8" fill-opacity="0.45"/>
+    <circle cx="666" cy="357" r="12" fill="#3B82F6"/>
+    <rect x="694" y="343" width="252" height="14" rx="7" fill="#CBD5E1" fill-opacity="0.8"/>
+    <rect x="694" y="366" width="188" height="10" rx="5" fill="#94A3B8" fill-opacity="0.45"/>
+    <circle cx="666" cy="454" r="12" fill="#34D399"/>
+    <rect x="694" y="440" width="210" height="14" rx="7" fill="#CBD5E1" fill-opacity="0.75"/>
+    <rect x="694" y="463" width="134" height="10" rx="5" fill="#94A3B8" fill-opacity="0.45"/>
+    <rect x="174" y="548" width="840" height="44" rx="22" fill="#22D3EE" fill-opacity="0.15" stroke="#22D3EE" stroke-opacity="0.25"/>
+    <text x="204" y="577" fill="#E0F2FE" font-family="Inter, Arial, sans-serif" font-size="17" font-weight="700">Miniatura local · /galeria/agencia_ariel.svg</text>
+  </g>
+</svg>

--- a/public/galeria/brasa-23.svg
+++ b/public/galeria/brasa-23.svg
@@ -1,0 +1,58 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="750" viewBox="0 0 1200 750" role="img" aria-labelledby="title desc">
+  <title id="title">Miniatura de Brasa 23</title>
+  <desc id="desc">Miniatura generada para la galería de proyectos de Marin.dev.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#050816"/>
+      <stop offset="0.55" stop-color="#0D1222"/>
+      <stop offset="1" stop-color="#080B14"/>
+    </linearGradient>
+    <radialGradient id="glowA" cx="22%" cy="18%" r="55%">
+      <stop offset="0" stop-color="#F97316" stop-opacity="0.55"/>
+      <stop offset="1" stop-color="#F97316" stop-opacity="0"/>
+    </radialGradient>
+    <radialGradient id="glowB" cx="78%" cy="72%" r="50%">
+      <stop offset="0" stop-color="#FBBF24" stop-opacity="0.38"/>
+      <stop offset="1" stop-color="#FBBF24" stop-opacity="0"/>
+    </radialGradient>
+    <pattern id="grid" width="42" height="42" patternUnits="userSpaceOnUse">
+      <path d="M 42 0 L 0 0 0 42" fill="none" stroke="#94A3B8" stroke-opacity="0.11" stroke-width="1"/>
+    </pattern>
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="28" stdDeviation="28" flood-color="#000000" flood-opacity="0.35"/>
+    </filter>
+  </defs>
+  <rect width="1200" height="750" fill="url(#bg)"/>
+  <rect width="1200" height="750" fill="url(#grid)" opacity="0.7"/>
+  <rect width="1200" height="750" fill="url(#glowA)"/>
+  <rect width="1200" height="750" fill="url(#glowB)"/>
+  <g filter="url(#shadow)">
+    <rect x="125" y="106" width="950" height="538" rx="36" fill="#0F172A" fill-opacity="0.78" stroke="#94A3B8" stroke-opacity="0.22"/>
+    <rect x="125" y="106" width="950" height="74" rx="36" fill="#111827" fill-opacity="0.82"/>
+    <circle cx="176" cy="143" r="10" fill="#F87171" fill-opacity="0.9"/>
+    <circle cx="211" cy="143" r="10" fill="#FBBF24" fill-opacity="0.9"/>
+    <circle cx="246" cy="143" r="10" fill="#34D399" fill-opacity="0.9"/>
+    <rect x="304" y="126" width="376" height="34" rx="17" fill="#020617" fill-opacity="0.78" stroke="#94A3B8" stroke-opacity="0.16"/>
+    <text x="327" y="148" fill="#94A3B8" font-family="Inter, Arial, sans-serif" font-size="15">marin.dev/proyectos/brasa-23</text>
+    <rect x="174" y="225" width="402" height="284" rx="28" fill="#020617" fill-opacity="0.58" stroke="#94A3B8" stroke-opacity="0.16"/>
+    <rect x="630" y="225" width="384" height="70" rx="22" fill="#020617" fill-opacity="0.5" stroke="#94A3B8" stroke-opacity="0.16"/>
+    <rect x="630" y="322" width="384" height="70" rx="22" fill="#020617" fill-opacity="0.5" stroke="#94A3B8" stroke-opacity="0.16"/>
+    <rect x="630" y="419" width="384" height="70" rx="22" fill="#020617" fill-opacity="0.5" stroke="#94A3B8" stroke-opacity="0.16"/>
+    <rect x="204" y="254" width="122" height="28" rx="14" fill="#F97316" fill-opacity="0.22" stroke="#F97316" stroke-opacity="0.4"/>
+    <text x="222" y="273" fill="#E0F2FE" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="700" letter-spacing="2">CASO</text>
+    <text x="204" y="345" fill="#F8FAFC" font-family="Inter, Arial, sans-serif" font-size="52" font-weight="800">Brasa 23</text>
+    <text x="204" y="397" fill="#CBD5E1" font-family="Inter, Arial, sans-serif" font-size="25" font-weight="600">Demo restaurante</text>
+    <text x="204" y="456" fill="#94A3B8" font-family="Inter, Arial, sans-serif" font-size="18">Carta · Reservas</text>
+    <circle cx="666" cy="260" r="12" fill="#F97316"/>
+    <rect x="694" y="246" width="230" height="14" rx="7" fill="#CBD5E1" fill-opacity="0.85"/>
+    <rect x="694" y="269" width="160" height="10" rx="5" fill="#94A3B8" fill-opacity="0.45"/>
+    <circle cx="666" cy="357" r="12" fill="#FBBF24"/>
+    <rect x="694" y="343" width="252" height="14" rx="7" fill="#CBD5E1" fill-opacity="0.8"/>
+    <rect x="694" y="366" width="188" height="10" rx="5" fill="#94A3B8" fill-opacity="0.45"/>
+    <circle cx="666" cy="454" r="12" fill="#34D399"/>
+    <rect x="694" y="440" width="210" height="14" rx="7" fill="#CBD5E1" fill-opacity="0.75"/>
+    <rect x="694" y="463" width="134" height="10" rx="5" fill="#94A3B8" fill-opacity="0.45"/>
+    <rect x="174" y="548" width="840" height="44" rx="22" fill="#F97316" fill-opacity="0.15" stroke="#F97316" stroke-opacity="0.25"/>
+    <text x="204" y="577" fill="#E0F2FE" font-family="Inter, Arial, sans-serif" font-size="17" font-weight="700">Miniatura local · /galeria/brasa-23.svg</text>
+  </g>
+</svg>

--- a/public/galeria/cristal-sagrado.svg
+++ b/public/galeria/cristal-sagrado.svg
@@ -1,0 +1,58 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="750" viewBox="0 0 1200 750" role="img" aria-labelledby="title desc">
+  <title id="title">Miniatura de Cristal Sagrado</title>
+  <desc id="desc">Miniatura generada para la galería de proyectos de Marin.dev.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#050816"/>
+      <stop offset="0.55" stop-color="#0D1222"/>
+      <stop offset="1" stop-color="#080B14"/>
+    </linearGradient>
+    <radialGradient id="glowA" cx="22%" cy="18%" r="55%">
+      <stop offset="0" stop-color="#8B5CF6" stop-opacity="0.55"/>
+      <stop offset="1" stop-color="#8B5CF6" stop-opacity="0"/>
+    </radialGradient>
+    <radialGradient id="glowB" cx="78%" cy="72%" r="50%">
+      <stop offset="0" stop-color="#22D3EE" stop-opacity="0.38"/>
+      <stop offset="1" stop-color="#22D3EE" stop-opacity="0"/>
+    </radialGradient>
+    <pattern id="grid" width="42" height="42" patternUnits="userSpaceOnUse">
+      <path d="M 42 0 L 0 0 0 42" fill="none" stroke="#94A3B8" stroke-opacity="0.11" stroke-width="1"/>
+    </pattern>
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="28" stdDeviation="28" flood-color="#000000" flood-opacity="0.35"/>
+    </filter>
+  </defs>
+  <rect width="1200" height="750" fill="url(#bg)"/>
+  <rect width="1200" height="750" fill="url(#grid)" opacity="0.7"/>
+  <rect width="1200" height="750" fill="url(#glowA)"/>
+  <rect width="1200" height="750" fill="url(#glowB)"/>
+  <g filter="url(#shadow)">
+    <rect x="125" y="106" width="950" height="538" rx="36" fill="#0F172A" fill-opacity="0.78" stroke="#94A3B8" stroke-opacity="0.22"/>
+    <rect x="125" y="106" width="950" height="74" rx="36" fill="#111827" fill-opacity="0.82"/>
+    <circle cx="176" cy="143" r="10" fill="#F87171" fill-opacity="0.9"/>
+    <circle cx="211" cy="143" r="10" fill="#FBBF24" fill-opacity="0.9"/>
+    <circle cx="246" cy="143" r="10" fill="#34D399" fill-opacity="0.9"/>
+    <rect x="304" y="126" width="376" height="34" rx="17" fill="#020617" fill-opacity="0.78" stroke="#94A3B8" stroke-opacity="0.16"/>
+    <text x="327" y="148" fill="#94A3B8" font-family="Inter, Arial, sans-serif" font-size="15">marin.dev/proyectos/cristal-sagrado</text>
+    <rect x="174" y="225" width="402" height="284" rx="28" fill="#020617" fill-opacity="0.58" stroke="#94A3B8" stroke-opacity="0.16"/>
+    <rect x="630" y="225" width="384" height="70" rx="22" fill="#020617" fill-opacity="0.5" stroke="#94A3B8" stroke-opacity="0.16"/>
+    <rect x="630" y="322" width="384" height="70" rx="22" fill="#020617" fill-opacity="0.5" stroke="#94A3B8" stroke-opacity="0.16"/>
+    <rect x="630" y="419" width="384" height="70" rx="22" fill="#020617" fill-opacity="0.5" stroke="#94A3B8" stroke-opacity="0.16"/>
+    <rect x="204" y="254" width="122" height="28" rx="14" fill="#8B5CF6" fill-opacity="0.22" stroke="#8B5CF6" stroke-opacity="0.4"/>
+    <text x="222" y="273" fill="#E0F2FE" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="700" letter-spacing="2">CASO</text>
+    <text x="204" y="345" fill="#F8FAFC" font-family="Inter, Arial, sans-serif" font-size="52" font-weight="800">Cristal Sagrado</text>
+    <text x="204" y="397" fill="#CBD5E1" font-family="Inter, Arial, sans-serif" font-size="25" font-weight="600">Web editable</text>
+    <text x="204" y="456" fill="#94A3B8" font-family="Inter, Arial, sans-serif" font-size="18">Bienestar · Consultas</text>
+    <circle cx="666" cy="260" r="12" fill="#8B5CF6"/>
+    <rect x="694" y="246" width="230" height="14" rx="7" fill="#CBD5E1" fill-opacity="0.85"/>
+    <rect x="694" y="269" width="160" height="10" rx="5" fill="#94A3B8" fill-opacity="0.45"/>
+    <circle cx="666" cy="357" r="12" fill="#22D3EE"/>
+    <rect x="694" y="343" width="252" height="14" rx="7" fill="#CBD5E1" fill-opacity="0.8"/>
+    <rect x="694" y="366" width="188" height="10" rx="5" fill="#94A3B8" fill-opacity="0.45"/>
+    <circle cx="666" cy="454" r="12" fill="#34D399"/>
+    <rect x="694" y="440" width="210" height="14" rx="7" fill="#CBD5E1" fill-opacity="0.75"/>
+    <rect x="694" y="463" width="134" height="10" rx="5" fill="#94A3B8" fill-opacity="0.45"/>
+    <rect x="174" y="548" width="840" height="44" rx="22" fill="#8B5CF6" fill-opacity="0.15" stroke="#8B5CF6" stroke-opacity="0.25"/>
+    <text x="204" y="577" fill="#E0F2FE" font-family="Inter, Arial, sans-serif" font-size="17" font-weight="700">Miniatura local · /galeria/cristal-sagrado.svg</text>
+  </g>
+</svg>

--- a/public/galeria/noir-barber-studio.svg
+++ b/public/galeria/noir-barber-studio.svg
@@ -1,0 +1,58 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="750" viewBox="0 0 1200 750" role="img" aria-labelledby="title desc">
+  <title id="title">Miniatura de Noir Barber Studio</title>
+  <desc id="desc">Miniatura generada para la galería de proyectos de Marin.dev.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#050816"/>
+      <stop offset="0.55" stop-color="#0D1222"/>
+      <stop offset="1" stop-color="#080B14"/>
+    </linearGradient>
+    <radialGradient id="glowA" cx="22%" cy="18%" r="55%">
+      <stop offset="0" stop-color="#111827" stop-opacity="0.55"/>
+      <stop offset="1" stop-color="#111827" stop-opacity="0"/>
+    </radialGradient>
+    <radialGradient id="glowB" cx="78%" cy="72%" r="50%">
+      <stop offset="0" stop-color="#22D3EE" stop-opacity="0.38"/>
+      <stop offset="1" stop-color="#22D3EE" stop-opacity="0"/>
+    </radialGradient>
+    <pattern id="grid" width="42" height="42" patternUnits="userSpaceOnUse">
+      <path d="M 42 0 L 0 0 0 42" fill="none" stroke="#94A3B8" stroke-opacity="0.11" stroke-width="1"/>
+    </pattern>
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="28" stdDeviation="28" flood-color="#000000" flood-opacity="0.35"/>
+    </filter>
+  </defs>
+  <rect width="1200" height="750" fill="url(#bg)"/>
+  <rect width="1200" height="750" fill="url(#grid)" opacity="0.7"/>
+  <rect width="1200" height="750" fill="url(#glowA)"/>
+  <rect width="1200" height="750" fill="url(#glowB)"/>
+  <g filter="url(#shadow)">
+    <rect x="125" y="106" width="950" height="538" rx="36" fill="#0F172A" fill-opacity="0.78" stroke="#94A3B8" stroke-opacity="0.22"/>
+    <rect x="125" y="106" width="950" height="74" rx="36" fill="#111827" fill-opacity="0.82"/>
+    <circle cx="176" cy="143" r="10" fill="#F87171" fill-opacity="0.9"/>
+    <circle cx="211" cy="143" r="10" fill="#FBBF24" fill-opacity="0.9"/>
+    <circle cx="246" cy="143" r="10" fill="#34D399" fill-opacity="0.9"/>
+    <rect x="304" y="126" width="376" height="34" rx="17" fill="#020617" fill-opacity="0.78" stroke="#94A3B8" stroke-opacity="0.16"/>
+    <text x="327" y="148" fill="#94A3B8" font-family="Inter, Arial, sans-serif" font-size="15">marin.dev/proyectos/noir-barber-studio</text>
+    <rect x="174" y="225" width="402" height="284" rx="28" fill="#020617" fill-opacity="0.58" stroke="#94A3B8" stroke-opacity="0.16"/>
+    <rect x="630" y="225" width="384" height="70" rx="22" fill="#020617" fill-opacity="0.5" stroke="#94A3B8" stroke-opacity="0.16"/>
+    <rect x="630" y="322" width="384" height="70" rx="22" fill="#020617" fill-opacity="0.5" stroke="#94A3B8" stroke-opacity="0.16"/>
+    <rect x="630" y="419" width="384" height="70" rx="22" fill="#020617" fill-opacity="0.5" stroke="#94A3B8" stroke-opacity="0.16"/>
+    <rect x="204" y="254" width="122" height="28" rx="14" fill="#111827" fill-opacity="0.22" stroke="#111827" stroke-opacity="0.4"/>
+    <text x="222" y="273" fill="#E0F2FE" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="700" letter-spacing="2">CASO</text>
+    <text x="204" y="345" fill="#F8FAFC" font-family="Inter, Arial, sans-serif" font-size="52" font-weight="800">Noir Barber Studio</text>
+    <text x="204" y="397" fill="#CBD5E1" font-family="Inter, Arial, sans-serif" font-size="25" font-weight="600">Demo barbería</text>
+    <text x="204" y="456" fill="#94A3B8" font-family="Inter, Arial, sans-serif" font-size="18">Reservas · Estética</text>
+    <circle cx="666" cy="260" r="12" fill="#111827"/>
+    <rect x="694" y="246" width="230" height="14" rx="7" fill="#CBD5E1" fill-opacity="0.85"/>
+    <rect x="694" y="269" width="160" height="10" rx="5" fill="#94A3B8" fill-opacity="0.45"/>
+    <circle cx="666" cy="357" r="12" fill="#22D3EE"/>
+    <rect x="694" y="343" width="252" height="14" rx="7" fill="#CBD5E1" fill-opacity="0.8"/>
+    <rect x="694" y="366" width="188" height="10" rx="5" fill="#94A3B8" fill-opacity="0.45"/>
+    <circle cx="666" cy="454" r="12" fill="#34D399"/>
+    <rect x="694" y="440" width="210" height="14" rx="7" fill="#CBD5E1" fill-opacity="0.75"/>
+    <rect x="694" y="463" width="134" height="10" rx="5" fill="#94A3B8" fill-opacity="0.45"/>
+    <rect x="174" y="548" width="840" height="44" rx="22" fill="#111827" fill-opacity="0.15" stroke="#111827" stroke-opacity="0.25"/>
+    <text x="204" y="577" fill="#E0F2FE" font-family="Inter, Arial, sans-serif" font-size="17" font-weight="700">Miniatura local · /galeria/noir-barber-studio.svg</text>
+  </g>
+</svg>

--- a/public/galeria/servicio-de-tarot.svg
+++ b/public/galeria/servicio-de-tarot.svg
@@ -1,0 +1,58 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="750" viewBox="0 0 1200 750" role="img" aria-labelledby="title desc">
+  <title id="title">Miniatura de Servicio de Tarot</title>
+  <desc id="desc">Miniatura generada para la galería de proyectos de Marin.dev.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#050816"/>
+      <stop offset="0.55" stop-color="#0D1222"/>
+      <stop offset="1" stop-color="#080B14"/>
+    </linearGradient>
+    <radialGradient id="glowA" cx="22%" cy="18%" r="55%">
+      <stop offset="0" stop-color="#8B5CF6" stop-opacity="0.55"/>
+      <stop offset="1" stop-color="#8B5CF6" stop-opacity="0"/>
+    </radialGradient>
+    <radialGradient id="glowB" cx="78%" cy="72%" r="50%">
+      <stop offset="0" stop-color="#FBBF24" stop-opacity="0.38"/>
+      <stop offset="1" stop-color="#FBBF24" stop-opacity="0"/>
+    </radialGradient>
+    <pattern id="grid" width="42" height="42" patternUnits="userSpaceOnUse">
+      <path d="M 42 0 L 0 0 0 42" fill="none" stroke="#94A3B8" stroke-opacity="0.11" stroke-width="1"/>
+    </pattern>
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="28" stdDeviation="28" flood-color="#000000" flood-opacity="0.35"/>
+    </filter>
+  </defs>
+  <rect width="1200" height="750" fill="url(#bg)"/>
+  <rect width="1200" height="750" fill="url(#grid)" opacity="0.7"/>
+  <rect width="1200" height="750" fill="url(#glowA)"/>
+  <rect width="1200" height="750" fill="url(#glowB)"/>
+  <g filter="url(#shadow)">
+    <rect x="125" y="106" width="950" height="538" rx="36" fill="#0F172A" fill-opacity="0.78" stroke="#94A3B8" stroke-opacity="0.22"/>
+    <rect x="125" y="106" width="950" height="74" rx="36" fill="#111827" fill-opacity="0.82"/>
+    <circle cx="176" cy="143" r="10" fill="#F87171" fill-opacity="0.9"/>
+    <circle cx="211" cy="143" r="10" fill="#FBBF24" fill-opacity="0.9"/>
+    <circle cx="246" cy="143" r="10" fill="#34D399" fill-opacity="0.9"/>
+    <rect x="304" y="126" width="376" height="34" rx="17" fill="#020617" fill-opacity="0.78" stroke="#94A3B8" stroke-opacity="0.16"/>
+    <text x="327" y="148" fill="#94A3B8" font-family="Inter, Arial, sans-serif" font-size="15">marin.dev/proyectos/servicio-de-tarot</text>
+    <rect x="174" y="225" width="402" height="284" rx="28" fill="#020617" fill-opacity="0.58" stroke="#94A3B8" stroke-opacity="0.16"/>
+    <rect x="630" y="225" width="384" height="70" rx="22" fill="#020617" fill-opacity="0.5" stroke="#94A3B8" stroke-opacity="0.16"/>
+    <rect x="630" y="322" width="384" height="70" rx="22" fill="#020617" fill-opacity="0.5" stroke="#94A3B8" stroke-opacity="0.16"/>
+    <rect x="630" y="419" width="384" height="70" rx="22" fill="#020617" fill-opacity="0.5" stroke="#94A3B8" stroke-opacity="0.16"/>
+    <rect x="204" y="254" width="122" height="28" rx="14" fill="#8B5CF6" fill-opacity="0.22" stroke="#8B5CF6" stroke-opacity="0.4"/>
+    <text x="222" y="273" fill="#E0F2FE" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="700" letter-spacing="2">CASO</text>
+    <text x="204" y="345" fill="#F8FAFC" font-family="Inter, Arial, sans-serif" font-size="52" font-weight="800">Servicio de Tarot</text>
+    <text x="204" y="397" fill="#CBD5E1" font-family="Inter, Arial, sans-serif" font-size="25" font-weight="600">Landing comercial</text>
+    <text x="204" y="456" fill="#94A3B8" font-family="Inter, Arial, sans-serif" font-size="18">Consultas · WhatsApp</text>
+    <circle cx="666" cy="260" r="12" fill="#8B5CF6"/>
+    <rect x="694" y="246" width="230" height="14" rx="7" fill="#CBD5E1" fill-opacity="0.85"/>
+    <rect x="694" y="269" width="160" height="10" rx="5" fill="#94A3B8" fill-opacity="0.45"/>
+    <circle cx="666" cy="357" r="12" fill="#FBBF24"/>
+    <rect x="694" y="343" width="252" height="14" rx="7" fill="#CBD5E1" fill-opacity="0.8"/>
+    <rect x="694" y="366" width="188" height="10" rx="5" fill="#94A3B8" fill-opacity="0.45"/>
+    <circle cx="666" cy="454" r="12" fill="#34D399"/>
+    <rect x="694" y="440" width="210" height="14" rx="7" fill="#CBD5E1" fill-opacity="0.75"/>
+    <rect x="694" y="463" width="134" height="10" rx="5" fill="#94A3B8" fill-opacity="0.45"/>
+    <rect x="174" y="548" width="840" height="44" rx="22" fill="#8B5CF6" fill-opacity="0.15" stroke="#8B5CF6" stroke-opacity="0.25"/>
+    <text x="204" y="577" fill="#E0F2FE" font-family="Inter, Arial, sans-serif" font-size="17" font-weight="700">Miniatura local · /galeria/servicio-de-tarot.svg</text>
+  </g>
+</svg>

--- a/public/galeria/smart-stock.svg
+++ b/public/galeria/smart-stock.svg
@@ -1,0 +1,58 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="750" viewBox="0 0 1200 750" role="img" aria-labelledby="title desc">
+  <title id="title">Miniatura de Smart Stock</title>
+  <desc id="desc">Miniatura generada para la galería de proyectos de Marin.dev.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#050816"/>
+      <stop offset="0.55" stop-color="#0D1222"/>
+      <stop offset="1" stop-color="#080B14"/>
+    </linearGradient>
+    <radialGradient id="glowA" cx="22%" cy="18%" r="55%">
+      <stop offset="0" stop-color="#34D399" stop-opacity="0.55"/>
+      <stop offset="1" stop-color="#34D399" stop-opacity="0"/>
+    </radialGradient>
+    <radialGradient id="glowB" cx="78%" cy="72%" r="50%">
+      <stop offset="0" stop-color="#3B82F6" stop-opacity="0.38"/>
+      <stop offset="1" stop-color="#3B82F6" stop-opacity="0"/>
+    </radialGradient>
+    <pattern id="grid" width="42" height="42" patternUnits="userSpaceOnUse">
+      <path d="M 42 0 L 0 0 0 42" fill="none" stroke="#94A3B8" stroke-opacity="0.11" stroke-width="1"/>
+    </pattern>
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="28" stdDeviation="28" flood-color="#000000" flood-opacity="0.35"/>
+    </filter>
+  </defs>
+  <rect width="1200" height="750" fill="url(#bg)"/>
+  <rect width="1200" height="750" fill="url(#grid)" opacity="0.7"/>
+  <rect width="1200" height="750" fill="url(#glowA)"/>
+  <rect width="1200" height="750" fill="url(#glowB)"/>
+  <g filter="url(#shadow)">
+    <rect x="125" y="106" width="950" height="538" rx="36" fill="#0F172A" fill-opacity="0.78" stroke="#94A3B8" stroke-opacity="0.22"/>
+    <rect x="125" y="106" width="950" height="74" rx="36" fill="#111827" fill-opacity="0.82"/>
+    <circle cx="176" cy="143" r="10" fill="#F87171" fill-opacity="0.9"/>
+    <circle cx="211" cy="143" r="10" fill="#FBBF24" fill-opacity="0.9"/>
+    <circle cx="246" cy="143" r="10" fill="#34D399" fill-opacity="0.9"/>
+    <rect x="304" y="126" width="376" height="34" rx="17" fill="#020617" fill-opacity="0.78" stroke="#94A3B8" stroke-opacity="0.16"/>
+    <text x="327" y="148" fill="#94A3B8" font-family="Inter, Arial, sans-serif" font-size="15">marin.dev/proyectos/smart-stock</text>
+    <rect x="174" y="225" width="402" height="284" rx="28" fill="#020617" fill-opacity="0.58" stroke="#94A3B8" stroke-opacity="0.16"/>
+    <rect x="630" y="225" width="384" height="70" rx="22" fill="#020617" fill-opacity="0.5" stroke="#94A3B8" stroke-opacity="0.16"/>
+    <rect x="630" y="322" width="384" height="70" rx="22" fill="#020617" fill-opacity="0.5" stroke="#94A3B8" stroke-opacity="0.16"/>
+    <rect x="630" y="419" width="384" height="70" rx="22" fill="#020617" fill-opacity="0.5" stroke="#94A3B8" stroke-opacity="0.16"/>
+    <rect x="204" y="254" width="122" height="28" rx="14" fill="#34D399" fill-opacity="0.22" stroke="#34D399" stroke-opacity="0.4"/>
+    <text x="222" y="273" fill="#E0F2FE" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="700" letter-spacing="2">CASO</text>
+    <text x="204" y="345" fill="#F8FAFC" font-family="Inter, Arial, sans-serif" font-size="52" font-weight="800">Smart Stock</text>
+    <text x="204" y="397" fill="#CBD5E1" font-family="Inter, Arial, sans-serif" font-size="25" font-weight="600">Dashboard operativo</text>
+    <text x="204" y="456" fill="#94A3B8" font-family="Inter, Arial, sans-serif" font-size="18">Stock · Inventario</text>
+    <circle cx="666" cy="260" r="12" fill="#34D399"/>
+    <rect x="694" y="246" width="230" height="14" rx="7" fill="#CBD5E1" fill-opacity="0.85"/>
+    <rect x="694" y="269" width="160" height="10" rx="5" fill="#94A3B8" fill-opacity="0.45"/>
+    <circle cx="666" cy="357" r="12" fill="#3B82F6"/>
+    <rect x="694" y="343" width="252" height="14" rx="7" fill="#CBD5E1" fill-opacity="0.8"/>
+    <rect x="694" y="366" width="188" height="10" rx="5" fill="#94A3B8" fill-opacity="0.45"/>
+    <circle cx="666" cy="454" r="12" fill="#34D399"/>
+    <rect x="694" y="440" width="210" height="14" rx="7" fill="#CBD5E1" fill-opacity="0.75"/>
+    <rect x="694" y="463" width="134" height="10" rx="5" fill="#94A3B8" fill-opacity="0.45"/>
+    <rect x="174" y="548" width="840" height="44" rx="22" fill="#34D399" fill-opacity="0.15" stroke="#34D399" stroke-opacity="0.25"/>
+    <text x="204" y="577" fill="#E0F2FE" font-family="Inter, Arial, sans-serif" font-size="17" font-weight="700">Miniatura local · /galeria/smart-stock.svg</text>
+  </g>
+</svg>

--- a/public/galeria/vetcare.svg
+++ b/public/galeria/vetcare.svg
@@ -1,0 +1,58 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="750" viewBox="0 0 1200 750" role="img" aria-labelledby="title desc">
+  <title id="title">Miniatura de VetCare</title>
+  <desc id="desc">Miniatura generada para la galería de proyectos de Marin.dev.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#050816"/>
+      <stop offset="0.55" stop-color="#0D1222"/>
+      <stop offset="1" stop-color="#080B14"/>
+    </linearGradient>
+    <radialGradient id="glowA" cx="22%" cy="18%" r="55%">
+      <stop offset="0" stop-color="#22D3EE" stop-opacity="0.55"/>
+      <stop offset="1" stop-color="#22D3EE" stop-opacity="0"/>
+    </radialGradient>
+    <radialGradient id="glowB" cx="78%" cy="72%" r="50%">
+      <stop offset="0" stop-color="#34D399" stop-opacity="0.38"/>
+      <stop offset="1" stop-color="#34D399" stop-opacity="0"/>
+    </radialGradient>
+    <pattern id="grid" width="42" height="42" patternUnits="userSpaceOnUse">
+      <path d="M 42 0 L 0 0 0 42" fill="none" stroke="#94A3B8" stroke-opacity="0.11" stroke-width="1"/>
+    </pattern>
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="28" stdDeviation="28" flood-color="#000000" flood-opacity="0.35"/>
+    </filter>
+  </defs>
+  <rect width="1200" height="750" fill="url(#bg)"/>
+  <rect width="1200" height="750" fill="url(#grid)" opacity="0.7"/>
+  <rect width="1200" height="750" fill="url(#glowA)"/>
+  <rect width="1200" height="750" fill="url(#glowB)"/>
+  <g filter="url(#shadow)">
+    <rect x="125" y="106" width="950" height="538" rx="36" fill="#0F172A" fill-opacity="0.78" stroke="#94A3B8" stroke-opacity="0.22"/>
+    <rect x="125" y="106" width="950" height="74" rx="36" fill="#111827" fill-opacity="0.82"/>
+    <circle cx="176" cy="143" r="10" fill="#F87171" fill-opacity="0.9"/>
+    <circle cx="211" cy="143" r="10" fill="#FBBF24" fill-opacity="0.9"/>
+    <circle cx="246" cy="143" r="10" fill="#34D399" fill-opacity="0.9"/>
+    <rect x="304" y="126" width="376" height="34" rx="17" fill="#020617" fill-opacity="0.78" stroke="#94A3B8" stroke-opacity="0.16"/>
+    <text x="327" y="148" fill="#94A3B8" font-family="Inter, Arial, sans-serif" font-size="15">marin.dev/proyectos/vetcare</text>
+    <rect x="174" y="225" width="402" height="284" rx="28" fill="#020617" fill-opacity="0.58" stroke="#94A3B8" stroke-opacity="0.16"/>
+    <rect x="630" y="225" width="384" height="70" rx="22" fill="#020617" fill-opacity="0.5" stroke="#94A3B8" stroke-opacity="0.16"/>
+    <rect x="630" y="322" width="384" height="70" rx="22" fill="#020617" fill-opacity="0.5" stroke="#94A3B8" stroke-opacity="0.16"/>
+    <rect x="630" y="419" width="384" height="70" rx="22" fill="#020617" fill-opacity="0.5" stroke="#94A3B8" stroke-opacity="0.16"/>
+    <rect x="204" y="254" width="122" height="28" rx="14" fill="#22D3EE" fill-opacity="0.22" stroke="#22D3EE" stroke-opacity="0.4"/>
+    <text x="222" y="273" fill="#E0F2FE" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="700" letter-spacing="2">CASO</text>
+    <text x="204" y="345" fill="#F8FAFC" font-family="Inter, Arial, sans-serif" font-size="52" font-weight="800">VetCare</text>
+    <text x="204" y="397" fill="#CBD5E1" font-family="Inter, Arial, sans-serif" font-size="25" font-weight="600">Demo veterinaria</text>
+    <text x="204" y="456" fill="#94A3B8" font-family="Inter, Arial, sans-serif" font-size="18">Agenda · Urgencias</text>
+    <circle cx="666" cy="260" r="12" fill="#22D3EE"/>
+    <rect x="694" y="246" width="230" height="14" rx="7" fill="#CBD5E1" fill-opacity="0.85"/>
+    <rect x="694" y="269" width="160" height="10" rx="5" fill="#94A3B8" fill-opacity="0.45"/>
+    <circle cx="666" cy="357" r="12" fill="#34D399"/>
+    <rect x="694" y="343" width="252" height="14" rx="7" fill="#CBD5E1" fill-opacity="0.8"/>
+    <rect x="694" y="366" width="188" height="10" rx="5" fill="#94A3B8" fill-opacity="0.45"/>
+    <circle cx="666" cy="454" r="12" fill="#34D399"/>
+    <rect x="694" y="440" width="210" height="14" rx="7" fill="#CBD5E1" fill-opacity="0.75"/>
+    <rect x="694" y="463" width="134" height="10" rx="5" fill="#94A3B8" fill-opacity="0.45"/>
+    <rect x="174" y="548" width="840" height="44" rx="22" fill="#22D3EE" fill-opacity="0.15" stroke="#22D3EE" stroke-opacity="0.25"/>
+    <text x="204" y="577" fill="#E0F2FE" font-family="Inter, Arial, sans-serif" font-size="17" font-weight="700">Miniatura local · /galeria/vetcare.svg</text>
+  </g>
+</svg>

--- a/src/components/FeaturedCases.astro
+++ b/src/components/FeaturedCases.astro
@@ -25,6 +25,7 @@ const { projects = [] } = Astro.props;
           stack={p.data.stack}
           slug={p.slug}
           cover={p.data.cover}
+          thumbnail={p.data.thumbnail}
           resultado={p.data.resultado}
           problema={p.data.problema}
           solucion={p.data.solucion}

--- a/src/components/ProjectCard.astro
+++ b/src/components/ProjectCard.astro
@@ -1,5 +1,6 @@
 ---
 import Badge from './Badge.astro';
+import { projectCoverImage } from '../lib/projectGallery';
 
 const FEATURE_LIMIT = 4;
 const {
@@ -8,6 +9,7 @@ const {
   stack = [],
   slug,
   cover = '/og-default.png',
+  thumbnail = '',
   resultado = '',
   problema = '',
   solucion = '',
@@ -35,7 +37,8 @@ const statusTone = {
 const chips = Array.isArray(features) && features.length > 0 ? features : stack;
 const commercialType = tipo || sector || 'Caso comercial';
 const benefit = impacto || resultado;
-const hasGenericCover = !cover || cover === '/og-default.png';
+const displayCover = projectCoverImage({ slug, thumbnail, cover });
+const hasGenericCover = !displayCover || displayCover === '/og-default.png';
 const isStarProject = Number(priority) >= 120;
 ---
 <a
@@ -66,7 +69,7 @@ const isStarProject = Number(priority) >= 120;
       </div>
     ) : (
       <img
-        src={cover}
+        src={displayCover}
         alt={`Portada de ${title}`}
         class="aspect-[16/10] w-full object-cover opacity-90 transition duration-500 group-hover:scale-[1.03] group-hover:opacity-100"
         loading="lazy"

--- a/src/components/ProjectLinkPreview.astro
+++ b/src/components/ProjectLinkPreview.astro
@@ -1,14 +1,18 @@
 ---
+import { projectCoverImage } from '../lib/projectGallery';
+
 const {
   title,
   url = '',
   cover = '/og-default.png',
+  thumbnail = '',
   slug = '',
   eager = false,
 } = Astro.props;
 
+const displayCover = projectCoverImage({ slug, thumbnail, cover });
 const hasPreviewUrl = typeof url === 'string' && url.length > 0;
-const hasCustomCover = cover && cover !== '/og-default.png';
+const hasCustomCover = displayCover && displayCover !== '/og-default.png';
 const previewHost = hasPreviewUrl ? new URL(url).host.replace(/^www\./, '') : `marin.dev/caso/${slug}`;
 ---
 <div class="relative">
@@ -43,7 +47,7 @@ const previewHost = hasPreviewUrl ? new URL(url).host.replace(/^www\./, '') : `m
           </a>
         </>
       ) : hasCustomCover ? (
-        <img src={cover} alt={`Mockup o portada de ${title}`} class="h-full w-full object-cover" loading={eager ? 'eager' : 'lazy'} decoding="async" />
+        <img src={displayCover} alt={`Mockup o portada de ${title}`} class="h-full w-full object-cover" loading={eager ? 'eager' : 'lazy'} decoding="async" />
       ) : (
         <div class="relative flex h-full flex-col justify-between overflow-hidden p-5">
           <div class="absolute inset-0 bg-premium-grid bg-[length:2rem_2rem] opacity-45"></div>

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -15,6 +15,7 @@ const proyectos = defineCollection({
     repoUrl: z.string().url().optional(),
     demoUrl: z.string().url().optional(),
     cover: z.string().optional(),
+    thumbnail: z.string().optional(),
     tipo: z.string().optional(),
     idealPara: z.string().optional(),
     features: z.array(z.string()).optional(),

--- a/src/content/proyectos/Agencia_ariel.mdx
+++ b/src/content/proyectos/Agencia_ariel.mdx
@@ -38,6 +38,7 @@ El_desarrollo_priorizo: >
 repoUrl: "https://github.com/Daegon13/Agencia_ariel"
 demoUrl: "https://Agencia-ariel.com"
 cover: "https://daegon13.github.io/Agencia_ariel/img/cover.png"
+thumbnail: "/galeria/agencia_ariel.svg"
 ---
 
 ### Decisiones clave

--- a/src/content/proyectos/brasa-23.mdx
+++ b/src/content/proyectos/brasa-23.mdx
@@ -29,6 +29,7 @@ impacto: >
   Ejemplo claro para gastronomía: una web liviana puede funcionar como carta digital, pieza comercial y enlace principal para redes.
 demoUrl: "https://daegon13.github.io/Brasa-23/"
 cover: "/og-default.png"
+thumbnail: "/galeria/brasa-23.svg"
 ---
 
 ### Enfoque del caso

--- a/src/content/proyectos/cristal-sagrado.mdx
+++ b/src/content/proyectos/cristal-sagrado.mdx
@@ -26,6 +26,7 @@ impacto: "Caso real con marca definida, estética cuidada y una estructura pensa
 repoUrl: "https://github.com/Daegon13/cristal-sagrado-site"
 demoUrl: "https://cristal-sagrado.com"
 cover: "https://cristal-sagrado.com/favicon_io/cristal_sagrado.png"
+thumbnail: "/galeria/cristal-sagrado.svg"
 ---
 
 ### Decisiones clave

--- a/src/content/proyectos/noir-barber-studio.mdx
+++ b/src/content/proyectos/noir-barber-studio.mdx
@@ -29,6 +29,7 @@ impacto: >
   Demo útil para negocios locales: transforma una marca visual en una página compartible, con servicios claros y reservas sin fricción.
 demoUrl: "https://barber-demo-puce.vercel.app/"
 cover: "/og-default.png"
+thumbnail: "/galeria/noir-barber-studio.svg"
 ---
 
 ### Enfoque del caso

--- a/src/content/proyectos/servicio-de-tarot.mdx
+++ b/src/content/proyectos/servicio-de-tarot.mdx
@@ -25,6 +25,7 @@ impacto: "Muestra cómo un servicio personal puede ordenar su propuesta y llevar
 repoUrl: "https://github.com/Daegon13/Servicio-de-Tarot"
 demoUrl: "https://daegon13.github.io/Servicio-de-Tarot/"
 cover: "https://daegon13.github.io/Servicio-de-Tarot/images/cover.png"
+thumbnail: "/galeria/servicio-de-tarot.svg"
 ---
 
 ### Decisiones clave

--- a/src/content/proyectos/smart-stock.mdx
+++ b/src/content/proyectos/smart-stock.mdx
@@ -31,6 +31,7 @@ impacto: >
 demoUrl: "https://smart-stock-showcase.vercel.app/"
 repoUrl: "https://github.com/Daegon13/smart-stock"
 cover: "/og-default.png"
+thumbnail: "/galeria/smart-stock.svg"
 ---
 
 ### Nota sobre estado comercial

--- a/src/content/proyectos/vetcare.mdx
+++ b/src/content/proyectos/vetcare.mdx
@@ -29,6 +29,7 @@ impacto: >
   Demo lista para mostrar una experiencia más completa que una web informativa: servicios claros, prioridades ordenadas y contacto fácil desde mobile.
 demoUrl: "https://vetcare-uy.vercel.app/"
 cover: "/og-default.png"
+thumbnail: "/galeria/vetcare.svg"
 ---
 
 ### Enfoque del caso

--- a/src/lib/projectGallery.ts
+++ b/src/lib/projectGallery.ts
@@ -1,0 +1,21 @@
+export const PROJECT_GALLERY_PATH = '/galeria';
+export const DEFAULT_PROJECT_IMAGE = '/og-default.png';
+
+export function projectThumbnailPath(slug: string) {
+  return `${PROJECT_GALLERY_PATH}/${slug}.svg`;
+}
+
+export function projectCoverImage({
+  slug,
+  thumbnail,
+  cover,
+}: {
+  slug?: string;
+  thumbnail?: string;
+  cover?: string;
+}) {
+  if (thumbnail) return thumbnail;
+  if (cover && cover !== DEFAULT_PROJECT_IMAGE) return cover;
+  if (slug) return projectThumbnailPath(slug);
+  return DEFAULT_PROJECT_IMAGE;
+}

--- a/src/pages/proyectos/[slug].astro
+++ b/src/pages/proyectos/[slug].astro
@@ -29,12 +29,15 @@ const {
   repoUrl,
   demoUrl,
   cover = '/og-default.png',
+  thumbnail = '',
   tipo,
   idealPara,
   features = [],
   impacto,
   status,
 } = proyecto.data;
+
+const previewImage = thumbnail || cover;
 
 const { Content } = await proyecto.render();
 const statusLabels = {
@@ -49,7 +52,7 @@ const statusTone = {
 };
 const whatsappText = `Hola Diego, quiero algo parecido a ${title}.\n\nRubro: [rubro]\nObjetivo: [más consultas / reservas / ventas]\nHoy tengo: [Instagram / web / nada]\nMe interesa: [web / demo / agenda / zona editable / no sé todavía]`;
 ---
-<BaseLayout title={`${title} | Caso Marin.dev`} description={resumen} image={cover} url={`/proyectos/${proyecto.slug}`}>
+<BaseLayout title={`${title} | Caso Marin.dev`} description={resumen} image={previewImage} url={`/proyectos/${proyecto.slug}`}>
   <Container class="py-12 sm:py-16">
     <article>
       <header class="grid gap-8 lg:grid-cols-[minmax(0,1fr)_28rem] lg:items-center">
@@ -96,7 +99,7 @@ const whatsappText = `Hola Diego, quiero algo parecido a ${title}.\n\nRubro: [ru
           </div>
         </div>
 
-        <ProjectLinkPreview title={title} url={demoUrl} cover={cover} slug={proyecto.slug} eager />
+        <ProjectLinkPreview title={title} url={demoUrl} cover={cover} thumbnail={thumbnail} slug={proyecto.slug} eager />
       </header>
 
       <section class="mt-12 grid gap-5 lg:grid-cols-3">

--- a/src/pages/proyectos/index.astro
+++ b/src/pages/proyectos/index.astro
@@ -43,6 +43,7 @@ const proyectos = (await getCollection('proyectos')).sort(byCommercialPriority);
           stack={p.data.stack}
           slug={p.slug}
           cover={p.data.cover}
+          thumbnail={p.data.thumbnail}
           resultado={p.data.resultado}
           problema={p.data.problema}
           solucion={p.data.solucion}


### PR DESCRIPTION
### Motivation

- Provide a local gallery of consistent, premium-looking thumbnails for portfolio projects so cards and previews render reliably without depending on external images.  
- Let each MDX project document reference a local thumbnail by slug to simplify authoring and prioritize local assets over remote `cover` images.  

### Description

- Added a public gallery folder with generated SVG thumbnails and guidance: `public/galeria/` plus `public/galeria/README.md`.  
- Introduced a small helper API `src/lib/projectGallery.ts` that resolves the image to use with priority `thumbnail` → `cover` → `/galeria/<slug>.svg` → `/og-default.png`.  
- Extended the content schema in `src/content/config.ts` with an optional `thumbnail` field and updated existing MDX files to include `thumbnail: "/galeria/<slug>.svg"`.  
- Updated UI to prefer thumbnails: `src/components/ProjectCard.astro` and `src/components/ProjectLinkPreview.astro` now use the helper and accept a `thumbnail` prop, and list/detail pages (`src/pages/proyectos/index.astro`, `src/components/FeaturedCases.astro`, `src/pages/proyectos/[slug].astro`) pass `thumbnail` through to the components.  

### Testing

- Built the site with `npm run build` and the static site generation completed successfully.  
- Attempted an automated visual capture using Playwright but the environment failed to install Playwright due to an external npm registry `403 Forbidden`, so screenshot capture could not run in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ffb17c064883288bdb3f99a4414fa5)