### PR TITLE
Redesign Sobre mí into V2 professional manifesto

### DIFF
--- a/src/pages/sobre-mi.astro
+++ b/src/pages/sobre-mi.astro
@@ -1,25 +1,238 @@
 ---
 import BaseLayout from '../layouts/BaseLayout.astro';
+import Container from '../components/Container.astro';
+import GlowCard from '../components/GlowCard.astro';
+import ContactCTA from '../components/ContactCTA.astro';
+import { DEMO_WHATSAPP_MESSAGE, waLink } from '../lib/contact';
+
+const principles = [
+  {
+    title: 'Primero el objetivo comercial',
+    description:
+      'Antes de hablar de secciones o efectos, defino qué acción tiene que lograr la web: consulta, reserva, venta, validación o confianza.',
+  },
+  {
+    title: 'Claridad antes que decoración',
+    description:
+      'Una interfaz puede verse premium sin volverse confusa. Ordeno mensajes, CTAs y jerarquía para que el usuario entienda rápido qué hacer.',
+  },
+  {
+    title: 'Demos que se pueden mostrar',
+    description:
+      'Me interesa construir versiones concretas: una landing compartible, un flujo por WhatsApp, una agenda simulada o un panel simple que ayude a vender la idea.',
+  },
+];
+
+const problems = [
+  'Negocios que tienen Instagram activo, pero ninguna web clara para convertir visitas en consultas.',
+  'Servicios que necesitan explicar valor, precios, pasos o reservas sin depender de mensajes repetidos.',
+  'Ideas que todavía no necesitan una app enorme, pero sí una demo seria para validar, presentar o vender.',
+  'Equipos chicos que necesitan ordenar contenido, leads o procesos con herramientas simples y mantenibles.',
+];
+
+const workflow = [
+  {
+    step: '01',
+    title: 'Diagnóstico y alcance',
+    description:
+      'Reviso el negocio, la web o Instagram actual, el objetivo principal y qué fricción está frenando consultas o reservas.',
+  },
+  {
+    step: '02',
+    title: 'Propuesta y estructura',
+    description:
+      'Defino qué conviene construir primero: demo comercial, landing, agenda, panel básico o una combinación simple.',
+  },
+  {
+    step: '03',
+    title: 'Construcción por hitos',
+    description:
+      'Trabajo con entregas revisables, repo ordenado, deploy activo y comunicación clara para evitar sorpresas al final.',
+  },
+  {
+    step: '04',
+    title: 'Lanzamiento y siguiente mejora',
+    description:
+      'Dejo la web lista para compartir y revisamos qué ajustar después: copy, CTAs, servicios, formularios o nuevas funciones.',
+  },
+];
+
+const stack = [
+  'Astro',
+  'Tailwind CSS',
+  'JavaScript / TypeScript',
+  'React cuando aporta valor',
+  'MDX y contenido editable',
+  'APIs / Firebase según necesidad',
+  'GitHub Pages, Vercel o Netlify',
+  'SEO técnico básico y performance',
+];
 ---
