### PR TITLE
Improve final CTA and footer contact links

### DIFF
--- a/src/components/ContactCTA.astro
+++ b/src/components/ContactCTA.astro
@@ -1,56 +1,162 @@
 ---
+import Icon from './Icon.astro';
 import SectionHeader from './SectionHeader.astro';
 import VisualBadge from './VisualBadge.astro';
-import { waLink, AUDIT_WHATSAPP_MESSAGE } from '../lib/contact';
+import {
+  AUDIT_WHATSAPP_MESSAGE,
+  EMAIL,
+  INSTAGRAM_HANDLE,
+  INSTAGRAM_URL,
+  waLink,
+} from '../lib/contact';
 
 const {
   eyebrow = 'Próximo paso',
-  title = 'Pasame tu idea y vemos el mejor camino',
-  description = 'Mandame tu web, Instagram o idea por WhatsApp. Te respondo con ideas concretas: qué mostrar primero, qué fricción reducir y qué demo o web tendría más sentido.',
-  primaryLabel = 'Mandame mi web o Instagram',
+  title = 'Pasame tu idea y vemos cómo convertirla en una web que venda mejor',
+  description = 'Podés mandarme tu Instagram, web actual o una explicación corta del negocio. Te digo qué camino conviene: landing, demo comercial, web corporativa o sistema simple.',
+  primaryLabel = 'Enviar mensaje por WhatsApp',
   primaryMessage = AUDIT_WHATSAPP_MESSAGE,
-  secondaryLabel,
-  secondaryHref,
+  secondaryLabel = 'Ver proyectos',
+  secondaryHref = '/proyectos',
 } = Astro.props;
 
