### PR TITLE
Redesign portfolio cards as commercial case studies

### DIFF
--- a/src/components/FeaturedCases.astro
+++ b/src/components/FeaturedCases.astro
@@ -2,6 +2,7 @@
 import ProjectCard from './ProjectCard.astro';
 import SectionHeader from './SectionHeader.astro';
 import VisualBadge from './VisualBadge.astro';
+import { DEMO_WHATSAPP_MESSAGE, waLink } from '../lib/contact';
 
 const { projects = [] } = Astro.props;
 const projectBadges = [
@@ -16,9 +17,9 @@ const projectBadges = [
   <div class="flex flex-col gap-6 md:flex-row md:items-end md:justify-between">
     <div class="space-y-5">
       <SectionHeader
-        eyebrow="Casos y demos"
-        title="Proyectos que muestran criterio comercial"
-        description="No son solo piezas visuales: cada caso está pensado para explicar un negocio, resolver una fricción y acercar al visitante a una acción concreta."
+        eyebrow="Portfolio"
+        title="Proyectos y demos pensados para vender mejor"
+        description="No son solo sitios lindos: cada pieza está diseñada para ordenar el mensaje, reducir fricción y llevar al usuario hacia una consulta o acción concreta."
         icon="folder"
       />
       <div class="flex flex-wrap gap-2">
@@ -50,6 +51,8 @@ const projectBadges = [
           impacto={p.data.impacto}
           ctaLabel={p.data.ctaLabel}
           priority={p.data.priority}
+          demoUrl={p.data.demoUrl}
+          repoUrl={p.data.repoUrl}
         />
       ))}
     </div>
@@ -58,4 +61,13 @@ const projectBadges = [
       Todavía no hay casos destacados cargados, pero el portfolio queda preparado para mostrarlos apenas se marque un proyecto como destacado.
     </div>
   )}
+
+  <div class="mt-10 flex flex-col gap-4 rounded-3xl border border-line bg-surface-glass p-5 shadow-premium backdrop-blur sm:flex-row sm:items-center sm:justify-between">
+    <p class="text-sm leading-6 text-muted-soft">
+      <span class="font-semibold text-slate-50">¿Querés algo parecido para tu negocio?</span> Mandame tu Instagram o web y te propongo una demo con foco comercial.
+    </p>
+    <a href={waLink(DEMO_WHATSAPP_MESSAGE)} target="_blank" rel="noreferrer" class="premium-button inline-flex w-fit items-center justify-center gap-2 rounded-2xl bg-brand-gradient px-5 py-3 text-sm font-semibold text-white shadow-glow">
+      Pedir una demo <span aria-hidden="true">↗</span>
+    </a>
+  </div>
 </section>

--- a/src/components/ProjectCard.astro
+++ b/src/components/ProjectCard.astro
@@ -1,8 +1,10 @@
 ---
 import Badge from './Badge.astro';
-import { projectCoverImage } from '../lib/projectGallery';
+import { projectVisualAsset } from '../lib/projectGallery';
 
 const FEATURE_LIMIT = 4;
