### PR TITLE
Add visual identity to homepage sections

### DIFF
--- a/src/components/ContactCTA.astro
+++ b/src/components/ContactCTA.astro
@@ -1,24 +1,39 @@
 ---
+import SectionHeader from './SectionHeader.astro';
+import VisualBadge from './VisualBadge.astro';
 import { waLink, AUDIT_WHATSAPP_MESSAGE } from '../lib/contact';
 
 const {
-  eyebrow = 'Último paso',
-  title = 'Mandame tu web o Instagram y te digo qué mejoraría.',
-  description = 'Te respondo con ideas concretas: qué mejorar, qué mostrar primero y qué demo o web tendría más sentido para recibir consultas al momento.',
+  eyebrow = 'Próximo paso',
+  title = 'Pasame tu idea y vemos el mejor camino',
+  description = 'Mandame tu web, Instagram o idea por WhatsApp. Te respondo con ideas concretas: qué mostrar primero, qué fricción reducir y qué demo o web tendría más sentido.',
   primaryLabel = 'Mandame mi web o Instagram',
   primaryMessage = AUDIT_WHATSAPP_MESSAGE,
   secondaryLabel,
   secondaryHref,
 } = Astro.props;
+
+const ctaBadges = [
+  { label: 'WhatsApp directo', icon: 'message', tone: 'cyan' },
+  { label: 'Idea o Instagram', icon: 'phone', tone: 'emerald' },
+  { label: 'Camino claro', icon: 'rocket', tone: 'violet' },
+];
 ---
 <section class="py-16 text-center md:py-24">
   <div class="premium-interactive halo-sweep relative overflow-hidden rounded-[2rem] border border-line bg-surface-glow p-8 shadow-premium backdrop-blur md:p-12">
     <div class="absolute inset-x-10 -top-20 h-40 rounded-full bg-cyan-electric/20 blur-3xl" aria-hidden="true"></div>
     <div class="absolute -bottom-24 right-0 h-44 w-44 rounded-full bg-brand-violet/20 blur-3xl" aria-hidden="true"></div>
-    <div class="relative mx-auto max-w-3xl">
-      <p class="text-sm font-semibold uppercase tracking-[0.22em] text-cyan-electric">{eyebrow}</p>
-      <h2 class="mt-4 text-3xl font-semibold tracking-tight text-slate-50 md:text-5xl">{title}</h2>
-      <p class="mt-4 text-base leading-7 text-muted-soft">{description}</p>
+    <div class="relative mx-auto flex max-w-3xl flex-col items-center">
+      <SectionHeader
+        eyebrow={eyebrow}
+        title={title}
+        description={description}
+        icon="message"
+        align="center"
+      />
+      <div class="mt-5 flex flex-wrap justify-center gap-2">
+        {ctaBadges.map((badge) => <VisualBadge label={badge.label} icon={badge.icon} tone={badge.tone} />)}
+      </div>
       <div class="mt-8 flex flex-col items-center justify-center gap-3 sm:flex-row">
         <a
           href={waLink(primaryMessage)}

--- a/src/components/FAQs.astro
+++ b/src/components/FAQs.astro
@@ -1,14 +1,26 @@
 ---
 import SectionHeader from './SectionHeader.astro';
+import VisualBadge from './VisualBadge.astro';
 import { faqs } from '../data/faqs';
+
+const faqBadges = [
+  { label: 'Tiempos claros', icon: 'speed', tone: 'cyan' },
+  { label: 'Alcance definido', icon: 'check', tone: 'emerald' },
+  { label: 'Sin backend innecesario', icon: 'shield', tone: 'violet' },
+];
 ---
-<section class="py-14 md:py-20">
+<section class="relative overflow-hidden border-t border-line/70 py-14 md:py-20">
+  <div class="absolute left-1/2 top-8 -z-10 h-52 w-52 -translate-x-1/2 rounded-full bg-cyan-electric/10 blur-3xl" aria-hidden="true"></div>
   <SectionHeader
-    eyebrow="FAQs"
-    title="Preguntas antes de crear tu demo o web."
-    description="Respuestas simples sobre tiempos, entrega, WhatsApp, agenda y contenido editable."
+    eyebrow="Antes de empezar"
+    title="Preguntas frecuentes"
+    description="Respuestas rápidas para reducir incertidumbre sobre tiempos, entrega, WhatsApp, agenda y contenido editable antes de escribir."
+    icon="help"
     align="center"
   />