-<BaseLayout title="Sobre mí" description="Quién soy y cómo trabajo.">
-  <section class="py-12">
-    <h1 class="text-2xl font-bold mb-6">Sobre mí</h1>
-    <div class="prose prose-slate max-w-none">
-      <p>Soy desarrollador web freelance. Me enfoco en construir sitios rápidos, claros y fáciles de mantener. Trabajo por objetivos, con entregas puntuales y comunicación transparente.</p>
-      <h2>Cómo trabajo</h2>
-      <ol>
-        <li>Descubrimiento y alcance</li>
-        <li>Wireframes y propuesta</li>
-        <li>Desarrollo iterativo</li>
-        <li>Lanzamiento + métricas</li>
-      </ol>
-      <h2>Stack</h2>
-      <ul>
-        <li>Frontend: HTML, CSS, JS, Tailwind, React</li>
-        <li>Contenido: Astro, MD/MDX</li>
-        <li>Conexiones: Firebase, APIs</li>
-        <li>Publicación: GitHub Pages, Netlify, Vercel</li>
-      </ul>
-    </div>
+<BaseLayout
+  title="Sobre mí | Marin.dev"
+  description="Conocé cómo Diego Marin piensa y construye webs, demos comerciales y sistemas simples con foco en conversión, claridad y entrega real."
+>
+  <section class="relative overflow-hidden py-16 md:py-24">
+    <div class="pointer-events-none absolute left-1/2 top-10 h-64 w-64 -translate-x-1/2 rounded-full bg-cyan-electric/15 blur-3xl" aria-hidden="true"></div>
+    <Container class="relative px-0">
+      <div class="grid items-center gap-10 lg:grid-cols-[1.08fr_0.92fr]">
+        <div class="max-w-3xl">
+          <p class="inline-flex w-fit items-center rounded-full border border-line bg-surface-glass px-3 py-1 text-xs font-semibold uppercase tracking-[0.22em] text-cyan-electric">
+            Diego Marin · Marin.dev
+          </p>
+          <h1 class="mt-6 text-4xl font-semibold tracking-tight text-slate-50 sm:text-5xl lg:text-6xl">
+            No construyo solo páginas: diseño demos y sistemas simples para vender con más claridad.
+          </h1>
+          <p class="mt-6 max-w-2xl text-base leading-8 text-muted-soft sm:text-lg">
+            Trabajo en webs, landings, demos comerciales y herramientas livianas para negocios que necesitan convertir visitas en consultas, reservas o ventas. Mi foco está en ordenar el mensaje, reducir fricción y entregar algo real, compartible y mantenible.
+          </p>
+          <div class="mt-8 flex flex-col gap-3 sm:flex-row">
+            <a
+              href={waLink(DEMO_WHATSAPP_MESSAGE)}
+              target="_blank"
+              rel="noopener noreferrer"
+              class="inline-flex items-center justify-center rounded-2xl bg-brand-gradient px-6 py-3 text-sm font-semibold text-white shadow-glow transition hover:-translate-y-0.5 hover:shadow-premium-hover"
+            >
+              Quiero una demo para mi negocio
+            </a>
+            <a
+              href="/proyectos"
+              class="inline-flex items-center justify-center rounded-2xl border border-line bg-surface-glass px-6 py-3 text-sm font-semibold text-slate-50 transition hover:-translate-y-0.5 hover:border-line-strong hover:text-cyan-electric"
+            >
+              Ver casos y demos
+            </a>
+          </div>
+        </div>
+
+        <GlowCard class="p-6 md:p-7">
+          <div class="flex items-center justify-between gap-4 border-b border-line pb-5">
+            <div>
+              <p class="text-sm font-semibold text-slate-50">Forma de trabajo</p>
+              <p class="mt-1 text-sm text-muted">Producto, conversión y entrega</p>
+            </div>
+            <span class="rounded-full border border-brand-success/25 bg-brand-success/10 px-3 py-1 text-xs font-semibold text-brand-success">
+              Deploy activo
+            </span>
+          </div>
+          <div class="mt-6 space-y-4">
+            <div class="rounded-2xl border border-line bg-ink/40 p-4">
+              <p class="text-xs uppercase tracking-[0.2em] text-muted">Entrada</p>
+              <p class="mt-2 text-sm font-medium text-slate-100">Instagram, web actual, idea o problema operativo</p>
+            </div>
+            <div class="grid gap-3 sm:grid-cols-2">
+              <div class="rounded-2xl border border-line bg-surface-glass p-4">
+                <p class="text-2xl font-semibold text-cyan-electric">CTA</p>
+                <p class="mt-1 text-sm text-muted-soft">Consulta guiada por WhatsApp</p>
+              </div>
+              <div class="rounded-2xl border border-line bg-surface-glass p-4">
+                <p class="text-2xl font-semibold text-brand-violet">Demo</p>
+                <p class="mt-1 text-sm text-muted-soft">Versión concreta para mostrar</p>
+              </div>
+            </div>
+            <div class="rounded-2xl border border-line bg-gradient-to-r from-cyan-electric/10 via-blue-electric/10 to-violet-electric/10 p-4">
+              <p class="text-sm font-semibold text-slate-50">Salida esperada</p>
+              <p class="mt-1 text-sm leading-6 text-muted-soft">Una experiencia clara, rápida y lista para compartir sin inflar el alcance ni esconder el proceso.</p>
+            </div>
+          </div>
+        </GlowCard>
+      </div>
+    </Container>
   </section>