+const VISUAL_PILL_LIMIT = 4;
+const STACK_LIMIT = 5;
 const {
   title,
   resumen,
@@ -18,8 +20,10 @@ const {
   status = '',
   features = [],
   impacto = '',
-  ctaLabel = 'Ver caso',
+  ctaLabel = 'Abrir caso',
   priority = 0,
+  demoUrl = '',
+  repoUrl = '',
 } = Astro.props;
 
 const statusLabels = {
@@ -34,49 +38,88 @@ const statusTone = {
   concepto: 'violet',
 };
 
-const chips = Array.isArray(features) && features.length > 0 ? features : stack;
+const categoryRules = [
+  { label: 'WhatsApp', terms: ['whatsapp', 'consulta', 'contacto'] },
+  { label: 'Agenda', terms: ['agenda', 'turno', 'reserva', 'reservas'] },
+  { label: 'Panel admin', terms: ['panel', 'admin', 'editable', 'dashboard', 'stock', 'firebase'] },
+  { label: 'Web corporativa', terms: ['corporativa', 'logística', 'empresa'] },
+  { label: 'Demo comercial', terms: ['demo', 'veterinaria', 'barber', 'restaurante', 'gastronomía'] },
+  { label: 'Landing', terms: ['landing', 'web', 'servicios'] },
+  { label: 'E-commerce', terms: ['e-commerce', 'tienda', 'catalogo', 'catálogo'] },
+  { label: 'Automatización', terms: ['automatización', 'automatizacion', 'operativa', 'movimientos'] },
+];
+
 const commercialType = tipo || sector || 'Caso comercial';
 const benefit = impacto || resultado;
-const displayCover = projectCoverImage({ slug, thumbnail, cover });
-const hasGenericCover = !displayCover || displayCover === '/og-default.png';
+const visual = projectVisualAsset({ slug, thumbnail, cover });
+const hasImage = visual.hasImage;
 const isStarProject = Number(priority) >= 120;
+const caseUrl = `/proyectos/${slug}`;
+const titleInitials = String(title ?? 'MD')
+  .split(/[\s–-]+/)
+  .filter(Boolean)
+  .slice(0, 2)
+  .map((word) => word[0]?.toUpperCase())
+  .join('') || 'MD';
+const normalizedSignals = [commercialType, sector, resumen, problema, solucion, ...features, ...stack]
+  .filter(Boolean)
+  .map((item) => String(item).toLowerCase());
+const categoryBadges = categoryRules
+  .filter((rule) => normalizedSignals.some((signal) => rule.terms.some((term) => signal.includes(term))))
+  .map((rule) => rule.label);
+const visualPills = [...new Set([...categoryBadges, ...features, ...stack])].slice(0, VISUAL_PILL_LIMIT);
+const primaryChips = Array.isArray(features) && features.length > 0 ? features : categoryBadges;
+const stackChips = Array.isArray(stack) ? stack.slice(0, STACK_LIMIT) : [];
+const copyFocus = solucion || problema;
 ---
-<a
-  href={`/proyectos/${slug}`}
-  class="group premium-interactive block h-full overflow-hidden rounded-3xl border border-line bg-surface-glow shadow-premium backdrop-blur hover:border-line-strong hover:shadow-premium-hover focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-cyan-electric"
+<article
+  class="group premium-interactive flex h-full flex-col overflow-hidden rounded-3xl border border-line bg-surface-glow shadow-premium backdrop-blur hover:-translate-y-1 hover:border-line-strong hover:shadow-premium-hover"
 >
   <div class="relative overflow-hidden border-b border-line bg-ink/60">
-    {hasGenericCover ? (
-      <div class="relative aspect-[16/10] overflow-hidden bg-ink">
-        <div class="absolute inset-0 bg-premium-grid bg-[length:2rem_2rem] opacity-45"></div>
-        <div class="absolute -left-16 top-6 h-40 w-40 rounded-full bg-cyan-electric/20 blur-3xl transition duration-500 group-hover:bg-cyan-electric/30"></div>
-        <div class="absolute -right-14 bottom-0 h-44 w-44 rounded-full bg-brand-violet/20 blur-3xl transition duration-500 group-hover:bg-brand-violet/30"></div>
-        <div class="relative flex h-full flex-col justify-between p-5">
-          <div class="flex items-center gap-2 text-[0.7rem] font-semibold uppercase tracking-[0.24em] text-muted-soft">
-            <span class="status-dot !h-2 !w-2 bg-brand-success text-emerald-300 shadow-[0_0_18px_rgba(52,211,153,0.85)]"></span>
-            Case preview
+    {hasImage ? (
+      <a href={caseUrl} class="block focus-visible:outline-none" aria-label={`Abrir caso de ${title}`}>
+        <img
+          src={visual.src}
+          alt={`Visual del proyecto ${title}`}
+          class="aspect-[16/10] w-full object-cover opacity-90 transition duration-500 group-hover:scale-[1.035] group-hover:opacity-100"
+          loading="lazy"
+          decoding="async"
+        />
+      </a>
+    ) : (
+      <a href={caseUrl} class="block focus-visible:outline-none" aria-label={`Abrir caso de ${title}`}>
+        <div class="relative aspect-[16/10] overflow-hidden bg-ink">
+          <div class="absolute inset-0 bg-premium-grid bg-[length:2rem_2rem] opacity-50"></div>
+          <div class="absolute -left-16 top-4 h-44 w-44 rounded-full bg-cyan-electric/25 blur-3xl transition duration-500 group-hover:bg-cyan-electric/35"></div>
+          <div class="absolute -right-16 bottom-0 h-48 w-48 rounded-full bg-brand-violet/25 blur-3xl transition duration-500 group-hover:bg-brand-violet/35"></div>
+          <div class="absolute inset-x-5 top-5 flex items-center gap-2 rounded-2xl border border-line bg-surface-glass px-3 py-2 shadow-premium backdrop-blur">
+            <span class="h-2.5 w-2.5 rounded-full bg-rose-400/90"></span>
+            <span class="h-2.5 w-2.5 rounded-full bg-amber-300/90"></span>
+            <span class="h-2.5 w-2.5 rounded-full bg-brand-success/90"></span>
+            <span class="ml-2 h-2 flex-1 rounded-full bg-slate-700/80"></span>
           </div>
-          <div class="rounded-2xl border border-line bg-surface-glass p-4 shadow-premium backdrop-blur">
-            <p class="text-xs font-semibold uppercase tracking-[0.2em] text-cyan-electric">{commercialType}</p>
-            <p class="mt-2 line-clamp-2 text-lg font-semibold leading-tight text-slate-50">{title}</p>
-            <div class="mt-4 grid grid-cols-3 gap-2" aria-hidden="true">
-              <span class="h-2 rounded-full bg-cyan-electric/70"></span>
-              <span class="h-2 rounded-full bg-brand-blue/60"></span>
-              <span class="h-2 rounded-full bg-brand-violet/60"></span>
+          <div class="relative flex h-full flex-col justify-end p-5 pt-16">
+            <div class="rounded-3xl border border-line bg-surface-glass p-4 shadow-premium backdrop-blur">
+              <div class="flex items-center justify-between gap-3">
+                <div class="flex h-14 w-14 shrink-0 items-center justify-center rounded-2xl border border-cyan-electric/25 bg-cyan-electric/10 text-lg font-black tracking-tight text-cyan-100 shadow-[0_0_34px_rgba(34,211,238,0.18)]">
+                  {titleInitials}
+                </div>
+                <p class="text-right text-[0.68rem] font-semibold uppercase tracking-[0.22em] text-muted-soft">Mini caso</p>
+              </div>
+              <p class="mt-4 text-xs font-semibold uppercase tracking-[0.2em] text-cyan-electric">{commercialType}</p>
+              <p class="mt-2 line-clamp-2 text-lg font-semibold leading-tight text-slate-50">{title}</p>
+              <div class="mt-4 flex flex-wrap gap-2" aria-hidden="true">
+                {visualPills.map((item: string) => (
+                  <span class="rounded-full border border-line bg-ink/55 px-2 py-1 text-[0.68rem] font-semibold text-muted-bright">{item}</span>
+                ))}
+              </div>
             </div>
           </div>
         </div>
-      </div>
-    ) : (
-      <img
-        src={displayCover}
-        alt={`Portada de ${title}`}
-        class="aspect-[16/10] w-full object-cover opacity-90 transition duration-500 group-hover:scale-[1.03] group-hover:opacity-100"
-        loading="lazy"
-        decoding="async"
-      />
+      </a>
     )}
-    <div class="absolute inset-x-0 bottom-0 h-24 bg-gradient-to-t from-ink/90 to-transparent"></div>
+
+    <div class="pointer-events-none absolute inset-x-0 bottom-0 h-24 bg-gradient-to-t from-ink/95 to-transparent"></div>
     <div class="absolute left-4 top-4 flex flex-wrap gap-2">
       {isStarProject && <Badge label="Proyecto estrella" tone="success" />}
       <Badge label={commercialType} tone="cyan" />
@@ -84,41 +127,62 @@ const isStarProject = Number(priority) >= 120;
     </div>
   </div>
 
-  <div class="flex min-h-[23rem] flex-col p-5 sm:p-6">
+  <div class="relative z-10 flex min-h-[24rem] flex-1 flex-col p-5 sm:p-6">
     <div>
-      <p class="text-xs font-semibold uppercase tracking-[0.22em] text-muted">{sector}</p>
-      <h3 class="mt-2 text-xl font-semibold tracking-tight text-slate-50 transition group-hover:text-cyan-electric">{title}</h3>
-      {resumen && <p class="mt-3 text-sm leading-6 text-muted-soft">{resumen}</p>}
+      <p class="text-xs font-semibold uppercase tracking-[0.22em] text-muted">{sector || commercialType}</p>
+      <h3 class="mt-2 text-xl font-semibold tracking-tight text-slate-50 transition group-hover:text-cyan-electric">
+        <a href={caseUrl} class="focus-visible:outline-none">{title}</a>
+      </h3>
+      {resumen && <p class="mt-3 line-clamp-3 text-sm leading-6 text-muted-soft">{resumen}</p>}
     </div>
 
-    <div class="mt-5 space-y-3 text-sm leading-6">
-      {problema && (
-        <p class="rounded-2xl border border-line bg-ink/35 p-3 text-muted-soft">
-          <span class="font-semibold text-slate-50">Problema:</span> {problema}
-        </p>
-      )}
-      {solucion && (
-        <p class="rounded-2xl border border-line bg-ink/35 p-3 text-muted-soft">
-          <span class="font-semibold text-slate-50">Solución:</span> {solucion}
-        </p>
-      )}
-    </div>
+    {copyFocus && (
+      <div class="mt-5 rounded-2xl border border-line bg-ink/35 p-4 text-sm leading-6 text-muted-soft">
+        {problema && (
+          <p><span class="font-semibold text-slate-50">Problema:</span> {problema}</p>
+        )}
+        {solucion && (
+          <p class={problema ? 'mt-3 border-t border-line pt-3' : ''}><span class="font-semibold text-slate-50">Solución:</span> {solucion}</p>
+        )}
+      </div>
+    )}
 
-    <div class="mt-5 flex flex-wrap gap-2">
-      {chips.slice(0, FEATURE_LIMIT).map((item: string) => <Badge label={item} />)}
-    </div>
+    {primaryChips.length > 0 && (
+      <div class="mt-5 flex flex-wrap gap-2" aria-label="Categorías y funcionalidades">
+        {primaryChips.slice(0, FEATURE_LIMIT).map((item: string) => <Badge label={item} />)}
+      </div>
+    )}
 
     {benefit && (
       <p class="mt-5 rounded-2xl border border-brand-success/20 bg-brand-success/10 p-3 text-sm leading-6 text-emerald-100">
-        <span class="font-semibold">Beneficio:</span> {benefit}
+        <span class="font-semibold">Resultado / beneficio:</span> {benefit}
       </p>
     )}
 
-    <div class="mt-auto pt-6">
-      <span class="inline-flex items-center gap-2 text-sm font-semibold text-cyan-electric">
+    {stackChips.length > 0 && (
+      <div class="mt-5 border-t border-line pt-4">
+        <p class="text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-muted">Tecnologías</p>
+        <div class="mt-2 flex flex-wrap gap-2">
+          {stackChips.map((item: string) => <Badge label={item} tone="violet" />)}
+        </div>
+      </div>
+    )}
+
+    <div class="mt-auto flex flex-wrap items-center gap-3 pt-6">
+      <a href={caseUrl} class="premium-button inline-flex items-center gap-2 rounded-2xl bg-brand-gradient px-4 py-2.5 text-sm font-semibold text-white shadow-glow">
         {ctaLabel}
-        <span aria-hidden="true" class="transition duration-300 group-hover:translate-x-1.5">→</span>
-      </span>
+        <span aria-hidden="true" class="transition duration-300 group-hover:translate-x-1">→</span>
+      </a>
+      {demoUrl && (
+        <a href={demoUrl} target="_blank" rel="noreferrer" class="inline-flex items-center gap-1.5 rounded-2xl border border-line bg-surface-glass px-4 py-2.5 text-sm font-semibold text-cyan-electric transition hover:border-line-strong hover:bg-surface-800/70">
+          Ver demo <span aria-hidden="true">↗</span>
+        </a>
+      )}
+      {!demoUrl && repoUrl && (
+        <a href={repoUrl} target="_blank" rel="noreferrer" class="inline-flex items-center gap-1.5 rounded-2xl border border-line bg-surface-glass px-4 py-2.5 text-sm font-semibold text-cyan-electric transition hover:border-line-strong hover:bg-surface-800/70">
+          Ver repo <span aria-hidden="true">↗</span>
+        </a>
+      )}
     </div>
   </div>
-</a>
+</article>

--- a/src/lib/projectGallery.ts
+++ b/src/lib/projectGallery.ts
@@ -1,5 +1,8 @@
-export const PROJECT_GALLERY_PATH = '/galeria';
-export const DEFAULT_PROJECT_IMAGE = '/og-default.png';
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+
+export const PROJECT_GALLERY_PATH = "/galeria";
+export const DEFAULT_PROJECT_IMAGE = "/og-default.png";
 
 export function projectThumbnailPath(slug: string) {
   return `${PROJECT_GALLERY_PATH}/${slug}.svg`;
@@ -14,8 +17,35 @@ export function projectCoverImage({
   thumbnail?: string;
   cover?: string;
 }) {
-  if (thumbnail) return thumbnail;
-  if (cover && cover !== DEFAULT_PROJECT_IMAGE) return cover;
-  if (slug) return projectThumbnailPath(slug);
-  return DEFAULT_PROJECT_IMAGE;
+  return projectVisualAsset({ slug, thumbnail, cover }).src;
+}
+
+export function projectVisualAsset({
+  slug,
+  thumbnail,
+  cover,
+}: {
+  slug?: string;
+  thumbnail?: string;
+  cover?: string;
+}) {
+  if (thumbnail) return { src: thumbnail, hasImage: true };
+  if (cover && cover !== DEFAULT_PROJECT_IMAGE)
+    return { src: cover, hasImage: true };
+
+  if (slug) {
+    const generatedThumbnail = projectThumbnailPath(slug);
+    const publicAssetPath = join(
+      process.cwd(),
+      "public",
+      "galeria",
+      `${slug}.svg`,
+    );
+
+    if (existsSync(publicAssetPath)) {
+      return { src: generatedThumbnail, hasImage: true };
+    }
+  }
+
+  return { src: DEFAULT_PROJECT_IMAGE, hasImage: false };
 }

--- a/src/pages/proyectos/index.astro
+++ b/src/pages/proyectos/index.astro
@@ -3,6 +3,7 @@ import BaseLayout from '../../layouts/BaseLayout.astro';
 import Container from '../../components/Container.astro';
 import ProjectCard from '../../components/ProjectCard.astro';
 import SectionHeader from '../../components/SectionHeader.astro';
+import { DEMO_WHATSAPP_MESSAGE, waLink } from '../../lib/contact';
 import { getCollection } from 'astro:content';
 
 const byCommercialPriority = (a, b) => {
@@ -25,9 +26,9 @@ const proyectos = (await getCollection('proyectos')).sort(byCommercialPriority);
   <Container class="py-14 sm:py-20">
     <div class="grid gap-8 lg:grid-cols-[minmax(0,1fr)_22rem] lg:items-end">
       <SectionHeader
-        eyebrow="Portfolio comercial"
-        title="Casos, demos y herramientas"
-        description="Cada proyecto muestra para qué negocio sirve, qué problema ayuda a ordenar y cómo una web puede guiar mejor la consulta."
+        eyebrow="Portfolio"
+        title="Proyectos y demos pensados para vender mejor"
+        description="No son solo sitios lindos: cada pieza está diseñada para ordenar el mensaje, reducir fricción y llevar al usuario hacia una consulta o acción concreta."
       />
       <div class="rounded-3xl border border-line bg-surface-glass p-5 text-sm leading-6 text-muted-soft shadow-premium backdrop-blur">
         <p class="font-semibold text-slate-50">Criterio de orden</p>
@@ -54,8 +55,20 @@ const proyectos = (await getCollection('proyectos')).sort(byCommercialPriority);
           impacto={p.data.impacto}
           ctaLabel={p.data.ctaLabel}
           priority={p.data.priority}
+          demoUrl={p.data.demoUrl}
+          repoUrl={p.data.repoUrl}
         />
       ))}
+    </div>
+
+    <div class="mt-10 flex flex-col gap-4 rounded-3xl border border-line bg-surface-glass p-5 shadow-premium backdrop-blur sm:flex-row sm:items-center sm:justify-between">
+      <div>
+        <p class="font-semibold text-slate-50">¿Querés algo parecido para tu negocio?</p>
+        <p class="mt-1 text-sm leading-6 text-muted-soft">Compartime tu Instagram, web o idea y te digo cómo convertirla en una demo accionable.</p>
+      </div>
+      <a href={waLink(DEMO_WHATSAPP_MESSAGE)} target="_blank" rel="noreferrer" class="premium-button inline-flex w-fit items-center justify-center gap-2 rounded-2xl bg-brand-gradient px-5 py-3 text-sm font-semibold text-white shadow-glow">
+        Pedir una demo <span aria-hidden="true">↗</span>
+      </a>
     </div>
   </Container>
 </BaseLayout>


### PR DESCRIPTION
### Motivation
- Make the projects section presentable as commercial mini case studies rather than tech-first text cards to improve conversion and perceived value. 
- Provide a resilient visual system so projects look premium even when no screenshot/cover is available. 
- Surface business-relevant fields (tipo, problema/solucion, impacto/resultado) and direct CTAs (demo/repo/WhatsApp) from existing MDX metadata without inventing metrics.

### Description
- Refactored `src/components/ProjectCard.astro` into a visual commercial case card that prioritizes thumbnail/mockup, title + sector/type, short copy, problem/solution microcopy, benefit/result, technology chips and clear CTAs (`Ver demo` / `Ver repo` / open case). 
- Added robust gallery/asset helpers in `src/lib/projectGallery.ts` (`projectVisualAsset` + `projectThumbnailPath`) so explicit thumbnails/covers are used first, public `/galeria/*.svg` thumbnails are used when present, and a dark HTML mockup fallback is rendered when no image exists. 
- Updated `src/components/FeaturedCases.astro` and `src/pages/proyectos/index.astro` to use the new card props (`demoUrl`, `repoUrl`), strengthen section copy/headline to a commercial framing, and add a WhatsApp CTA to request a similar demo. 
- Implemented lightweight category derivation and visual pills from existing metadata (features/stack/resumen) so badges like `Agenda`, `WhatsApp`, `Panel admin` appear automatically without extra fields.

### Testing
- `npm run build` completed successfully and generated the static output (`dist/`) with all pages including `/proyectos` and `/proyectos/[slug]`. 
- `git diff --check` returned no whitespace/merge issues after changes. 
- `npx prettier --write` formatted the TypeScript helper but could not infer a parser for `.astro` files in this environment because no Astro Prettier plugin is configured. 
- `npm run lint` reported a repo-level ESLint configuration issue (ESLint v9 cannot find an `eslint.config.*`), which is an existing tooling gap and not caused by the patch.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0003cbfa648328aa886e40df821c1b)