### PR TITLE
Redesign contact page for guided WhatsApp leads

### DIFF
--- a/src/pages/contacto.astro
+++ b/src/pages/contacto.astro
@@ -1,122 +1,223 @@
 ---
-/* Página de Contacto (sin backend)
-   - Arma un mensaje comercial para WhatsApp
+/* Página de Contacto V2 (sin backend)
+   - Guía la consulta para abrir una conversación útil por WhatsApp
    - Validación mínima con atributos HTML
    - No depende de librerías
 */
 import BaseLayout from "../layouts/BaseLayout.astro";
 import Container from "../components/Container.astro";
+import GlowCard from "../components/GlowCard.astro";
 import {
   AUDIT_WHATSAPP_MESSAGE,
   EMAIL,
+  GITHUB_URL,
   INSTAGRAM_HANDLE,
   INSTAGRAM_URL,
+  LINKEDIN_URL,
   WHATSAPP_BASE_URL,
   WHATSAPP_NUMBER_E164,
   waLink,
 } from "../lib/contact";
 
 const title = "Contacto – Marin.dev";
-const description = "Mandame tu web o Instagram y te digo qué demo, landing o sistema simple puede ayudarte a recibir más consultas.";
+const description =
+  "Contame qué querés mejorar y te digo el mejor camino: demo, landing, agenda, panel o sistema simple para convertir mejor.";
 const url = "https://daegon13.github.io/contacto";
 const image = "/og-default.png";
+
+const objetivos = [
+  "Más consultas",
+  "Reservas",
+  "Ventas",
+  "Sistema interno",
+  "Otro",
+];
+
+const intereses = [
+  "Demo comercial",
+  "Landing de conversión",
+  "Agenda o reservas",
+  "Panel simple",
+  "No sé todavía",
+];
+
+const budgetRanges = [
+  "Todavía no lo sé",
+  "Menos de USD 300",
+  "USD 300 - 600",
+  "USD 600 - 1000",
+  "Más de USD 1000",
+];
+
+const contactCards = [
+  {
+    label: "WhatsApp directo",
+    value: "Responder con contexto guiado",
+    href: waLink(AUDIT_WHATSAPP_MESSAGE),
+  },
+  {
+    label: "Instagram",
+    value: INSTAGRAM_HANDLE,
+    href: INSTAGRAM_URL,
+  },
+  {
+    label: "Email",
+    value: EMAIL,
+    href: `mailto:${EMAIL}`,
+  },
+  {
+    label: "GitHub",
+    value: "Ver proyectos y repos",
+    href: GITHUB_URL,
+  },
+  {
+    label: "LinkedIn",
+    value: "Perfil profesional",
+    href: LINKEDIN_URL,
+  },
+];
 ---
 <BaseLayout {title} {description} {url} {image}>
-  <Container class="py-12 md:py-16">
-    <section class="grid gap-8 lg:grid-cols-[0.85fr_1.15fr] lg:items-start">
-      <div class="rounded-[2rem] border border-line bg-surface-glass p-6 shadow-premium backdrop-blur md:p-8">
-        <p class="text-sm font-semibold uppercase tracking-[0.22em] text-cyan-electric">Contacto directo</p>
-        <h1 class="mt-4 text-3xl font-semibold tracking-tight text-slate-50 md:text-5xl">Mandame mi web o Instagram</h1>
-        <p class="mt-4 text-base leading-7 text-muted-soft">
-          Contame tu rubro, qué querés mejorar y qué tenés hoy. Te respondo con un camino concreto: landing, demo, agenda, panel o una opción más simple si alcanza.
-        </p>
+  <Container class="py-12 md:py-16 lg:py-20">
+    <section class="relative overflow-hidden rounded-[2.25rem] border border-line bg-surface-glass p-5 shadow-premium backdrop-blur md:p-8 lg:p-10">
+      <div class="pointer-events-none absolute -left-20 top-8 h-64 w-64 rounded-full bg-cyan-electric/15 blur-3xl"></div>
+      <div class="pointer-events-none absolute -right-24 bottom-6 h-72 w-72 rounded-full bg-violet-electric/15 blur-3xl"></div>
 
