### PR TITLE
Add reusable visual foundation components

### DIFF
--- a/src/components/FeaturedCases.astro
+++ b/src/components/FeaturedCases.astro
@@ -10,6 +10,7 @@ const { projects = [] } = Astro.props;
       eyebrow="Casos destacados"
       title="Proyectos presentados como prueba comercial."
       description="Proyectos elegidos para mostrar rubro, problema, solución y una próxima acción clara: ver la demo, entender el caso o pedir algo parecido."
+      icon="folder"
     />
     <a href="/proyectos" class="premium-button inline-flex w-fit items-center gap-2 rounded-2xl border border-line bg-surface-glass px-5 py-3 text-sm font-semibold text-cyan-electric hover:-translate-y-0.5 hover:border-line-strong">
       Ver portfolio completo <span aria-hidden="true">→</span>

--- a/src/components/Icon.astro
+++ b/src/components/Icon.astro
@@ -1,0 +1,152 @@
+---
+type IconName =
+  | 'rocket'
+  | 'message'
+  | 'target'
+  | 'shield'
+  | 'zap'
+  | 'speed'
+  | 'friction'
+  | 'flow'
+  | 'folder'
+  | 'briefcase'
+  | 'code'
+  | 'layout'
+  | 'database'
+  | 'settings'
+  | 'help'
+  | 'phone'
+  | 'mail'
+  | 'external'
+  | 'check'
+  | 'arrow';
+
+const {
+  name = 'check',
+  size = 'md',
+  label,
+  class: className = '',
+  strokeWidth = 1.8,
+} = Astro.props as {
+  name?: IconName;
+  size?: 'sm' | 'md' | 'lg' | number | string;
+  label?: string;
+  class?: string;
+  strokeWidth?: number;
+};
+
+const sizeClasses: Record<string, string> = {
+  sm: 'h-4 w-4',
+  md: 'h-5 w-5',
+  lg: 'h-6 w-6',
+};
+
+const iconPaths: Record<IconName, string[]> = {
+  rocket: [
+    'M6 14.5 4.5 19.5 9.5 18 18.5 9c1.2-1.2 1.9-3.1 2-5.5-2.4.1-4.3.8-5.5 2L6 14.5Z',
+    'M14.5 5.5 18.5 9.5',
+    'M8.5 16.5 5.5 19.5',
+    'M5.5 12.5 2.5 11.5 5.5 8.5 8 9',
+    'M11.5 18.5 12.5 21.5 15.5 18.5 15 16',
+  ],
+  message: [
+    'M4.5 6.5A3.5 3.5 0 0 1 8 3h8a3.5 3.5 0 0 1 3.5 3.5v5A3.5 3.5 0 0 1 16 15h-4.5L7 19v-4H8a3.5 3.5 0 0 1-3.5-3.5v-5Z',
+    'M8 8h8',
+    'M8 11.5h5.5',
+  ],
+  target: [
+    'M12 21a9 9 0 1 0 0-18 9 9 0 0 0 0 18Z',
+    'M12 17a5 5 0 1 0 0-10 5 5 0 0 0 0 10Z',
+    'M12 13.5a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3Z',
+  ],
+  shield: [
+    'M12 3.5 19 6v5.4c0 4.5-2.8 7.4-7 9.1-4.2-1.7-7-4.6-7-9.1V6l7-2.5Z',
+    'M8.5 12 11 14.5 15.8 9.5',
+  ],
+  zap: ['M13 2.8 5.5 13h5L10 21.2 18.5 10h-5L13 2.8Z'],
+  speed: [
+    'M4 14a8 8 0 1 1 16 0',
+    'M12 14 16.5 8.5',
+    'M7 15h10',
+    'M5.5 10.5h2',
+    'M16.5 10.5h2',
+  ],
+  friction: [
+    'M4 7h10a3 3 0 0 1 0 6H9a3 3 0 0 0 0 6h11',
+    'M7 4 4 7l3 3',
+    'M17 10l3 3-3 3',
+  ],
+  flow: [
+    'M4 7h5a3 3 0 0 1 3 3v4a3 3 0 0 0 3 3h5',
+    'M17 14l3 3-3 3',
+    'M7 4 4 7l3 3',
+  ],
+  folder: [
+    'M3.5 7.5A2.5 2.5 0 0 1 6 5h4l2 2h6A2.5 2.5 0 0 1 20.5 9.5v7A2.5 2.5 0 0 1 18 19H6a2.5 2.5 0 0 1-2.5-2.5v-9Z',
+    'M3.5 9h17',
+  ],
+  briefcase: [
+    'M9 6V5a2 2 0 0 1 2-2h2a2 2 0 0 1 2 2v1',
+    'M4.5 7h15A1.5 1.5 0 0 1 21 8.5v9A2.5 2.5 0 0 1 18.5 20h-13A2.5 2.5 0 0 1 3 17.5v-9A1.5 1.5 0 0 1 4.5 7Z',
+    'M3 12h18',
+    'M10 12v2h4v-2',
+  ],
+  code: ['M8.5 8 4.5 12l4 4', 'M15.5 8l4 4-4 4', 'M13 5.5l-2 13'],
+  layout: [
+    'M4 5.5A1.5 1.5 0 0 1 5.5 4h13A1.5 1.5 0 0 1 20 5.5v13a1.5 1.5 0 0 1-1.5 1.5h-13A1.5 1.5 0 0 1 4 18.5v-13Z',
+    'M4 9h16',
+    'M9 9v11',
+  ],
+  database: [
+    'M5 6.5C5 4.6 8.1 3 12 3s7 1.6 7 3.5S15.9 10 12 10 5 8.4 5 6.5Z',
+    'M5 6.5v5c0 1.9 3.1 3.5 7 3.5s7-1.6 7-3.5v-5',
+    'M5 11.5v5c0 1.9 3.1 3.5 7 3.5s7-1.6 7-3.5v-5',
+  ],
+  settings: [
+    'M12 15.5a3.5 3.5 0 1 0 0-7 3.5 3.5 0 0 0 0 7Z',
+    'M12 2.8v3',
+    'M12 18.2v3',
+    'M4.2 7.3l2.6 1.5',
+    'M17.2 15.2l2.6 1.5',
+    'M19.8 7.3l-2.6 1.5',
+    'M6.8 15.2l-2.6 1.5',
+  ],
+  help: [
+    'M12 21a9 9 0 1 0 0-18 9 9 0 0 0 0 18Z',
+    'M9.6 9a2.5 2.5 0 0 1 4.8.9c0 1.8-2.4 2.2-2.4 4.1',
+    'M12 17.2h.01',
+  ],
+  phone: [
+    'M7.3 4.2 9.2 8c.3.6.1 1.3-.4 1.8l-1 1a12.5 12.5 0 0 0 5.4 5.4l1-1c.5-.5 1.2-.7 1.8-.4l3.8 1.9c.7.3 1.1 1.1.9 1.8l-.7 2.2c-.2.6-.8 1-1.5 1A16.5 16.5 0 0 1 2.3 5.5c0-.7.4-1.3 1-1.5l2.2-.7c.7-.2 1.5.2 1.8.9Z',
+  ],
+  mail: [
+    'M4.5 6h15A1.5 1.5 0 0 1 21 7.5v9a1.5 1.5 0 0 1-1.5 1.5h-15A1.5 1.5 0 0 1 3 16.5v-9A1.5 1.5 0 0 1 4.5 6Z',
+    'm4 8 8 5.5L20 8',
+  ],
+  external: ['M14 4h6v6', 'M20 4l-9 9', 'M20 14.5V19a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1V5a1 1 0 0 1 1-1h4.5'],
+  check: ['M5 12.5 9.2 16.7 19 7'],
+  arrow: ['M5 12h14', 'M13 6l6 6-6 6'],
+};
+
+const sizeClass = typeof size === 'number' ? '' : sizeClasses[String(size)] ?? String(size);
+const numericSize = typeof size === 'number' ? size : undefined;
+const paths = iconPaths[name] ?? iconPaths.check;
+const accessibilityProps = label
+  ? { role: 'img', 'aria-label': label }
+  : { 'aria-hidden': 'true' };
+---
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width={strokeWidth}
+  stroke-linecap="round"
+  stroke-linejoin="round"
+  width={numericSize}
+  height={numericSize}
+  class={`${sizeClass} shrink-0 ${className}`}
+  {...accessibilityProps}
+>
+  {paths.map((d) => <path d={d} />)}
+</svg>