+  <div class="mx-auto mt-5 flex max-w-3xl flex-wrap justify-center gap-2">
+    {faqBadges.map((badge) => <VisualBadge label={badge.label} icon={badge.icon} tone={badge.tone} />)}
+  </div>
 
   <div class="mx-auto mt-8 max-w-3xl space-y-3">
     {faqs.map((item) => (

--- a/src/components/FeaturedCases.astro
+++ b/src/components/FeaturedCases.astro
@@ -1,17 +1,30 @@
 ---
 import ProjectCard from './ProjectCard.astro';
 import SectionHeader from './SectionHeader.astro';
+import VisualBadge from './VisualBadge.astro';
 
 const { projects = [] } = Astro.props;
+const projectBadges = [
+  { label: 'Landing', icon: 'layout', tone: 'cyan' },
+  { label: 'Admin panel', icon: 'database', tone: 'violet' },
+  { label: 'Web corporativa', icon: 'briefcase', tone: 'emerald' },
+  { label: 'Demo comercial', icon: 'rocket', tone: 'amber' },
+];
 ---
-<section id="casos" class="scroll-mt-24 py-14 md:py-20">
+<section id="casos" class="relative scroll-mt-24 overflow-hidden border-t border-line/70 py-14 md:py-20">
+  <div class="absolute -right-28 top-8 -z-10 h-60 w-60 rounded-full bg-violet-electric/10 blur-3xl" aria-hidden="true"></div>
   <div class="flex flex-col gap-6 md:flex-row md:items-end md:justify-between">
-    <SectionHeader
-      eyebrow="Casos destacados"
-      title="Proyectos presentados como prueba comercial."
-      description="Proyectos elegidos para mostrar rubro, problema, solución y una próxima acción clara: ver la demo, entender el caso o pedir algo parecido."
-      icon="folder"
-    />
+    <div class="space-y-5">
+      <SectionHeader
+        eyebrow="Casos y demos"
+        title="Proyectos que muestran criterio comercial"
+        description="No son solo piezas visuales: cada caso está pensado para explicar un negocio, resolver una fricción y acercar al visitante a una acción concreta."
+        icon="folder"
+      />
+      <div class="flex flex-wrap gap-2">
+        {projectBadges.map((badge) => <VisualBadge label={badge.label} icon={badge.icon} tone={badge.tone} />)}
+      </div>
+    </div>
     <a href="/proyectos" class="premium-button inline-flex w-fit items-center gap-2 rounded-2xl border border-line bg-surface-glass px-5 py-3 text-sm font-semibold text-cyan-electric hover:-translate-y-0.5 hover:border-line-strong">
       Ver portfolio completo <span aria-hidden="true">→</span>
     </a>

--- a/src/components/HeroV2.astro
+++ b/src/components/HeroV2.astro
@@ -1,24 +1,42 @@
 ---
 import BrowserMockup from './BrowserMockup.astro';
+import IconBubble from './IconBubble.astro';
 import MetricPill from './MetricPill.astro';
+import VisualBadge from './VisualBadge.astro';
 import { heroSignals } from '../data/site';
 import { waLink, DEMO_WHATSAPP_MESSAGE } from '../lib/contact';
+
+const heroBadges = [
+  { label: 'Propuesta en 24h', icon: 'speed', tone: 'cyan' },
+  { label: 'Repo + deploy', icon: 'code', tone: 'violet' },
+  { label: 'Pagos por hitos', icon: 'check', tone: 'emerald' },
+  { label: 'WhatsApp CTA', icon: 'message', tone: 'amber' },
+];
 ---
-<section class="relative overflow-hidden py-20 md:py-28">
+<section class="relative overflow-hidden py-20 md:py-28" aria-labelledby="hero-title">
   <div class="absolute left-1/2 top-10 -z-10 h-72 w-72 -translate-x-1/2 rounded-full bg-cyan-electric/20 blur-3xl" aria-hidden="true"></div>
+  <div class="absolute -right-24 top-32 -z-10 h-64 w-64 rounded-full bg-violet-electric/15 blur-3xl" aria-hidden="true"></div>
   <div class="absolute inset-x-0 top-0 -z-10 h-px bg-gradient-to-r from-transparent via-cyan-electric/40 to-transparent" aria-hidden="true"></div>
   <div class="grid items-center gap-12 lg:grid-cols-[0.95fr_1.05fr]">
     <div>
-      <p class="inline-flex items-center gap-2 rounded-full border border-cyan-electric/25 bg-cyan-electric/10 px-4 py-2 text-xs font-semibold uppercase tracking-[0.22em] text-cyan-100 shadow-[0_0_32px_rgba(34,211,238,0.12)]">
-        <span class="status-dot" aria-hidden="true"></span>
-        Marin.dev · páginas, demos y herramientas simples
-      </p>
-      <h1 class="mt-6 max-w-4xl text-4xl font-semibold tracking-tight text-slate-50 sm:text-5xl lg:text-6xl">
+      <div class="inline-flex items-center gap-3 rounded-full border border-cyan-electric/25 bg-cyan-electric/10 px-3 py-2 shadow-[0_0_32px_rgba(34,211,238,0.12)] backdrop-blur sm:px-4">
+        <IconBubble icon="rocket" tone="cyan" size="sm" label="Conversión, tecnología y velocidad" />
+        <span class="text-xs font-semibold uppercase tracking-[0.2em] text-cyan-100">
+          Marin.dev · conversión + tecnología + velocidad
+        </span>
+      </div>
+      <h1 id="hero-title" class="mt-6 max-w-4xl text-4xl font-semibold tracking-tight text-slate-50 sm:text-5xl lg:text-6xl">
         Convertí tu Instagram o idea en una web clara, linda y lista para recibir consultas.
       </h1>
       <p class="mt-6 max-w-2xl text-base leading-8 text-muted-soft sm:text-lg">
         Te ayudo a mostrar qué ofrecés, ordenar tus servicios y llevar a la persona correcta a escribirte, reservar o comprar al momento.
       </p>
+
+      <div class="mt-6 flex flex-wrap gap-2.5">
+        {heroBadges.map((badge) => (
+          <VisualBadge label={badge.label} icon={badge.icon} tone={badge.tone} />
+        ))}
+      </div>
 
       <div class="mt-8 flex flex-col gap-3 sm:flex-row">
         <a

--- a/src/components/OutcomeGrid.astro
+++ b/src/components/OutcomeGrid.astro
@@ -1,5 +1,6 @@
 ---
 import SectionHeader from './SectionHeader.astro';
+import VisualBadge from './VisualBadge.astro';
 import VisualCard from './VisualCard.astro';
 import { outcomes } from '../data/outcomes';
 
@@ -9,15 +10,27 @@ const outcomeVisuals = [
   { icon: 'flow', tone: 'emerald' },
   { icon: 'rocket', tone: 'amber' },
 ];
+
+const outcomeBadges = [
+  { label: 'CTA claro', icon: 'target', tone: 'cyan' },
+  { label: 'Menos dudas', icon: 'friction', tone: 'violet' },
+  { label: 'Más confianza', icon: 'shield', tone: 'emerald' },
+];
 ---
 
-<section id="que-resuelvo" class="scroll-mt-24 py-14 md:py-20">
-  <SectionHeader
-    eyebrow="Qué resuelvo"
-    title="La web no solo tiene que verse bien: tiene que guiar a la consulta."
-    description="Trabajo la estructura, los mensajes y los llamados a la acción para que el visitante entienda rápido qué ofrecés, qué paso dar y por qué confiar."
-    icon="target"
-  />
+<section id="que-resuelvo" class="relative scroll-mt-24 overflow-hidden border-t border-line/70 py-14 md:py-20">
+  <div class="absolute -left-28 top-10 -z-10 h-56 w-56 rounded-full bg-cyan-electric/10 blur-3xl" aria-hidden="true"></div>
+  <div class="flex flex-col gap-5 lg:flex-row lg:items-end lg:justify-between">
+    <SectionHeader
+      eyebrow="Problemas que resolvemos"
+      title="Menos fricción, más consultas"
+      description="Ordeno la web para que el visitante entienda rápido qué ofrecés, por qué confiar y cuál es el próximo paso: escribir, reservar o comprar."
+      icon="target"
+    />
+    <div class="flex flex-wrap gap-2 lg:max-w-sm lg:justify-end">
+      {outcomeBadges.map((badge) => <VisualBadge label={badge.label} icon={badge.icon} tone={badge.tone} />)}
+    </div>
+  </div>
   <div class="mt-8 grid gap-5 sm:grid-cols-2 lg:grid-cols-4">
     {
       outcomes.map((item, index) => (

--- a/src/components/ProductizedServices.astro
+++ b/src/components/ProductizedServices.astro
@@ -2,15 +2,30 @@
 import Badge from './Badge.astro';
 import GlowCard from './GlowCard.astro';
 import SectionHeader from './SectionHeader.astro';
+import VisualBadge from './VisualBadge.astro';
 import { productizedServices } from '../data/services';
 import { waLink, SERVICE_WHATSAPP_MESSAGE } from '../lib/contact';
+
+const serviceBadges = [
+  { label: '3–5 días', icon: 'speed', tone: 'cyan' },
+  { label: 'SEO base', icon: 'target', tone: 'violet' },
+  { label: 'Performance', icon: 'zap', tone: 'emerald' },
+  { label: 'Integraciones', icon: 'settings', tone: 'amber' },
+];
 ---
-<section id="planes" class="scroll-mt-24 py-14 md:py-20">
-  <SectionHeader
-    eyebrow="Servicios productizados"
-    title="Opciones claras para empezar sin vueltas."
-    description="Cada opción resuelve una necesidad concreta: mostrar mejor tu negocio, recibir consultas o mantener información actualizada."
-  />
+<section id="planes" class="relative scroll-mt-24 overflow-hidden rounded-[2rem] border border-line/80 bg-surface-glow px-4 py-14 shadow-premium md:px-6 md:py-20">
+  <div class="absolute -left-24 top-10 -z-10 h-56 w-56 rounded-full bg-cyan-electric/10 blur-3xl" aria-hidden="true"></div>
+  <div class="flex flex-col gap-5 lg:flex-row lg:items-end lg:justify-between">
+    <SectionHeader
+      eyebrow="Servicios"
+      title="Soluciones empaquetadas para avanzar rápido"
+      description="Cada paquete es un punto de partida: definimos alcance, prioridad comercial y próximos pasos para que puedas publicar sin perder semanas en decisiones sueltas."
+      icon="layout"
+    />
+    <div class="flex flex-wrap gap-2 lg:max-w-md lg:justify-end">
+      {serviceBadges.map((badge) => <VisualBadge label={badge.label} icon={badge.icon} tone={badge.tone} />)}
+    </div>
+  </div>
   <div class="mt-8 grid gap-6 md:grid-cols-2 xl:grid-cols-4">
     {productizedServices.map((service) => (
       <GlowCard class={`h-full ${service.featured ? 'border-cyan-electric/35' : ''}`}>


### PR DESCRIPTION
### Motivation
- Improve scanability and commercial clarity of the homepage by assigning each major section a clear visual identity (icon + badge + header) so visitors understand purpose before reading text. 
- Use the reusable components created in Patch 01 (`SectionHeader`, `IconBubble`, `VisualBadge`, `VisualCard`) to keep UI consistent and low-risk. 
- Preserve existing content, routes and card layouts while increasing hierarchy and reducing perceived text saturation.

### Description
- Replaced plain headings with `SectionHeader` and added section-specific icons and short descriptions for Hero, "Qué resuelvo", Projects, Services, FAQs and the final CTA. (files modified: `src/components/HeroV2.astro`, `src/components/OutcomeGrid.astro`, `src/components/FeaturedCases.astro`, `src/components/ProductizedServices.astro`, `src/components/FAQs.astro`, `src/components/ContactCTA.astro`).
- Added small scannable `VisualBadge` groups per section (hero signals like “Propuesta en 24h / Repo + deploy / Pagos por hitos / WhatsApp CTA”, project-type badges, service quick badges, FAQ reassurance badges, CTA anchor badges) and kept them responsive to wrap cleanly on mobile. 
- Introduced subtle visual anchors (soft radial orbs, light top borders, elevated surface backgrounds for services and CTA) to separate sections without adding image assets. 
- Kept existing components that render project cards, pricing and flows unchanged so content rendering and routing remain the same.

### Testing
- Ran `npm run build` which completed successfully and generated the static site (14 page(s) built). 
- Ran `git diff --check` (no whitespace or syntax issues reported) and started the dev server locally with `npm run dev` to validate layout changes. 
- Attempted an automated screenshot with Playwright, but the transient `npx playwright` step failed due to registry `403 Forbidden` in this environment, so visual QA was limited to local dev preview rather than an automated capture.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fff2a2c3608328b7a282fdf4304e6d)