-        <div class="mt-6 space-y-3 text-sm text-muted-soft">
-          <a class="block rounded-2xl border border-line bg-white/5 px-4 py-3 transition hover:border-cyan-electric/40 hover:text-cyan-100" href={waLink(AUDIT_WHATSAPP_MESSAGE)} target="_blank" rel="noopener noreferrer">
-            Revisar mi web o Instagram por WhatsApp
-          </a>
-          <a class="block rounded-2xl border border-line bg-white/5 px-4 py-3 transition hover:border-cyan-electric/40 hover:text-cyan-100" href={INSTAGRAM_URL} target="_blank" rel="noopener noreferrer">
-            Instagram: {INSTAGRAM_HANDLE}
-          </a>
-          <a class="block rounded-2xl border border-line bg-white/5 px-4 py-3 transition hover:border-cyan-electric/40 hover:text-cyan-100" href={`mailto:${EMAIL}`}>
-            Email: {EMAIL}
-          </a>
-        </div>
-      </div>
-
-      <form id="contacto" class="rounded-[2rem] border border-line bg-surface/80 p-6 shadow-premium backdrop-blur md:p-8">
-        <div class="grid gap-4 md:grid-cols-2">
+      <div class="relative grid gap-8 lg:grid-cols-[0.88fr_1.12fr] lg:items-start">
+        <aside class="space-y-6">
           <div>
-            <label for="nombre" class="block text-sm font-medium text-slate-100">Nombre</label>
-            <input id="nombre" name="nombre" type="text" required class="mt-2 w-full rounded-2xl border border-line bg-ink/50 px-4 py-3 text-slate-50 outline-none transition placeholder:text-muted focus:border-cyan-electric/60 focus:ring-2 focus:ring-cyan-electric/20" placeholder="Tu nombre" />
+            <p class="inline-flex rounded-full border border-cyan-electric/30 bg-cyan-electric/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.22em] text-cyan-100">
+              Contacto guiado
+            </p>
+            <h1 class="mt-5 text-3xl font-semibold tracking-tight text-slate-50 sm:text-4xl lg:text-5xl">
+              Contame qué querés mejorar y te digo el mejor camino
+            </h1>
+            <p class="mt-5 text-base leading-7 text-muted-soft sm:text-lg">
+              No necesitás tener todo definido. Con tu Instagram, web actual o una idea alcanza para empezar y detectar si conviene una demo, landing, agenda, panel o algo más simple.
+            </p>
           </div>
 
-          <div>
-            <label for="rubro" class="block text-sm font-medium text-slate-100">Rubro</label>
-            <input id="rubro" name="rubro" type="text" required class="mt-2 w-full rounded-2xl border border-line bg-ink/50 px-4 py-3 text-slate-50 outline-none transition placeholder:text-muted focus:border-cyan-electric/60 focus:ring-2 focus:ring-cyan-electric/20" placeholder="Barbería, gimnasio, tienda..." />
-          </div>
-        </div>
-
-        <div class="mt-4 grid gap-4 md:grid-cols-2">
-          <div>
-            <label for="objetivo" class="block text-sm font-medium text-slate-100">Objetivo</label>
-            <select id="objetivo" name="objetivo" required class="mt-2 w-full rounded-2xl border border-line bg-ink/50 px-4 py-3 text-slate-50 outline-none transition focus:border-cyan-electric/60 focus:ring-2 focus:ring-cyan-electric/20">
-              <option value="más consultas">Más consultas</option>
-              <option value="reservas">Reservas</option>
-              <option value="ventas">Ventas</option>
-              <option value="ordenar procesos">Ordenar procesos</option>
-            </select>
+          <div class="grid gap-3 sm:grid-cols-3 lg:grid-cols-1">
+            <div class="rounded-2xl border border-line bg-ink/45 p-4">
+              <p class="text-sm font-semibold text-slate-50">1. Me pasás contexto</p>
+              <p class="mt-1 text-sm leading-6 text-muted-soft">Rubro, link actual y objetivo principal.</p>
+            </div>
+            <div class="rounded-2xl border border-line bg-ink/45 p-4">
+              <p class="text-sm font-semibold text-slate-50">2. Ordeno la oportunidad</p>
+              <p class="mt-1 text-sm leading-6 text-muted-soft">Te digo si conviene demo, landing o sistema simple.</p>
+            </div>
+            <div class="rounded-2xl border border-line bg-ink/45 p-4">
+              <p class="text-sm font-semibold text-slate-50">3. Hablamos por WhatsApp</p>
+              <p class="mt-1 text-sm leading-6 text-muted-soft">Sin formulario frío ni datos sensibles.</p>
+            </div>
           </div>
 