--- a/src/components/IconBubble.astro
+++ b/src/components/IconBubble.astro
@@ -1,0 +1,34 @@
+---
+import Icon from './Icon.astro';
+
+const {
+  icon = 'check',
+  tone = 'cyan',
+  size = 'md',
+  label,
+  class: className = '',
+} = Astro.props;
+
+const toneClasses = {
+  cyan: 'border-cyan-electric/25 bg-cyan-electric/10 text-cyan-electric shadow-[0_0_28px_rgba(34,211,238,0.16)]',
+  violet: 'border-violet-electric/25 bg-violet-electric/10 text-violet-300 shadow-[0_0_28px_rgba(139,92,246,0.16)]',
+  emerald: 'border-emerald-300/25 bg-emerald-400/10 text-emerald-300 shadow-[0_0_28px_rgba(52,211,153,0.14)]',
+  amber: 'border-amber-300/25 bg-amber-300/10 text-amber-200 shadow-[0_0_28px_rgba(251,191,36,0.12)]',
+  neutral: 'border-line bg-surface-glass text-muted-bright shadow-[0_0_28px_rgba(148,163,184,0.10)]',
+};
+
+const sizeClasses = {
+  sm: 'h-8 w-8 rounded-xl',
+  md: 'h-10 w-10 rounded-2xl',
+  lg: 'h-12 w-12 rounded-2xl',
+};
+
+const iconSizes = {
+  sm: 'sm',
+  md: 'md',
+  lg: 'lg',
+};
+---
+<span class={`inline-flex shrink-0 items-center justify-center border backdrop-blur ${toneClasses[tone] ?? toneClasses.cyan} ${sizeClasses[size] ?? sizeClasses.md} ${className}`}>
+  <Icon name={icon} size={iconSizes[size] ?? 'md'} label={label} />
+</span>