-const ctaBadges = [
-  { label: 'WhatsApp directo', icon: 'message', tone: 'cyan' },
-  { label: 'Idea o Instagram', icon: 'phone', tone: 'emerald' },
-  { label: 'Camino claro', icon: 'rocket', tone: 'violet' },
+const trustBadges = [
+  { label: 'Propuesta clara', icon: 'target', tone: 'cyan' },
+  { label: 'Repo + deploy', icon: 'code', tone: 'violet' },
+  { label: 'Pagos por hitos', icon: 'check', tone: 'emerald' },
+  { label: 'Soporte post-lanzamiento', icon: 'shield', tone: 'cyan' },
+  { label: 'Sin humo', icon: 'zap', tone: 'amber' },
 ];
+
+const contactMethods = [
+  {
+    label: 'WhatsApp',
+    description: 'Para cotizar rápido o pasarme tu idea.',
+    cta: 'Escribir',
+    href: waLink(primaryMessage),
+    icon: 'message',
+    external: true,
+    tone: 'from-cyan-electric/20 to-blue-electric/10',
+  },
+  INSTAGRAM_URL && {
+    label: 'Instagram',
+    description: 'Para ver contenido, demos y avances.',
+    cta: 'Abrir Instagram',
+    href: INSTAGRAM_URL,
+    icon: 'external',
+    external: true,
+    helper: INSTAGRAM_HANDLE,
+    tone: 'from-violet-electric/20 to-cyan-electric/10',
+  },
+  EMAIL && {
+    label: 'Email',
+    description: 'Para propuestas o archivos más detallados.',
+    cta: 'Enviar email',
+    href: `mailto:${EMAIL}`,
+    icon: 'mail',
+    external: false,
+    helper: EMAIL,
+    tone: 'from-emerald-400/15 to-cyan-electric/10',
+  },
+].filter(Boolean);
 ---
-<section class="py-16 text-center md:py-24">
-  <div class="premium-interactive halo-sweep relative overflow-hidden rounded-[2rem] border border-line bg-surface-glow p-8 shadow-premium backdrop-blur md:p-12">
-    <div class="absolute inset-x-10 -top-20 h-40 rounded-full bg-cyan-electric/20 blur-3xl" aria-hidden="true"></div>
-    <div class="absolute -bottom-24 right-0 h-44 w-44 rounded-full bg-brand-violet/20 blur-3xl" aria-hidden="true"></div>
-    <div class="relative mx-auto flex max-w-3xl flex-col items-center">
-      <SectionHeader
-        eyebrow={eyebrow}
-        title={title}
-        description={description}
-        icon="message"
-        align="center"
-      />
-      <div class="mt-5 flex flex-wrap justify-center gap-2">
-        {ctaBadges.map((badge) => <VisualBadge label={badge.label} icon={badge.icon} tone={badge.tone} />)}
-      </div>
-      <div class="mt-8 flex flex-col items-center justify-center gap-3 sm:flex-row">
-        <a
-          href={waLink(primaryMessage)}
-          target="_blank"
-          rel="noopener noreferrer"
-          class="premium-button inline-flex items-center justify-center rounded-2xl bg-brand-gradient px-6 py-3 text-sm font-semibold text-white shadow-glow hover:-translate-y-0.5 hover:shadow-premium-hover"
-        >
-          {primaryLabel}
-        </a>
-        {secondaryLabel && secondaryHref && (
+<section class="py-16 md:py-24">
+  <div class="premium-interactive halo-sweep relative overflow-hidden rounded-[2rem] border border-line bg-surface-glow p-5 shadow-premium backdrop-blur sm:p-7 md:p-10 lg:p-12">
+    <div class="absolute inset-x-8 -top-24 h-56 rounded-full bg-cyan-electric/20 blur-3xl" aria-hidden="true"></div>
+    <div class="absolute -bottom-28 right-0 h-56 w-56 rounded-full bg-brand-violet/20 blur-3xl" aria-hidden="true"></div>
+    <div class="absolute left-1/2 top-0 h-px w-3/4 -translate-x-1/2 bg-gradient-to-r from-transparent via-cyan-electric/60 to-transparent" aria-hidden="true"></div>
+
+    <div class="relative grid gap-9 lg:grid-cols-[minmax(0,1.05fr)_minmax(20rem,0.8fr)] lg:items-center">
+      <div>
+        <SectionHeader
+          eyebrow={eyebrow}
+          title={title}
+          description={description}
+          icon="message"
+          align="left"
+        />
+
+        <div class="mt-6 flex flex-wrap gap-2">
+          {trustBadges.map((badge) => <VisualBadge label={badge.label} icon={badge.icon} tone={badge.tone} />)}
+        </div>
+
+        <div class="mt-8 flex flex-col gap-3 sm:flex-row">
           <a
-            href={secondaryHref}
-            class="premium-button inline-flex items-center justify-center rounded-2xl border border-line bg-surface-glass px-6 py-3 text-sm font-semibold text-slate-50 hover:-translate-y-0.5 hover:border-line-strong hover:text-cyan-electric"
+            href={waLink(primaryMessage)}
+            target="_blank"
+            rel="noopener noreferrer"
+            class="premium-button inline-flex min-h-12 items-center justify-center gap-2 rounded-2xl bg-brand-gradient px-6 py-3 text-sm font-semibold text-white shadow-glow hover:-translate-y-0.5 hover:shadow-premium-hover sm:min-w-64"
           >
-            {secondaryLabel}
+            <Icon name="message" size="sm" />
+            {primaryLabel}
           </a>
-        )}
+          {secondaryLabel && secondaryHref && (
+            <a
+              href={secondaryHref}
+              class="premium-button inline-flex min-h-12 items-center justify-center gap-2 rounded-2xl border border-line bg-surface-glass px-6 py-3 text-sm font-semibold text-slate-50 hover:-translate-y-0.5 hover:border-line-strong hover:text-cyan-electric"
+            >
+              {secondaryLabel}
+              <Icon name="arrow" size="sm" />
+            </a>
+          )}
+        </div>
+
+        <div class="mt-7 grid gap-3 sm:grid-cols-3">
+          {contactMethods.map((method) => (
+            <a
+              href={method.href}
+              target={method.external ? '_blank' : undefined}
+              rel={method.external ? 'noopener noreferrer' : undefined}
+              class="group rounded-2xl border border-line bg-surface-glass p-4 text-left transition duration-300 hover:-translate-y-0.5 hover:border-line-strong hover:bg-surface-850/80"
+            >
+              <span class={`inline-flex size-10 items-center justify-center rounded-xl bg-gradient-to-br ${method.tone} text-cyan-100 ring-1 ring-white/10`}>
+                <Icon name={method.icon} size="sm" />
+              </span>
+              <span class="mt-3 block text-sm font-semibold text-slate-50">{method.label}</span>
+              {method.helper && <span class="mt-1 block truncate text-xs text-cyan-100/80">{method.helper}</span>}
+              <span class="mt-2 block text-xs leading-5 text-muted-soft">{method.description}</span>
+              <span class="mt-3 inline-flex items-center gap-1.5 text-xs font-semibold text-cyan-electric group-hover:text-cyan-100">
+                {method.cta}
+                <Icon name="arrow" size="sm" />
+              </span>
+            </a>
+          ))}
+        </div>
+      </div>
+
+      <div class="relative">
+        <div class="absolute -inset-4 rounded-[2rem] bg-gradient-to-br from-cyan-electric/15 via-blue-electric/10 to-violet-electric/15 blur-2xl" aria-hidden="true"></div>
+        <div class="relative overflow-hidden rounded-[1.75rem] border border-line-strong bg-ink/80 p-4 shadow-premium">
+          <div class="flex items-center justify-between border-b border-line pb-4">
+            <div class="flex items-center gap-2">
+              <span class="size-3 rounded-full bg-brand-success shadow-[0_0_1rem_rgba(52,211,153,0.55)]"></span>
+              <span class="text-xs font-semibold uppercase tracking-[0.18em] text-muted-soft">Chat inicial</span>
+            </div>
+            <span class="rounded-full border border-cyan-electric/20 bg-cyan-electric/10 px-3 py-1 text-[0.68rem] font-semibold uppercase tracking-[0.14em] text-cyan-100">WhatsApp-first</span>
+          </div>
+
+          <div class="space-y-4 py-5">
+            <div class="max-w-[86%] rounded-2xl rounded-tl-sm border border-line bg-surface-glass p-4 text-left">
+              <p class="text-sm leading-6 text-slate-100">Hola, tengo un negocio y quiero mejorar mi web…</p>
+              <p class="mt-2 text-xs text-muted">Cliente · 10:24</p>
+            </div>
+            <div class="ml-auto max-w-[88%] rounded-2xl rounded-tr-sm border border-cyan-electric/20 bg-cyan-electric/10 p-4 text-left">
+              <p class="text-sm leading-6 text-cyan-50">Perfecto, pasame tu Instagram o web actual y te digo qué conviene.</p>
+              <p class="mt-2 text-xs text-cyan-100/70">Marin.dev · respuesta guiada</p>
+            </div>
+          </div>
+
+          <div class="grid gap-3 border-t border-line pt-4 sm:grid-cols-2">
+            <div class="rounded-2xl border border-line bg-surface-glass p-3">
+              <p class="text-[0.68rem] font-semibold uppercase tracking-[0.16em] text-muted">Entrada</p>
+              <p class="mt-1 text-sm font-semibold text-slate-50">Instagram / web / idea</p>
+            </div>
+            <div class="rounded-2xl border border-line bg-surface-glass p-3">
+              <p class="text-[0.68rem] font-semibold uppercase tracking-[0.16em] text-muted">Salida</p>
+              <p class="mt-1 text-sm font-semibold text-slate-50">Camino y demo clara</p>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
   </div>

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,25 +1,40 @@
 ---
 import Container from './Container.astro';
+import Icon from './Icon.astro';
 import { EMAIL, GITHUB_URL, INSTAGRAM_HANDLE, INSTAGRAM_URL, LINKEDIN_URL, waLink } from '../lib/contact';
+
+const footerLinks = [
+  { label: 'Privacidad', href: '/politica-de-privacidad', icon: 'shield' },
+  { label: 'WhatsApp', href: waLink(), icon: 'message', external: true },
+  { label: `Instagram ${INSTAGRAM_HANDLE}`, href: INSTAGRAM_URL, icon: 'external', external: true },
+  { label: 'Email', href: `mailto:${EMAIL}`, icon: 'mail' },
+  { label: 'GitHub', href: GITHUB_URL, icon: 'code', external: true },
+  { label: 'LinkedIn', href: LINKEDIN_URL, icon: 'briefcase', external: true },
+].filter((link) => Boolean(link.href));
 ---
-<footer class="mt-20 border-t border-line bg-ink/70">
+<footer class="mt-20 border-t border-line bg-ink/75 backdrop-blur">
   <Container class="py-10 text-sm text-muted-soft">
-    <div class="grid gap-8 md:grid-cols-[1.2fr_1fr] md:items-center">
+    <div class="grid gap-8 md:grid-cols-[1.05fr_1fr] md:items-center">
       <div>
         <p class="text-base font-semibold text-slate-50">Marin.dev</p>
         <p class="mt-2 max-w-xl leading-6">
-          Webs rápidas, claras y listas para compartir por WhatsApp.
+          Demos web, landings y sistemas simples para convertir visitas en consultas, reservas o ventas.
         </p>
       </div>
 
-      <div class="flex flex-wrap gap-x-4 gap-y-2 md:justify-end">
-        <a href="/politica-de-privacidad" class="transition hover:text-cyan-100">Privacidad</a>
-        <a href={waLink()} class="transition hover:text-cyan-100" target="_blank" rel="noopener noreferrer">WhatsApp</a>
-        <a href={INSTAGRAM_URL} class="transition hover:text-cyan-100" target="_blank" rel="noopener noreferrer">Instagram {INSTAGRAM_HANDLE}</a>
-        <a href={`mailto:${EMAIL}`} class="transition hover:text-cyan-100">Email</a>
-        <a href={GITHUB_URL} class="transition hover:text-cyan-100" target="_blank" rel="noopener noreferrer">GitHub</a>
-        <a href={LINKEDIN_URL} class="transition hover:text-cyan-100" target="_blank" rel="noopener noreferrer">LinkedIn</a>
-      </div>
+      <nav class="flex flex-wrap gap-2 md:justify-end" aria-label="Links de contacto y sitio">
+        {footerLinks.map((link) => (
+          <a
+            href={link.href}
+            target={link.external ? '_blank' : undefined}
+            rel={link.external ? 'noopener noreferrer' : undefined}
+            class="inline-flex items-center gap-1.5 rounded-full border border-line bg-surface-glass px-3 py-1.5 text-xs font-medium transition hover:-translate-y-0.5 hover:border-line-strong hover:text-cyan-100"
+          >
+            <Icon name={link.icon} size="sm" />
+            <span>{link.label}</span>
+          </a>
+        ))}
+      </nav>
     </div>
 
     <div class="mt-8 flex flex-col gap-3 border-t border-line pt-6 text-xs text-muted sm:flex-row sm:items-center sm:justify-between">


### PR DESCRIPTION
### Motivation
- Strengthen the final conversion area so the next step is visually obvious and WhatsApp becomes the primary, low-friction action. 
- Make contact methods easier to scan and add trust signals without changing existing contact data or global behaviour. 

### Description
- Enhanced the final CTA component at `src/components/ContactCTA.astro` with new default copy, a WhatsApp-first primary CTA, a secondary project link, and a set of trust badges (`Propuesta clara`, `Repo + deploy`, `Pagos por hitos`, `Soporte post-lanzamiento`, `Sin humo`).
- Added contact method cards (WhatsApp, Instagram, Email) fed from the centralized `src/lib/contact.ts` helpers and messages so URLs and messages are not duplicated across files.
- Introduced a subtle decorative chat/mockup panel to the CTA to give context to the WhatsApp-first flow while keeping the layout compact and non-aggressive.
- Improved the footer at `src/components/Footer.astro` to use compact icon pills for privacy, WhatsApp, Instagram, Email, GitHub and LinkedIn while preserving copyright and privacy links.

### Testing
- Ran a full static build with `npm run build` and it completed successfully (generated 14 pages and sitemap). 
- Ran `npm run lint` which failed due to repository ESLint config expectations (ESLint v9 requires an `eslint.config.*` file), which is an existing repo/tooling issue and not caused by these UI changes.
- Attempted formatting with `npx prettier --write` but it reported no Astro parser/plugin configured in the environment; formatting was not applied for that reason.
- Attempted to run Playwright for screenshots but installing/playwright failed due to a `403` from the npm registry so automated visual tests/screenshots were not available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a009789c2848328b8bc980ec35144eb)