-          <div>
-            <label for="hoy_tengo" class="block text-sm font-medium text-slate-100">Hoy tengo</label>
-            <select id="hoy_tengo" name="hoy_tengo" required class="mt-2 w-full rounded-2xl border border-line bg-ink/50 px-4 py-3 text-slate-50 outline-none transition focus:border-cyan-electric/60 focus:ring-2 focus:ring-cyan-electric/20">
-              <option value="Instagram">Instagram</option>
-              <option value="web">Web</option>
-              <option value="nada">Nada todavía</option>
-              <option value="idea">Una idea para validar</option>
-            </select>
+          <GlowCard class="p-5">
+            <p class="text-sm font-semibold text-slate-50">Canales directos</p>
+            <div class="mt-4 space-y-3">
+              {contactCards.map((card) => (
+                <a class="group/contact flex items-center justify-between gap-4 rounded-2xl border border-line bg-white/[0.04] px-4 py-3 text-sm transition hover:-translate-y-0.5 hover:border-cyan-electric/40 hover:bg-cyan-electric/10" href={card.href} target={card.href.startsWith("http") ? "_blank" : undefined} rel={card.href.startsWith("http") ? "noopener noreferrer" : undefined}>
+                  <span>
+                    <span class="block font-medium text-slate-100">{card.label}</span>
+                    <span class="mt-0.5 block text-muted-soft">{card.value}</span>
+                  </span>
+                  <span class="text-cyan-100 transition group-hover/contact:translate-x-1" aria-hidden="true">→</span>
+                </a>
+              ))}
+            </div>
+          </GlowCard>
+        </aside>
+
+        <form id="contacto" class="rounded-[2rem] border border-line bg-ink/70 p-5 shadow-premium backdrop-blur md:p-7" aria-describedby="contacto-ayuda">
+          <div class="flex flex-col gap-3 border-b border-line pb-5 sm:flex-row sm:items-start sm:justify-between">
+            <div>
+              <p class="text-sm font-semibold uppercase tracking-[0.18em] text-cyan-electric">Armá el mensaje</p>
+              <h2 class="mt-2 text-2xl font-semibold tracking-tight text-slate-50">Te abre WhatsApp con todo ordenado</h2>
+            </div>
+            <span class="w-fit rounded-full border border-emerald-300/20 bg-emerald-300/10 px-3 py-1 text-xs font-semibold text-emerald-200">
+              Sin backend
+            </span>
           </div>
-        </div>
 