+
+  <section class="py-12 md:py-16">
+    <Container class="px-0">
+      <div class="grid gap-4 md:grid-cols-3">
+        {principles.map((principle) => (
+          <GlowCard>
+            <h2 class="text-xl font-semibold text-slate-50">{principle.title}</h2>
+            <p class="mt-3 text-sm leading-7 text-muted-soft">{principle.description}</p>
+          </GlowCard>
+        ))}
+      </div>
+    </Container>
+  </section>
+
+  <section class="py-12 md:py-16">
+    <Container class="px-0">
+      <div class="grid gap-8 lg:grid-cols-[0.8fr_1.2fr]">
+        <div>
+          <p class="text-sm font-semibold uppercase tracking-[0.22em] text-cyan-electric">Cómo pienso los proyectos</p>
+          <h2 class="mt-4 text-3xl font-semibold tracking-tight text-slate-50 md:text-4xl">
+            Una buena web no empieza en el diseño: empieza en la decisión que querés facilitar.
+          </h2>
+          <p class="mt-4 text-base leading-7 text-muted-soft">
+            Por eso trabajo con preguntas simples: qué vendés, quién necesita confiar en vos, qué objeción aparece antes de consultar y cuál es el próximo paso más fácil para el usuario.
+          </p>
+        </div>
+        <div class="grid gap-4 sm:grid-cols-2">
+          {problems.map((problem) => (
+            <div class="rounded-3xl border border-line bg-surface-glass p-5 text-sm leading-7 text-muted-soft shadow-soft">
+              {problem}
+            </div>
+          ))}
+        </div>
+      </div>
+    </Container>
+  </section>
+
+  <section class="py-12 md:py-16">
+    <Container class="px-0">
+      <div class="mb-8 max-w-3xl">
+        <p class="text-sm font-semibold uppercase tracking-[0.22em] text-cyan-electric">Forma de trabajo</p>
+        <h2 class="mt-4 text-3xl font-semibold tracking-tight text-slate-50 md:text-4xl">
+          Hitos claros, repo ordenado, deploy visible y comunicación directa.
+        </h2>
+      </div>
+      <div class="grid gap-4 md:grid-cols-2">
+        {workflow.map((item) => (
+          <GlowCard class="p-6">
+            <div class="flex gap-4">
+              <span class="flex h-11 w-11 shrink-0 items-center justify-center rounded-2xl border border-cyan-electric/25 bg-cyan-electric/10 text-sm font-semibold text-cyan-electric">
+                {item.step}
+              </span>
+              <div>
+                <h3 class="text-lg font-semibold text-slate-50">{item.title}</h3>
+                <p class="mt-2 text-sm leading-7 text-muted-soft">{item.description}</p>
+              </div>
+            </div>
+          </GlowCard>
+        ))}
+      </div>
+    </Container>
+  </section>
+
+  <section class="py-12 md:py-16">
+    <Container class="px-0">
+      <div class="grid gap-8 lg:grid-cols-[0.85fr_1.15fr]">
+        <div>
+          <p class="text-sm font-semibold uppercase tracking-[0.22em] text-cyan-electric">Stack técnico</p>
+          <h2 class="mt-4 text-3xl font-semibold tracking-tight text-slate-50 md:text-4xl">
+            La tecnología acompaña al objetivo, no al revés.
+          </h2>
+          <p class="mt-4 text-base leading-7 text-muted-soft">
+            Uso herramientas rápidas y mantenibles para construir experiencias estáticas, livianas y fáciles de publicar. Si una dependencia no suma al negocio o al mantenimiento, prefiero no agregarla.
+          </p>
+        </div>
+        <GlowCard class="p-6">
+          <div class="flex flex-wrap gap-3">
+            {stack.map((item) => (
+              <span class="rounded-full border border-line bg-ink/40 px-4 py-2 text-sm font-medium text-muted-soft">
+                {item}
+              </span>
+            ))}
+          </div>
+        </GlowCard>
+      </div>
+    </Container>
+  </section>
+
+  <ContactCTA
+    eyebrow="Hablemos de tu caso"
+    title="Mandame tu negocio, web o Instagram y vemos qué demo tendría más sentido."
+    description="Te puedo responder con una dirección concreta: qué mostrar primero, qué CTA usar y qué versión simple conviene construir para validar o empezar a recibir consultas."
+    primaryLabel="Mandame mi web o Instagram"
+    primaryMessage={DEMO_WHATSAPP_MESSAGE}
+    secondaryLabel="Ver servicios"
+    secondaryHref="/servicios"
+  />
 </BaseLayout>


### PR DESCRIPTION
### Motivation
- Convert the existing simple bio page into a commercial-facing manifesto that positions Marin.dev as a creator of demos, landing pages and simple systems focused on conversion and delivery.
- Give visitors quick trust signals and a clear next step (WhatsApp demo CTA) while keeping the site’s V2 dark/premium aesthetic and static build behavior.

### Description
- Rewrote `src/pages/sobre-mi.astro` to a V2 manifesto layout and content, adding a hero, principles, problem statements, workflow steps, stack summary and a final `ContactCTA` pointing to WhatsApp.
- Added imports and usage of existing components: `Container`, `GlowCard`, and `ContactCTA`, and wired WhatsApp helpers from `src/lib/contact.ts` (`DEMO_WHATSAPP_MESSAGE`, `waLink`).
- Introduced inline data arrays (`principles`, `problems`, `workflow`, `stack`) to drive the new sections and keep markup compact and reusable.
- Kept all changes limited to the About page and preserved build, routes and site behavior (no new dependencies, no layout or routing changes). 

### Testing
- Ran `npm run build` and the static site build completed successfully. 
- Ran project formatting with `npm run format` which completed; running `npx prettier --write src/pages/sobre-mi.astro` directly produced a parser inference warning but this did not block the build. 
- Ran `git diff --check` to validate whitespace/patch errors and it passed. 
- Attempted to install Playwright for automated screenshots but the environment returned an `npm` registry `403 Forbidden`, so screenshot tooling was not prepared (this did not affect the build).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ffbc9255508328b605c4a6d6576181)