--- a/src/components/OutcomeGrid.astro
+++ b/src/components/OutcomeGrid.astro
@@ -1,7 +1,14 @@
 ---
-import GlowCard from './GlowCard.astro';
 import SectionHeader from './SectionHeader.astro';
+import VisualCard from './VisualCard.astro';
 import { outcomes } from '../data/outcomes';
+
+const outcomeVisuals = [
+  { icon: 'message', tone: 'cyan' },
+  { icon: 'shield', tone: 'violet' },
+  { icon: 'flow', tone: 'emerald' },
+  { icon: 'rocket', tone: 'amber' },
+];
 ---
 
 <section id="que-resuelvo" class="scroll-mt-24 py-14 md:py-20">
@@ -9,17 +16,19 @@ import { outcomes } from '../data/outcomes';
     eyebrow="Qué resuelvo"
     title="La web no solo tiene que verse bien: tiene que guiar a la consulta."
     description="Trabajo la estructura, los mensajes y los llamados a la acción para que el visitante entienda rápido qué ofrecés, qué paso dar y por qué confiar."
+    icon="target"
   />
   <div class="mt-8 grid gap-5 sm:grid-cols-2 lg:grid-cols-4">
     {
-      outcomes.map((item) => (
-        <GlowCard class="h-full">
-          <p class="text-xs font-semibold uppercase tracking-[0.18em] text-cyan-electric">{item.goal}</p>
-          <h3 class="mt-3 text-lg font-semibold text-slate-50">{item.title}</h3>
-          <p class="mt-3 text-sm leading-6 text-muted-soft">
-            {item.description}
-          </p>
-        </GlowCard>
+      outcomes.map((item, index) => (
+        <VisualCard
+          class="h-full"
+          title={item.title}
+          description={item.description}
+          badge={item.goal}
+          icon={outcomeVisuals[index]?.icon ?? 'target'}
+          tone={outcomeVisuals[index]?.tone ?? 'cyan'}
+        />
       ))
     }
   </div>

--- a/src/components/SectionHeader.astro
+++ b/src/components/SectionHeader.astro
@@ -1,20 +1,41 @@
 ---
-const { eyebrow, title, description, align = 'left', class: className = '' } = Astro.props;
-const alignment = align === 'center' ? 'mx-auto text-center items-center' : 'items-start';
+import IconBubble from './IconBubble.astro';
+
+const {
+  eyebrow,
+  title,
+  description,
+  icon,
+  align = 'left',
+  class: className = '',
+} = Astro.props;
+
+const isCenter = align === 'center';
+const alignment = isCenter ? 'mx-auto items-center text-center' : 'items-start text-left';
+const eyebrowAlignment = isCenter ? 'justify-center' : 'justify-start';
 ---
-<header class={`flex max-w-3xl flex-col gap-3 ${alignment} ${className}`}>
-  {eyebrow && (
-    <p class="inline-flex w-fit items-center rounded-full border border-line bg-surface-glass px-3 py-1 text-xs font-semibold uppercase tracking-[0.22em] text-cyan-electric">
-      {eyebrow}
-    </p>
-  )}
-  {title && (
-    <h2 class="text-3xl font-semibold tracking-tight text-slate-50 sm:text-4xl lg:text-5xl">
-      {title}
-    </h2>
-  )}
+<header class={`relative flex max-w-3xl flex-col gap-4 ${alignment} ${className}`}>
+  <div class={`flex w-full items-center gap-3 ${eyebrowAlignment}`}>
+    {icon && <IconBubble icon={icon} tone="cyan" size="sm" label={eyebrow ?? title ?? 'Sección'} />}
+    {eyebrow && (
+      <p class="inline-flex w-fit items-center rounded-full border border-line bg-surface-glass px-3 py-1 text-xs font-semibold uppercase tracking-[0.22em] text-cyan-electric shadow-[inset_0_1px_0_rgba(255,255,255,0.06)] backdrop-blur">
+        <span class="mr-2 h-1.5 w-1.5 rounded-full bg-cyan-electric shadow-[0_0_14px_rgba(34,211,238,0.7)]" aria-hidden="true"></span>
+        {eyebrow}
+      </p>
+    )}
+  </div>
+
+  <div class="relative">
+    <div class={`pointer-events-none absolute -inset-x-4 -inset-y-3 -z-10 rounded-3xl bg-gradient-to-r from-cyan-electric/10 via-blue-electric/5 to-violet-electric/10 blur-2xl ${isCenter ? 'opacity-60' : 'opacity-45'}`}></div>
+    {title && (
+      <h2 class="text-3xl font-semibold tracking-tight text-slate-50 sm:text-4xl lg:text-5xl">
+        {title}
+      </h2>
+    )}
+  </div>
+
   {description && (
-    <p class="text-base leading-7 text-muted-soft sm:text-lg">
+    <p class={`text-base leading-7 text-muted-soft sm:text-lg ${isCenter ? 'mx-auto max-w-2xl' : 'max-w-copy'}`}>
       {description}
     </p>
   )}

--- a/src/components/VisualBadge.astro
+++ b/src/components/VisualBadge.astro
@@ -1,0 +1,28 @@
+---
+import Icon from './Icon.astro';
+
+const {
+  label,
+  icon,
+  tone = 'neutral',
+  size = 'sm',
+  class: className = '',
+} = Astro.props;
+
+const toneClasses = {
+  cyan: 'border-cyan-electric/25 bg-cyan-electric/10 text-cyan-100 shadow-[inset_0_1px_0_rgba(255,255,255,0.08)]',
+  violet: 'border-violet-electric/25 bg-violet-electric/10 text-violet-100 shadow-[inset_0_1px_0_rgba(255,255,255,0.08)]',
+  emerald: 'border-emerald-300/25 bg-emerald-400/10 text-emerald-100 shadow-[inset_0_1px_0_rgba(255,255,255,0.08)]',
+  amber: 'border-amber-300/25 bg-amber-300/10 text-amber-100 shadow-[inset_0_1px_0_rgba(255,255,255,0.08)]',
+  neutral: 'border-line bg-surface-glass text-muted-soft shadow-[inset_0_1px_0_rgba(255,255,255,0.06)]',
+};
+
+const sizeClasses = {
+  sm: 'gap-1.5 px-2.5 py-1 text-[0.72rem]',
+  md: 'gap-2 px-3 py-1.5 text-xs',
+};
+---
+<span class={`inline-flex w-fit items-center rounded-full border font-semibold uppercase tracking-[0.16em] backdrop-blur ${toneClasses[tone] ?? toneClasses.neutral} ${sizeClasses[size] ?? sizeClasses.sm} ${className}`}>
+  {icon && <Icon name={icon} size="sm" />}
+  <span>{label}</span>
+</span>

--- a/src/components/VisualCard.astro
+++ b/src/components/VisualCard.astro
@@ -1,0 +1,38 @@
+---
+import IconBubble from './IconBubble.astro';
+import VisualBadge from './VisualBadge.astro';
+
+const {
+  title,
+  description,
+  icon,
+  tone = 'cyan',
+  href,
+  badge,
+  class: className = '',
+} = Astro.props;
+
+const Tag = href ? 'a' : 'article';
+const attrs = href ? { href } : {};
+---
+<Tag
+  {...attrs}
+  class={`group premium-interactive block h-full overflow-hidden rounded-3xl border border-line bg-surface-glow p-5 shadow-premium backdrop-blur hover:border-line-strong hover:shadow-premium-hover focus-visible:outline-cyan-electric ${className}`}
+>
+  <div class="pointer-events-none absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-cyan-electric/50 to-transparent opacity-70"></div>
+  <div class="pointer-events-none absolute -right-16 -top-16 h-32 w-32 rounded-full bg-cyan-electric/10 blur-3xl transition duration-300 group-hover:bg-cyan-electric/20"></div>
+
+  <div class="relative flex h-full flex-col gap-4">
+    <div class="flex items-start justify-between gap-4">
+      {icon && <IconBubble icon={icon} tone={tone} size="md" />}
+      {badge && <VisualBadge label={badge} tone={tone} />}
+    </div>
+
+    <div>
+      {title && <h3 class="text-lg font-semibold tracking-tight text-slate-50">{title}</h3>}
+      {description && <p class="mt-3 text-sm leading-6 text-muted-soft">{description}</p>}
+    </div>
+
+    <slot />
+  </div>
+</Tag>


### PR DESCRIPTION
### Motivation
- Provide a lightweight, reusable visual foundation that gives the site a premium dark/tech-commercial tone without redesigning pages one-by-one. 
- Standardize small UI building blocks (icons, icon bubbles, badges, cards, section headers) so future patches can reuse consistent primitives. 
- Apply the new primitives lightly to a couple of safe sections so their usage is documented and tested without changing full layouts.

### Description
- Added a small inline SVG icon system with accessible labels and size/stroke controls in `src/components/Icon.astro`. 
- Added framed icon container `src/components/IconBubble.astro`, pill badges `src/components/VisualBadge.astro`, and a reusable dark premium card `src/components/VisualCard.astro`. 
- Enhanced `src/components/SectionHeader.astro` to accept `icon` and `align` props and to render a subtle gradient/frame compatible with the V2 aesthetic. 
- Replaced the previous outcome cards with the new `VisualCard` in `src/components/OutcomeGrid.astro` and added the `SectionHeader` icon to `src/components/FeaturedCases.astro` to demonstrate usage; no full-section redesign was performed. 
- All components use Tailwind classes only and follow the existing V2 theme tokens and utilities in the repo (no new dependencies added).

### Testing
- Ran the site build with `npm run build` and it completed successfully (14 pages generated). 
- Verified the generated static output reports no build errors and all modified pages render during the build. 
- Ran `npx prettier --write` attempt on the new `.astro` files which failed to auto-format because the repo lacks an Astro Prettier parser/plugin, so formatting was not applied automatically.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fff170f6fc8328998b332467cb80d8)