-        <div class="mt-4 grid gap-4 md:grid-cols-2">
-          <div>
-            <label for="interes" class="block text-sm font-medium text-slate-100">Me interesa</label>
-            <select id="interes" name="interes" required class="mt-2 w-full rounded-2xl border border-line bg-ink/50 px-4 py-3 text-slate-50 outline-none transition focus:border-cyan-electric/60 focus:ring-2 focus:ring-cyan-electric/20">
-              <option value="landing">Landing</option>
-              <option value="demo">Demo</option>
-              <option value="agenda">Agenda</option>
-              <option value="panel">Panel</option>
-              <option value="no sé todavía">No sé todavía</option>
-            </select>
-          </div>
-
-          <div>
-            <label for="referencia" class="block text-sm font-medium text-slate-100">Link de referencia</label>
-            <input id="referencia" name="referencia" type="url" class="mt-2 w-full rounded-2xl border border-line bg-ink/50 px-4 py-3 text-slate-50 outline-none transition placeholder:text-muted focus:border-cyan-electric/60 focus:ring-2 focus:ring-cyan-electric/20" placeholder="Instagram o web" />
-          </div>
-        </div>
-
-        <div class="mt-4">
-          <label for="mensaje" class="block text-sm font-medium text-slate-100">Contexto breve</label>
-          <textarea id="mensaje" name="mensaje" rows="5" class="mt-2 w-full rounded-2xl border border-line bg-ink/50 px-4 py-3 text-slate-50 outline-none transition placeholder:text-muted focus:border-cyan-electric/60 focus:ring-2 focus:ring-cyan-electric/20" placeholder="Qué vendés, qué querés mejorar y si tenés alguna referencia."></textarea>
-        </div>
-
-        <div class="mt-6">
-          <button type="submit" class="inline-flex w-full items-center justify-center rounded-2xl bg-brand-gradient px-6 py-3 text-sm font-semibold text-white shadow-glow transition hover:-translate-y-0.5 hover:shadow-premium-hover sm:w-auto">
-            Mandame mi web o Instagram
-          </button>
-        </div>
-
-        <noscript>
-          <p class="mt-3 text-sm text-muted-soft">
-            Si tu navegador no permite enviar el formulario, escribime a
-            <a class="text-cyan-100 underline" href={`mailto:${EMAIL}`}>{EMAIL}</a>
-            o abrí WhatsApp en
-            <a class="text-cyan-100 underline" href={WHATSAPP_BASE_URL}>{WHATSAPP_BASE_URL}</a>.
+          <p id="contacto-ayuda" class="mt-5 text-sm leading-6 text-muted-soft">
+            Completá lo importante. Email y presupuesto son opcionales para no frenar la conversación.
           </p>
