### PR TITLE
Redesign benefits section as visual cards

### DIFF
--- a/src/components/OutcomeGrid.astro
+++ b/src/components/OutcomeGrid.astro
@@ -4,45 +4,45 @@ import VisualBadge from './VisualBadge.astro';
 import VisualCard from './VisualCard.astro';
 import { outcomes } from '../data/outcomes';
 
-const outcomeVisuals = [
-  { icon: 'message', tone: 'cyan' },
-  { icon: 'shield', tone: 'violet' },
-  { icon: 'flow', tone: 'emerald' },
-  { icon: 'rocket', tone: 'amber' },
-];
-
-const outcomeBadges = [
-  { label: 'CTA claro', icon: 'target', tone: 'cyan' },
-  { label: 'Menos dudas', icon: 'friction', tone: 'violet' },
-  { label: 'Más confianza', icon: 'shield', tone: 'emerald' },
+const supportingBadges = [
+  { label: 'claridad', icon: 'target', tone: 'cyan' },
+  { label: 'velocidad', icon: 'zap', tone: 'amber' },
+  { label: 'conversión', icon: 'message', tone: 'emerald' },
 ];
 ---
 
 <section id="que-resuelvo" class="relative scroll-mt-24 overflow-hidden border-t border-line/70 py-14 md:py-20">
   <div class="absolute -left-28 top-10 -z-10 h-56 w-56 rounded-full bg-cyan-electric/10 blur-3xl" aria-hidden="true"></div>
-  <div class="flex flex-col gap-5 lg:flex-row lg:items-end lg:justify-between">
-    <SectionHeader
-      eyebrow="Problemas que resolvemos"
-      title="Menos fricción, más consultas"
-      description="Ordeno la web para que el visitante entienda rápido qué ofrecés, por qué confiar y cuál es el próximo paso: escribir, reservar o comprar."
-      icon="target"
-    />
-    <div class="flex flex-wrap gap-2 lg:max-w-sm lg:justify-end">
-      {outcomeBadges.map((badge) => <VisualBadge label={badge.label} icon={badge.icon} tone={badge.tone} />)}
-    </div>
-  </div>
-  <div class="mt-8 grid gap-5 sm:grid-cols-2 lg:grid-cols-4">
+  <div class="absolute -right-32 bottom-10 -z-10 h-64 w-64 rounded-full bg-violet-electric/10 blur-3xl" aria-hidden="true"></div>
+
+  <SectionHeader
+    eyebrow="Qué resuelvo"
+    title="Tu web no debería solo verse bien: debería ayudarte a vender"
+    description="Ordeno el mensaje, reduzco la fricción y diseño caminos claros para que la visita termine en consulta, reserva o venta."
+    icon="target"
+  />
+
+  <div class="mt-8 grid gap-4 sm:grid-cols-2 lg:grid-cols-4 lg:gap-5">
     {
-      outcomes.map((item, index) => (
+      outcomes.map((item) => (
         <VisualCard
-          class="h-full"
+          class="min-h-[13rem]"
           title={item.title}
           description={item.description}
-          badge={item.goal}
-          icon={outcomeVisuals[index]?.icon ?? 'target'}
-          tone={outcomeVisuals[index]?.tone ?? 'cyan'}
+          badge={item.badge}
+          icon={item.icon}
+          tone={item.tone}
         />
       ))
     }
+  </div>
+
+  <div class="mt-6 flex flex-col gap-3 rounded-3xl border border-line bg-surface-glass px-4 py-4 backdrop-blur sm:flex-row sm:items-center sm:justify-between sm:px-5">
+    <p class="text-sm leading-6 text-muted-soft">
+      Cada bloque está pensado para que el cliente entienda rápido qué hacer después.
+    </p>
+    <div class="flex flex-wrap gap-2">
+      {supportingBadges.map((badge) => <VisualBadge label={badge.label} icon={badge.icon} tone={badge.tone} />)}
+    </div>
   </div>
 </section>

--- a/src/data/outcomes.ts
+++ b/src/data/outcomes.ts
@@ -1,26 +1,34 @@
 export const outcomes = [
   {
-    goal: "Consulta",
-    title: "Más consultas claras",
+    title: "Más consultas",
     description:
-      "Botones visibles, WhatsApp con mensaje preparado y secciones que responden las dudas más comunes antes del primer contacto.",
+      "CTAs claros, WhatsApp guiado y secciones que responden objeciones antes del primer mensaje.",
+    badge: "WhatsApp CTA",
+    icon: "message",
+    tone: "cyan",
   },
   {
-    goal: "Confianza",
-    title: "Más confianza para decidir",
+    title: "Más confianza",
     description:
-      "Una presentación cuidada, casos concretos y mensajes simples para que la persona entienda rápido por qué elegirte.",
+      "Estructura institucional, prueba social y mensajes de seguridad para que elegirte sea más fácil.",
+    badge: "Confianza",
+    icon: "shield",
+    tone: "violet",
   },
   {
-    goal: "Operación",
-    title: "Reservas y pedidos más ordenados",
+    title: "Más velocidad",
     description:
-      "Agendas, listas de servicios y contenido editable para que cada consulta llegue con la información necesaria.",
+      "Carga rápida, base SEO y una experiencia fluida para no perder visitas en el camino.",
+    badge: "Performance",
+    icon: "zap",
+    tone: "amber",
   },
   {
-    goal: "Validación",
-    title: "Una demo lista para mostrar",
+    title: "Menos fricción",
     description:
-      "Una página navegable para compartir por WhatsApp, probar la idea y mostrar cómo se vería tu negocio online.",
+      "Formularios, integraciones y entrega prolija con repositorio, deploy y próximos pasos claros.",
+    badge: "Repo + deploy",
+    icon: "flow",
+    tone: "emerald",
   },
 ];


### PR DESCRIPTION
### Motivation
- Make the existing “Qué resuelvo” area immediately scannable and commercial by turning verbose text into four visual benefit cards with icons, short titles, concise descriptions and subtle badges.
- Preserve the commercial messaging (Más consultas, Más confianza, Más velocidad, Menos fricción) while improving visual hierarchy and usability on mobile and desktop.
- Reuse existing design tokens and components to keep the update lightweight and consistent with the V2 aesthetic.

### Description
- Replaced the older outcome block with a new `OutcomeGrid` that includes a stronger `SectionHeader`, subtle background glows and a responsive 4-card grid using the existing `VisualCard`, `IconBubble` and `VisualBadge` components (`src/components/OutcomeGrid.astro`).
- Replaced the outcomes dataset with four commercial benefits including `badge`, `icon` and `tone` fields to drive visuals (`src/data/outcomes.ts`).
- Added a compact supporting strip below the cards with three small badges and a short clarifying line to improve scannability and reinforce conversion messaging (`OutcomeGrid` changes).
- Kept all changes scoped to that section and reused existing components to avoid wider regressions.

### Testing
- Ran `npm run build` and the static build completed successfully (pages generated, `dist/` created). ✅
- Ran `npx prettier --check src/data/outcomes.ts` which passed, while `npx prettier --check` for the `.astro` file reported parser/config limitations in this repo (not blocking the build). ⚠️
- Ran `npm run lint` which failed due to the repo's ESLint configuration (ESLint v9 expects `eslint.config.*`), an existing tooling issue not introduced by this PR. ⚠️
- Attempted `npx playwright --version` to capture visual verification but the environment blocked the registry request, so no browser screenshot was captured (environment limitation). ⚠️

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00016edaac8328b4f671ba220424ea)