-        </noscript>
-      </form>
+
+          <div class="mt-6 grid gap-4 md:grid-cols-2">
+            <div>
+              <label for="nombre" class="block text-sm font-medium text-slate-100">Nombre</label>
+              <input id="nombre" name="nombre" type="text" autocomplete="name" required class="mt-2 w-full rounded-2xl border border-line bg-surface/75 px-4 py-3 text-slate-50 outline-none transition placeholder:text-muted focus:border-cyan-electric/60 focus:ring-2 focus:ring-cyan-electric/20" placeholder="Tu nombre" />
+            </div>
+
+            <div>
+              <label for="email" class="block text-sm font-medium text-slate-100">Email <span class="text-muted-soft">(opcional)</span></label>
+              <input id="email" name="email" type="email" autocomplete="email" class="mt-2 w-full rounded-2xl border border-line bg-surface/75 px-4 py-3 text-slate-50 outline-none transition placeholder:text-muted focus:border-cyan-electric/60 focus:ring-2 focus:ring-cyan-electric/20" placeholder="tu@email.com" />
+            </div>
+          </div>
+
+          <div class="mt-4 grid gap-4 md:grid-cols-2">
+            <div>
+              <label for="rubro" class="block text-sm font-medium text-slate-100">Rubro</label>
+              <input id="rubro" name="rubro" type="text" required class="mt-2 w-full rounded-2xl border border-line bg-surface/75 px-4 py-3 text-slate-50 outline-none transition placeholder:text-muted focus:border-cyan-electric/60 focus:ring-2 focus:ring-cyan-electric/20" placeholder="Barbería, gimnasio, tienda..." />
+            </div>
+
+            <div>
+              <label for="referencia" class="block text-sm font-medium text-slate-100">Instagram o web actual</label>
+              <input id="referencia" name="referencia" type="url" inputmode="url" class="mt-2 w-full rounded-2xl border border-line bg-surface/75 px-4 py-3 text-slate-50 outline-none transition placeholder:text-muted focus:border-cyan-electric/60 focus:ring-2 focus:ring-cyan-electric/20" placeholder="https://instagram.com/tu_negocio" />
+            </div>
+          </div>
+
+          <div class="mt-4 grid gap-4 md:grid-cols-2">
+            <div>
+              <label for="objetivo" class="block text-sm font-medium text-slate-100">Objetivo</label>
+              <select id="objetivo" name="objetivo" required class="mt-2 w-full rounded-2xl border border-line bg-surface/75 px-4 py-3 text-slate-50 outline-none transition focus:border-cyan-electric/60 focus:ring-2 focus:ring-cyan-electric/20">
+                {objetivos.map((objetivo) => <option value={objetivo}>{objetivo}</option>)}
+              </select>
+            </div>
+
+            <div>
+              <label for="interes" class="block text-sm font-medium text-slate-100">Interés</label>
+              <select id="interes" name="interes" required class="mt-2 w-full rounded-2xl border border-line bg-surface/75 px-4 py-3 text-slate-50 outline-none transition focus:border-cyan-electric/60 focus:ring-2 focus:ring-cyan-electric/20">
+                {intereses.map((interes) => <option value={interes}>{interes}</option>)}
+              </select>
+            </div>
+          </div>
+
+          <div class="mt-4">
+            <label for="presupuesto" class="block text-sm font-medium text-slate-100">Presupuesto estimado <span class="text-muted-soft">(opcional)</span></label>
+            <select id="presupuesto" name="presupuesto" class="mt-2 w-full rounded-2xl border border-line bg-surface/75 px-4 py-3 text-slate-50 outline-none transition focus:border-cyan-electric/60 focus:ring-2 focus:ring-cyan-electric/20">
+              {budgetRanges.map((range) => <option value={range}>{range}</option>)}
+            </select>
+          </div>
+
+          <div class="mt-4">
+            <label for="mensaje" class="block text-sm font-medium text-slate-100">Mensaje libre</label>
+            <textarea id="mensaje" name="mensaje" rows="5" class="mt-2 w-full rounded-2xl border border-line bg-surface/75 px-4 py-3 text-slate-50 outline-none transition placeholder:text-muted focus:border-cyan-electric/60 focus:ring-2 focus:ring-cyan-electric/20" placeholder="Contame qué vendés, qué querés mejorar, qué te preocupa o qué referencia querés imitar."></textarea>
+          </div>
+
+          <div class="mt-6 rounded-2xl border border-cyan-electric/20 bg-cyan-electric/10 p-4 text-sm leading-6 text-cyan-50">
+            No hace falta tener briefing perfecto. Si solo tenés un Instagram, una idea o una web que no convierte, lo ordenamos desde ahí.
+          </div>
+
+          <div class="mt-6 flex flex-col gap-3 sm:flex-row sm:items-center">
+            <button type="submit" class="inline-flex w-full items-center justify-center rounded-2xl bg-brand-gradient px-6 py-3 text-sm font-semibold text-white shadow-glow transition hover:-translate-y-0.5 hover:shadow-premium-hover sm:w-auto">
+              Abrir conversación por WhatsApp
+            </button>
+            <a class="inline-flex w-full items-center justify-center rounded-2xl border border-line bg-white/[0.04] px-6 py-3 text-sm font-semibold text-slate-100 transition hover:border-cyan-electric/40 hover:bg-white/[0.07] sm:w-auto" href={WHATSAPP_BASE_URL} target="_blank" rel="noopener noreferrer">
+              WhatsApp sin mensaje
+            </a>
+          </div>
+
+          <noscript>
+            <p class="mt-3 text-sm text-muted-soft">
+              Si tu navegador no permite enviar el formulario, escribime a
+              <a class="text-cyan-100 underline" href={`mailto:${EMAIL}`}>{EMAIL}</a>
+              o abrí WhatsApp en
+              <a class="text-cyan-100 underline" href={WHATSAPP_BASE_URL}>{WHATSAPP_BASE_URL}</a>.
+            </p>
+          </noscript>
+        </form>
+      </div>
     </section>
   </Container>
 
@@ -128,27 +229,31 @@ const image = "/og-default.png";
       const data = new FormData(form);
 
       const nombre = String(data.get('nombre') || '').trim();
+      const email = String(data.get('email') || '').trim();
       const rubro = String(data.get('rubro') || '').trim();
-      const objetivo = String(data.get('objetivo') || '').trim();
-      const hoyTengo = String(data.get('hoy_tengo') || '').trim();
-      const interes = String(data.get('interes') || '').trim();
       const referencia = String(data.get('referencia') || '').trim();
+      const objetivo = String(data.get('objetivo') || '').trim();
+      const interes = String(data.get('interes') || '').trim();
+      const presupuesto = String(data.get('presupuesto') || '').trim();
       const mensaje = String(data.get('mensaje') || '').trim();
 
       const lines = [
-        `Hola Diego, quiero una demo/web para mi negocio.`,
+        `Hola Diego, quiero mejorar mi web/demo para vender o recibir más consultas.`,
         '',
-        nombre ? `Soy: ${nombre}` : null,
+        nombre ? `Nombre: ${nombre}` : null,
+        email ? `Email: ${email}` : null,
         `Rubro: ${rubro || '[rubro]'}`,
-        `Objetivo: ${objetivo || '[más consultas / reservas / ventas]'}`,
-        `Hoy tengo: ${hoyTengo || '[Instagram / web / nada]'}`,
-        `Me interesa: ${interes || '[landing / demo / agenda / panel / no sé todavía]'}`,
-        `Link de referencia: ${referencia || '[Instagram o web]'}`,
+        `Instagram/web actual: ${referencia || '[link actual o Instagram]'}`,
+        `Objetivo: ${objetivo || '[más consultas / reservas / ventas / sistema interno / otro]'}`,
+        `Me interesa: ${interes || '[demo / landing / agenda / panel / no sé todavía]'}`,
+        presupuesto && presupuesto !== 'Todavía no lo sé' ? `Presupuesto estimado: ${presupuesto}` : null,
       ].filter((line) => line !== null);
 
       if (mensaje) {
-        lines.push('', `Contexto: ${mensaje}`);
+        lines.push('', `Contexto libre: ${mensaje}`);
       }
+
+      lines.push('', 'No tengo todo definido todavía; quiero que me recomiendes el mejor camino.');
 
       const text = lines.join(String.fromCharCode(10));
       const href = `https://wa.me/${WHATSAPP_NUMBER_E164}?text=${encodeURIComponent(text)}`;


### PR DESCRIPTION
### Motivation
- Replace the cold contact form with a guided WhatsApp-first flow to improve conversion and align the site with the V2 dark/premium visual direction.
- Reduce friction for leads by prompting key commercial inputs (name, rubro, link, objetivo, interés, presupuesto) so conversations start with useful context.

### Description
- Reworked `src/pages/contacto.astro` to a V2 dark/premium layout with decorative glows, a two-column guided layout and `GlowCard` usage for contact channels.
- Added guided fields: `nombre`, optional `email`, `rubro`, `referencia` (Instagram/web), `objetivo`, `interes`, optional `presupuesto`, and `mensaje`, and contact cards for WhatsApp, Instagram, Email, GitHub and LinkedIn using centralized constants from `src/lib/contact.ts`.
- Updated the client-side submit handler to assemble a structured WhatsApp message and open `https://wa.me/${WHATSAPP_NUMBER_E164}` with the encoded text, while including a `noscript` fallback to email/WhatsApp links.
- Preserved the no-backend constraint, added `aria-describedby` for the form helper text, and kept compatibility with the static build.

### Testing
- Ran `npm run build`, which completed successfully and generated the static pages.
- Ran `git diff --check`, which reported no issues.
- Ran `npx prettier --check src/pages/contacto.astro`, which failed because Prettier could not infer a parser for `.astro` in this repo (no parser configured).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ffd55ab2648328a06a26dea8a58f17)