### PR TITLE
Add reusable project visual system and optional project metadata

### DIFF
--- a/docs/portfolio-projects.md
+++ b/docs/portfolio-projects.md
@@ -1,0 +1,73 @@
+# Portfolio projects workflow
+
+Los proyectos del portfolio viven como archivos MDX en `src/content/proyectos`. El esquema está en `src/content/config.ts` y todos los campos visuales nuevos son opcionales para que los casos viejos sigan funcionando.
+
+## Cómo agregar un proyecto nuevo
+
+1. Crear `src/content/proyectos/mi-proyecto.mdx`.
+2. Completar los campos obligatorios actuales: `title`, `sector`, `rol`, `stack`, `fecha`, `resumen`, `problema` y `solucion`.
+3. Agregar solo la metadata comercial que ayude a presentar mejor el caso.
+4. Ejecutar `npm run build` para validar frontmatter, rutas y render.
+
+## Metadata visual opcional
+
+Estos campos mejoran la tarjeta sin obligar a crear una imagen personalizada:
+
+```yaml
+category: "Sistema / panel"
+businessType: "Comercio con stock"
+resultLabel: "Demo lista para validar el flujo operativo."
+highlight: "Ordena productos, compras y señales de reposición."
+visualTone: "cyan"
+badges:
+  - Dashboard
+  - Stock
+  - Compras
+  - Datos POS
+image: "/galeria/mi-proyecto.png"
+demoUrl: "https://ejemplo.com"
+caseUrl: "/proyectos/mi-proyecto"
+featured: true
+priority: 80
+```
+
+### Campos recomendados
+
+- `category`: rubro visual del proyecto. Ejemplos: `Veterinaria`, `Barbería`, `Gastronomía`, `Sistema / panel`, `Bienestar`, `Corporativo` o `Landing comercial`.
+- `businessType`: lectura comercial más concreta del cliente o vertical.
+- `resultLabel`: beneficio corto que se muestra como resultado de la card.
+- `highlight`: frase clave de negocio; reemplaza el bloque problema/solución dentro de la card cuando existe.
+- `visualTone`: tono visual del fallback. Valores válidos: `cyan`, `violet`, `emerald`, `amber`, `rose`, `neutral`.
+- `badges`: 2 a 4 chips comerciales visibles en la card y en el fallback.
+- `image`: asset opcional para la tarjeta. Puede ser local (`/galeria/demo.png`) o remoto.
+- `featured`: pone el proyecto arriba en los listados destacados.
+- `priority`: ordena casos con más peso comercial; números mayores aparecen antes.
+
+## Cómo funcionan los fallback visuals
+
+`ProjectCard.astro` usa `src/lib/projectVisuals.ts` para generar una visual si falta `image`, `thumbnail` o `cover` útil. El fallback combina:
+
+- ícono por categoría,
+- iniciales del título,
+- gradiente según `visualTone`,
+- badges explícitos o inferidos,
+- frame sutil tipo navegador.
+
+Esto permite cargar demos nuevas con metadata mínima y mantener una estética premium consistente sin diseñar una portada manual para cada caso.
+
+## Orden de prioridad de imágenes
+
+La tarjeta intenta mostrar imagen en este orden:
+
+1. `image`, si está definido y no es `/og-default.png`.
+2. `thumbnail`, si está definido.
+3. `cover`, si está definido y no es `/og-default.png`.
+4. `/galeria/<slug>.svg`, si existe en `public/galeria`.
+5. Fallback visual generado por metadata.
+
+## Buenas prácticas
+
+- No inventar métricas: usar `resultLabel` o `impacto` cualitativo si no hay datos medidos.
+- Priorizar beneficios de negocio antes que stack técnico.
+- Usar entre 2 y 4 badges para evitar ruido visual.
+- Elegir `featured: true` solo para casos fuertes comercialmente o visualmente.

--- a/src/components/FeaturedCases.astro
+++ b/src/components/FeaturedCases.astro
@@ -41,11 +41,18 @@ const projectBadges = [
           slug={p.slug}
           cover={p.data.cover}
           thumbnail={p.data.thumbnail}
+          image={p.data.image}
           resultado={p.data.resultado}
           problema={p.data.problema}
           solucion={p.data.solucion}
           tipo={p.data.tipo}
           sector={p.data.sector}
+          category={p.data.category}
+          businessType={p.data.businessType}
+          resultLabel={p.data.resultLabel}
+          highlight={p.data.highlight}
+          visualTone={p.data.visualTone}
+          badges={p.data.badges}
           status={p.data.status}
           features={p.data.features}
           impacto={p.data.impacto}
@@ -53,6 +60,7 @@ const projectBadges = [
           priority={p.data.priority}
           demoUrl={p.data.demoUrl}
           repoUrl={p.data.repoUrl}
+          caseUrl={p.data.caseUrl}
         />
       ))}
     </div>

--- a/src/components/ProjectCard.astro
+++ b/src/components/ProjectCard.astro
@@ -1,9 +1,9 @@
 ---
 import Badge from './Badge.astro';
 import { projectVisualAsset } from '../lib/projectGallery';
+import { getProjectVisual } from '../lib/projectVisuals';
 
 const FEATURE_LIMIT = 4;
-const VISUAL_PILL_LIMIT = 4;
 const STACK_LIMIT = 5;
 const {
   title,
@@ -12,11 +12,18 @@ const {
   slug,
   cover = '/og-default.png',
   thumbnail = '',
+  image = '',
   resultado = '',
   problema = '',
   solucion = '',
   tipo = '',
   sector = '',
+  category = '',
+  businessType = '',
+  resultLabel = '',
+  highlight = '',
+  visualTone = '',
+  badges = [],
   status = '',
   features = [],
   impacto = '',
@@ -24,6 +31,7 @@ const {
   priority = 0,
   demoUrl = '',
   repoUrl = '',
+  caseUrl = '',
 } = Astro.props;
 
 const statusLabels = {
@@ -49,35 +57,47 @@ const categoryRules = [
   { label: 'Automatización', terms: ['automatización', 'automatizacion', 'operativa', 'movimientos'] },
 ];
 
-const commercialType = tipo || sector || 'Caso comercial';
-const benefit = impacto || resultado;
-const visual = projectVisualAsset({ slug, thumbnail, cover });
+const visualSystem = getProjectVisual({
+  title,
+  category,
+  businessType,
+  visualTone,
+  badges,
+  features,
+  stack,
+  sector,
+  tipo,
+  resumen,
+});
+const visualStyles = visualSystem.styles;
+const commercialType = category || tipo || sector || visualSystem.category.label || 'Caso comercial';
+const businessLabel = businessType || sector || commercialType;
+const benefit = resultLabel || highlight || impacto || resultado;
+const visual = projectVisualAsset({ slug, thumbnail, cover, image });
 const hasImage = visual.hasImage;
 const isStarProject = Number(priority) >= 120;
-const caseUrl = `/proyectos/${slug}`;
-const titleInitials = String(title ?? 'MD')
-  .split(/[\s–-]+/)
-  .filter(Boolean)
-  .slice(0, 2)
-  .map((word) => word[0]?.toUpperCase())
-  .join('') || 'MD';
+const resolvedCaseUrl = caseUrl || `/proyectos/${slug}`;
 const normalizedSignals = [commercialType, sector, resumen, problema, solucion, ...features, ...stack]
   .filter(Boolean)
   .map((item) => String(item).toLowerCase());
 const categoryBadges = categoryRules
   .filter((rule) => normalizedSignals.some((signal) => rule.terms.some((term) => signal.includes(term))))
   .map((rule) => rule.label);
-const visualPills = [...new Set([...categoryBadges, ...features, ...stack])].slice(0, VISUAL_PILL_LIMIT);
-const primaryChips = Array.isArray(features) && features.length > 0 ? features : categoryBadges;
+const visualPills = visualSystem.badges;
+const primaryChips = Array.isArray(badges) && badges.length > 0
+  ? badges
+  : Array.isArray(features) && features.length > 0
+    ? features
+    : categoryBadges;
 const stackChips = Array.isArray(stack) ? stack.slice(0, STACK_LIMIT) : [];
-const copyFocus = solucion || problema;
+const copyFocus = highlight || solucion || problema;
 ---
 <article
   class="group premium-interactive flex h-full flex-col overflow-hidden rounded-3xl border border-line bg-surface-glow shadow-premium backdrop-blur hover:-translate-y-1 hover:border-line-strong hover:shadow-premium-hover"
 >
   <div class="relative overflow-hidden border-b border-line bg-ink/60">
     {hasImage ? (
-      <a href={caseUrl} class="block focus-visible:outline-none" aria-label={`Abrir caso de ${title}`}>
+      <a href={resolvedCaseUrl} class="block focus-visible:outline-none" aria-label={`Abrir caso de ${title}`}>
         <img
           src={visual.src}
           alt={`Visual del proyecto ${title}`}
@@ -87,30 +107,35 @@ const copyFocus = solucion || problema;
         />
       </a>
     ) : (
-      <a href={caseUrl} class="block focus-visible:outline-none" aria-label={`Abrir caso de ${title}`}>
-        <div class="relative aspect-[16/10] overflow-hidden bg-ink">
-          <div class="absolute inset-0 bg-premium-grid bg-[length:2rem_2rem] opacity-50"></div>
-          <div class="absolute -left-16 top-4 h-44 w-44 rounded-full bg-cyan-electric/25 blur-3xl transition duration-500 group-hover:bg-cyan-electric/35"></div>
-          <div class="absolute -right-16 bottom-0 h-48 w-48 rounded-full bg-brand-violet/25 blur-3xl transition duration-500 group-hover:bg-brand-violet/35"></div>
+      <a href={resolvedCaseUrl} class="block focus-visible:outline-none" aria-label={`Abrir caso de ${title}`}>
+        <div class={`relative aspect-[16/10] overflow-hidden bg-ink ${visualStyles.gradient}`}>
+          <div class="absolute inset-0 bg-premium-grid bg-[length:2rem_2rem] opacity-45"></div>
+          <div class={`absolute -left-16 top-4 h-44 w-44 rounded-full blur-3xl transition duration-500 group-hover:opacity-90 ${visualStyles.glowPrimary}`}></div>
+          <div class={`absolute -right-16 bottom-0 h-48 w-48 rounded-full blur-3xl transition duration-500 group-hover:opacity-90 ${visualStyles.glowSecondary}`}></div>
           <div class="absolute inset-x-5 top-5 flex items-center gap-2 rounded-2xl border border-line bg-surface-glass px-3 py-2 shadow-premium backdrop-blur">
             <span class="h-2.5 w-2.5 rounded-full bg-rose-400/90"></span>
             <span class="h-2.5 w-2.5 rounded-full bg-amber-300/90"></span>
             <span class="h-2.5 w-2.5 rounded-full bg-brand-success/90"></span>
             <span class="ml-2 h-2 flex-1 rounded-full bg-slate-700/80"></span>
+            <span class={`h-2 w-12 rounded-full ${visualStyles.line}`}></span>
           </div>
           <div class="relative flex h-full flex-col justify-end p-5 pt-16">
             <div class="rounded-3xl border border-line bg-surface-glass p-4 shadow-premium backdrop-blur">
               <div class="flex items-center justify-between gap-3">
-                <div class="flex h-14 w-14 shrink-0 items-center justify-center rounded-2xl border border-cyan-electric/25 bg-cyan-electric/10 text-lg font-black tracking-tight text-cyan-100 shadow-[0_0_34px_rgba(34,211,238,0.18)]">
-                  {titleInitials}
+                <div class={`flex h-14 w-14 shrink-0 items-center justify-center rounded-2xl border text-lg font-black tracking-tight ${visualStyles.iconShell}`}>
+                  <span aria-hidden="true" class="text-xl leading-none">{visualSystem.category.icon}</span>
+                  <span class="sr-only">{visualSystem.initials}</span>
                 </div>
-                <p class="text-right text-[0.68rem] font-semibold uppercase tracking-[0.22em] text-muted-soft">Mini caso</p>
+                <div class="text-right">
+                  <p class="text-[0.68rem] font-semibold uppercase tracking-[0.22em] text-muted-soft">Mini caso</p>
+                  <p class={`mt-1 text-xs font-semibold ${visualStyles.accentText}`}>{visualSystem.initials}</p>
+                </div>
               </div>
-              <p class="mt-4 text-xs font-semibold uppercase tracking-[0.2em] text-cyan-electric">{commercialType}</p>
+              <p class={`mt-4 text-xs font-semibold uppercase tracking-[0.2em] ${visualStyles.accentText}`}>{commercialType}</p>
               <p class="mt-2 line-clamp-2 text-lg font-semibold leading-tight text-slate-50">{title}</p>
               <div class="mt-4 flex flex-wrap gap-2" aria-hidden="true">
                 {visualPills.map((item: string) => (
-                  <span class="rounded-full border border-line bg-ink/55 px-2 py-1 text-[0.68rem] font-semibold text-muted-bright">{item}</span>
+                  <span class={`rounded-full border px-2 py-1 text-[0.68rem] font-semibold ${visualStyles.chip}`}>{item}</span>
                 ))}
               </div>
             </div>
@@ -129,20 +154,26 @@ const copyFocus = solucion || problema;
 
   <div class="relative z-10 flex min-h-[24rem] flex-1 flex-col p-5 sm:p-6">
     <div>
-      <p class="text-xs font-semibold uppercase tracking-[0.22em] text-muted">{sector || commercialType}</p>
+      <p class="text-xs font-semibold uppercase tracking-[0.22em] text-muted">{businessLabel}</p>
       <h3 class="mt-2 text-xl font-semibold tracking-tight text-slate-50 transition group-hover:text-cyan-electric">
-        <a href={caseUrl} class="focus-visible:outline-none">{title}</a>
+        <a href={resolvedCaseUrl} class="focus-visible:outline-none">{title}</a>
       </h3>
       {resumen && <p class="mt-3 line-clamp-3 text-sm leading-6 text-muted-soft">{resumen}</p>}
     </div>
 
     {copyFocus && (
       <div class="mt-5 rounded-2xl border border-line bg-ink/35 p-4 text-sm leading-6 text-muted-soft">
-        {problema && (
-          <p><span class="font-semibold text-slate-50">Problema:</span> {problema}</p>
-        )}
-        {solucion && (
-          <p class={problema ? 'mt-3 border-t border-line pt-3' : ''}><span class="font-semibold text-slate-50">Solución:</span> {solucion}</p>
+        {highlight ? (
+          <p><span class="font-semibold text-slate-50">Clave:</span> {highlight}</p>
+        ) : (
+          <>
+            {problema && (
+              <p><span class="font-semibold text-slate-50">Problema:</span> {problema}</p>
+            )}
+            {solucion && (
+              <p class={problema ? 'mt-3 border-t border-line pt-3' : ''}><span class="font-semibold text-slate-50">Solución:</span> {solucion}</p>
+            )}
+          </>
         )}
       </div>
     )}
@@ -169,7 +200,7 @@ const copyFocus = solucion || problema;
     )}
 
     <div class="mt-auto flex flex-wrap items-center gap-3 pt-6">
-      <a href={caseUrl} class="premium-button inline-flex items-center gap-2 rounded-2xl bg-brand-gradient px-4 py-2.5 text-sm font-semibold text-white shadow-glow">
+      <a href={resolvedCaseUrl} class="premium-button inline-flex items-center gap-2 rounded-2xl bg-brand-gradient px-4 py-2.5 text-sm font-semibold text-white shadow-glow">
         {ctaLabel}
         <span aria-hidden="true" class="transition duration-300 group-hover:translate-x-1">→</span>
       </a>

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -16,6 +16,16 @@ const proyectos = defineCollection({
     demoUrl: z.string().url().optional(),
     cover: z.string().optional(),
     thumbnail: z.string().optional(),
+    image: z.string().optional(),
+    category: z.string().optional(),
+    businessType: z.string().optional(),
+    resultLabel: z.string().optional(),
+    highlight: z.string().optional(),
+    visualTone: z
+      .enum(["cyan", "violet", "emerald", "amber", "rose", "neutral"])
+      .optional(),
+    badges: z.array(z.string()).optional(),
+    caseUrl: z.string().optional(),
     tipo: z.string().optional(),
     idealPara: z.string().optional(),
     features: z.array(z.string()).optional(),

--- a/src/content/proyectos/Agencia_ariel.mdx
+++ b/src/content/proyectos/Agencia_ariel.mdx
@@ -3,6 +3,15 @@ title: "Agencia Ariel – Soluciones Logísticas Integrales"
 tipo: "Web corporativa"
 sector: "Depósito / Transporte"
 idealPara: "Empresas logísticas que necesitan transmitir confianza y ordenar consultas comerciales."
+category: "Corporativo"
+businessType: "Logística / transporte"
+visualTone: "neutral"
+badges:
+  - Servicios
+  - Firebase
+  - Contacto
+  - Mobile
+highlight: "Ordena la propuesta de una empresa tradicional en una web confiable y consultable."
 rol: "Desarrollador Frontend"
 stack:
   - HTML5

--- a/src/content/proyectos/brasa-23.mdx
+++ b/src/content/proyectos/brasa-23.mdx
@@ -3,6 +3,15 @@ title: "Brasa 23 – Demo restaurante"
 tipo: "Demo comercial"
 sector: "Gastronomía / Restaurante"
 idealPara: "Restaurantes, parrillas y cafeterías que quieren mostrar carta, reservas y contacto desde una web rápida."
+category: "Gastronomía"
+businessType: "Restaurante / parrilla"
+visualTone: "amber"
+badges:
+  - Carta
+  - Reserva
+  - Pedido
+  - Ubicación
+highlight: "Centraliza carta, ambiente y contacto para no perder intención de compra."
 rol: "Diseño UI y desarrollo Frontend"
 stack:
   - HTML

--- a/src/content/proyectos/cristal-sagrado.mdx
+++ b/src/content/proyectos/cristal-sagrado.mdx
@@ -3,6 +3,16 @@ title: "Cristal Sagrado – Web con contenido editable"
 tipo: "Web con contenido editable"
 sector: "Servicios / Bienestar"
 idealPara: "Servicios personales que necesitan una web editable y un canal directo de consultas."
+category: "Bienestar"
+businessType: "Servicios personales"
+visualTone: "rose"
+badges:
+  - Web editable
+  - Servicios
+  - Consultas
+  - Marca cuidada
+highlight: "Una web editable para sostener una marca de servicios sin depender de cambios manuales."
+image: "https://cristal-sagrado.com/favicon_io/cristal_sagrado.png"
 rol: "Desarrollador Frontend"
 stack:
   - Astro

--- a/src/content/proyectos/noir-barber-studio.mdx
+++ b/src/content/proyectos/noir-barber-studio.mdx
@@ -3,6 +3,15 @@ title: "Noir Barber Studio – Demo para barbería"
 tipo: "Demo comercial"
 sector: "Barbería / Estética masculina"
 idealPara: "Barberías y estudios de estética que quieren una presencia premium con reservas y contacto directo."
+category: "Barbería"
+businessType: "Barbería / estética masculina"
+visualTone: "violet"
+badges:
+  - Reservas
+  - Servicios
+  - Estética premium
+  - Mobile-first
+highlight: "Convierte contenido de redes en una experiencia premium orientada a reservas."
 rol: "Diseño UI y desarrollo Frontend"
 stack:
   - Astro

--- a/src/content/proyectos/servicio-de-tarot.mdx
+++ b/src/content/proyectos/servicio-de-tarot.mdx
@@ -3,6 +3,15 @@ title: "Servicio de Tarot – Web informativa"
 tipo: "Web para recibir consultas"
 sector: "Servicios / Bienestar"
 idealPara: "Profesionales independientes que venden por confianza y necesitan llevar consultas a WhatsApp."
+category: "Bienestar"
+businessType: "Profesional independiente"
+visualTone: "rose"
+badges:
+  - WhatsApp
+  - Confianza
+  - Mobile-first
+  - SEO básico
+highlight: "Una presencia simple y directa para llevar visitantes hacia conversación por WhatsApp."
 rol: "Desarrollador Frontend"
 stack:
   - html

--- a/src/content/proyectos/smart-stock.mdx
+++ b/src/content/proyectos/smart-stock.mdx
@@ -3,6 +3,16 @@ title: "Smart Stock – Sistema funcional de inventario"
 tipo: "Proyecto estrella / sistema funcional"
 sector: "Inventario / Gestión interna"
 idealPara: "Comercios minoristas, minimarkets y operaciones con stock que necesitan pasar de planillas a un panel operativo navegable."
+category: "Sistema / panel"
+businessType: "Comercio con stock"
+visualTone: "cyan"
+badges:
+  - Dashboard
+  - Stock
+  - Compras
+  - Datos POS
+highlight: "Demuestra capacidad para construir herramientas operativas navegables, no solo landings."
+resultLabel: "Showcase funcional en modo solo lectura para validar producto y flujo operativo."
 rol: "Desarrollador Frontend"
 stack:
   - React

--- a/src/content/proyectos/vetcare.mdx
+++ b/src/content/proyectos/vetcare.mdx
@@ -3,6 +3,16 @@ title: "VetCare – Demo veterinaria con agenda y urgencias"
 tipo: "Demo comercial / sistema simple"
 sector: "Veterinarias"
 idealPara: "Clínicas veterinarias que quieren ordenar consultas, urgencias y turnos desde una experiencia web clara."
+category: "Veterinaria"
+businessType: "Clínica veterinaria"
+visualTone: "emerald"
+badges:
+  - Agenda
+  - Urgencias
+  - WhatsApp
+  - Portal mascota
+highlight: "Ordena turnos, urgencias y consultas en una experiencia mobile clara."
+resultLabel: "Demo lista para vender una experiencia más completa que una web institucional."
 rol: "Diseño UI y desarrollo Frontend"
 stack:
   - Astro

--- a/src/lib/projectGallery.ts
+++ b/src/lib/projectGallery.ts
@@ -12,23 +12,29 @@ export function projectCoverImage({
   slug,
   thumbnail,
   cover,
+  image,
 }: {
   slug?: string;
   thumbnail?: string;
   cover?: string;
+  image?: string;
 }) {
-  return projectVisualAsset({ slug, thumbnail, cover }).src;
+  return projectVisualAsset({ slug, thumbnail, cover, image }).src;
 }
 
 export function projectVisualAsset({
   slug,
   thumbnail,
   cover,
+  image,
 }: {
   slug?: string;
   thumbnail?: string;
   cover?: string;
+  image?: string;
 }) {
+  if (image && image !== DEFAULT_PROJECT_IMAGE)
+    return { src: image, hasImage: true };
   if (thumbnail) return { src: thumbnail, hasImage: true };
   if (cover && cover !== DEFAULT_PROJECT_IMAGE)
     return { src: cover, hasImage: true };

--- a/src/lib/projectVisuals.ts
+++ b/src/lib/projectVisuals.ts
@@ -1,0 +1,270 @@
+export const VISUAL_TONES = [
+  "cyan",
+  "violet",
+  "emerald",
+  "amber",
+  "rose",
+  "neutral",
+] as const;
+
+export type ProjectVisualTone = (typeof VISUAL_TONES)[number];
+
+export type ProjectVisualInput = {
+  title?: string;
+  category?: string;
+  businessType?: string;
+  visualTone?: string;
+  badges?: string[];
+  features?: string[];
+  stack?: string[];
+  sector?: string;
+  tipo?: string;
+  resumen?: string;
+};
+
+export const toneStyles: Record<
+  ProjectVisualTone,
+  {
+    gradient: string;
+    glowPrimary: string;
+    glowSecondary: string;
+    iconShell: string;
+    accentText: string;
+    chip: string;
+    line: string;
+  }
+> = {
+  cyan: {
+    gradient:
+      "bg-gradient-to-br from-cyan-electric/25 via-blue-electric/15 to-ink",
+    glowPrimary: "bg-cyan-electric/30",
+    glowSecondary: "bg-blue-electric/25",
+    iconShell:
+      "border-cyan-electric/30 bg-cyan-electric/10 text-cyan-100 shadow-[0_0_34px_rgba(34,211,238,0.20)]",
+    accentText: "text-cyan-electric",
+    chip: "border-cyan-electric/20 bg-cyan-electric/10 text-cyan-100",
+    line: "bg-cyan-electric/70",
+  },
+  violet: {
+    gradient:
+      "bg-gradient-to-br from-brand-violet/25 via-blue-electric/10 to-ink",
+    glowPrimary: "bg-brand-violet/30",
+    glowSecondary: "bg-cyan-electric/20",
+    iconShell:
+      "border-brand-violet/30 bg-brand-violet/10 text-violet-100 shadow-[0_0_34px_rgba(139,92,246,0.22)]",
+    accentText: "text-violet-200",
+    chip: "border-brand-violet/20 bg-brand-violet/10 text-violet-100",
+    line: "bg-brand-violet/70",
+  },
+  emerald: {
+    gradient:
+      "bg-gradient-to-br from-brand-success/20 via-cyan-electric/10 to-ink",
+    glowPrimary: "bg-brand-success/25",
+    glowSecondary: "bg-cyan-electric/20",
+    iconShell:
+      "border-brand-success/30 bg-brand-success/10 text-emerald-100 shadow-[0_0_34px_rgba(52,211,153,0.20)]",
+    accentText: "text-emerald-200",
+    chip: "border-brand-success/20 bg-brand-success/10 text-emerald-100",
+    line: "bg-brand-success/70",
+  },
+  amber: {
+    gradient:
+      "bg-gradient-to-br from-brand-warning/20 via-orange-500/10 to-ink",
+    glowPrimary: "bg-brand-warning/25",
+    glowSecondary: "bg-orange-500/20",
+    iconShell:
+      "border-brand-warning/30 bg-brand-warning/10 text-amber-100 shadow-[0_0_34px_rgba(251,191,36,0.18)]",
+    accentText: "text-amber-200",
+    chip: "border-brand-warning/20 bg-brand-warning/10 text-amber-100",
+    line: "bg-brand-warning/70",
+  },
+  rose: {
+    gradient: "bg-gradient-to-br from-rose-500/20 via-brand-violet/10 to-ink",
+    glowPrimary: "bg-rose-500/25",
+    glowSecondary: "bg-brand-violet/20",
+    iconShell:
+      "border-rose-400/30 bg-rose-500/10 text-rose-100 shadow-[0_0_34px_rgba(244,63,94,0.18)]",
+    accentText: "text-rose-200",
+    chip: "border-rose-400/20 bg-rose-500/10 text-rose-100",
+    line: "bg-rose-400/70",
+  },
+  neutral: {
+    gradient: "bg-gradient-to-br from-slate-500/20 via-slate-700/15 to-ink",
+    glowPrimary: "bg-slate-400/20",
+    glowSecondary: "bg-cyan-electric/10",
+    iconShell:
+      "border-slate-400/25 bg-slate-400/10 text-slate-100 shadow-[0_0_34px_rgba(148,163,184,0.15)]",
+    accentText: "text-muted-bright",
+    chip: "border-line bg-surface-glass text-muted-bright",
+    line: "bg-slate-400/70",
+  },
+};
+
+export const categoryVisuals = [
+  {
+    key: "veterinaria",
+    label: "Veterinaria",
+    icon: "✚",
+    tone: "emerald",
+    defaultBadges: ["Agenda", "Urgencias", "WhatsApp"],
+    terms: ["veterinaria", "vet", "mascota", "urgencia"],
+  },
+  {
+    key: "barberia",
+    label: "Barbería",
+    icon: "✂",
+    tone: "violet",
+    defaultBadges: ["Reservas", "Servicios", "Mobile"],
+    terms: ["barber", "barbería", "barberia", "estética", "estetica"],
+  },
+  {
+    key: "gastronomia",
+    label: "Gastronomía",
+    icon: "◆",
+    tone: "amber",
+    defaultBadges: ["Carta", "Reserva", "Pedido"],
+    terms: [
+      "restaurante",
+      "gastronomía",
+      "gastronomia",
+      "carta",
+      "parrilla",
+      "cafetería",
+      "cafeteria",
+    ],
+  },
+  {
+    key: "sistema",
+    label: "Sistema / panel",
+    icon: "▦",
+    tone: "cyan",
+    defaultBadges: ["Dashboard", "Operación", "Datos"],
+    terms: [
+      "sistema",
+      "panel",
+      "dashboard",
+      "stock",
+      "inventario",
+      "gestión",
+      "gestion",
+      "admin",
+    ],
+  },
+  {
+    key: "bienestar",
+    label: "Bienestar",
+    icon: "✦",
+    tone: "rose",
+    defaultBadges: ["Confianza", "Servicios", "Consultas"],
+    terms: ["bienestar", "tarot", "servicios personales", "consultas"],
+  },
+  {
+    key: "corporativo",
+    label: "Corporativo",
+    icon: "▰",
+    tone: "neutral",
+    defaultBadges: ["Empresa", "Servicios", "Contacto"],
+    terms: [
+      "corporativa",
+      "corporativo",
+      "logística",
+      "logistica",
+      "empresa",
+      "transporte",
+    ],
+  },
+  {
+    key: "landing",
+    label: "Landing comercial",
+    icon: "↗",
+    tone: "cyan",
+    defaultBadges: ["CTA", "SEO", "WhatsApp"],
+    terms: [
+      "landing",
+      "web",
+      "demo comercial",
+      "consulta",
+      "conversión",
+      "conversion",
+    ],
+  },
+] as const;
+
+function normalizeText(value?: string) {
+  return String(value ?? "")
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "");
+}
+
+export function getProjectInitials(title = "MD") {
+  return (
+    title
+      .split(/[\s–-]+/)
+      .filter(Boolean)
+      .slice(0, 2)
+      .map((word) => word[0]?.toUpperCase())
+      .join("") || "MD"
+  );
+}
+
+export function getVisualTone(tone?: string): ProjectVisualTone {
+  return VISUAL_TONES.includes(tone as ProjectVisualTone)
+    ? (tone as ProjectVisualTone)
+    : "cyan";
+}
+
+export function getProjectCategory(input: ProjectVisualInput) {
+  const explicitCategory = normalizeText(input.category);
+
+  if (explicitCategory) {
+    const exactMatch = categoryVisuals.find(
+      (category) =>
+        normalizeText(category.key) === explicitCategory ||
+        normalizeText(category.label) === explicitCategory,
+    );
+
+    if (exactMatch) return exactMatch;
+  }
+
+  const haystack = [
+    input.category,
+    input.businessType,
+    input.sector,
+    input.tipo,
+    input.resumen,
+    ...(input.features ?? []),
+    ...(input.stack ?? []),
+  ]
+    .map(normalizeText)
+    .join(" ");
+
+  return (
+    categoryVisuals.find((category) =>
+      category.terms.some((term) => haystack.includes(normalizeText(term))),
+    ) ?? categoryVisuals[categoryVisuals.length - 1]
+  );
+}
+
+export function getProjectVisual(input: ProjectVisualInput) {
+  const category = getProjectCategory(input);
+  const tone = getVisualTone(input.visualTone ?? category.tone);
+  const explicitBadges = Array.isArray(input.badges) ? input.badges : [];
+  const badges = [
+    ...explicitBadges,
+    ...(input.features ?? []),
+    ...category.defaultBadges,
+    ...(input.stack ?? []),
+  ]
+    .filter(Boolean)
+    .filter((item, index, array) => array.indexOf(item) === index)
+    .slice(0, 4);
+
+  return {
+    category,
+    tone,
+    styles: toneStyles[tone],
+    badges,
+    initials: getProjectInitials(input.title),
+  };
+}

--- a/src/pages/proyectos/[slug].astro
+++ b/src/pages/proyectos/[slug].astro
@@ -30,6 +30,7 @@ const {
   demoUrl,
   cover = '/og-default.png',
   thumbnail = '',
+  image = '',
   tipo,
   idealPara,
   features = [],
@@ -37,7 +38,7 @@ const {
   status,
 } = proyecto.data;
 
-const previewImage = thumbnail || cover;
+const previewImage = image || thumbnail || cover;
 
 const { Content } = await proyecto.render();
 const statusLabels = {
@@ -99,7 +100,7 @@ const whatsappText = `Hola Diego, quiero algo parecido a ${title}.\n\nRubro: [ru
           </div>
         </div>
 
-        <ProjectLinkPreview title={title} url={demoUrl} cover={cover} thumbnail={thumbnail} slug={proyecto.slug} eager />
+        <ProjectLinkPreview title={title} url={demoUrl} cover={image || cover} thumbnail={thumbnail} slug={proyecto.slug} eager />
       </header>
 
       <section class="mt-12 grid gap-5 lg:grid-cols-3">

--- a/src/pages/proyectos/index.astro
+++ b/src/pages/proyectos/index.astro
@@ -45,11 +45,18 @@ const proyectos = (await getCollection('proyectos')).sort(byCommercialPriority);
           slug={p.slug}
           cover={p.data.cover}
           thumbnail={p.data.thumbnail}
+          image={p.data.image}
           resultado={p.data.resultado}
           problema={p.data.problema}
           solucion={p.data.solucion}
           tipo={p.data.tipo}
           sector={p.data.sector}
+          category={p.data.category}
+          businessType={p.data.businessType}
+          resultLabel={p.data.resultLabel}
+          highlight={p.data.highlight}
+          visualTone={p.data.visualTone}
+          badges={p.data.badges}
           status={p.data.status}
           features={p.data.features}
           impacto={p.data.impacto}
@@ -57,6 +64,7 @@ const proyectos = (await getCollection('proyectos')).sort(byCommercialPriority);
           priority={p.data.priority}
           demoUrl={p.data.demoUrl}
           repoUrl={p.data.repoUrl}
+          caseUrl={p.data.caseUrl}
         />
       ))}
     </div>


### PR DESCRIPTION
### Motivation
- Provide a maintainable visual system so new portfolio entries look polished without manual artwork. 
- Let project cards be driven by minimal metadata (category, tone, badges, etc.) while keeping existing MDX backward-compatible. 
- Ensure graceful degradation so projects without images still render a branded, browser-style fallback visual.

### Description
- Extend the content schema in `src/content/config.ts` with optional fields: `image`, `category`, `businessType`, `resultLabel`, `highlight`, `visualTone`, `badges`, and `caseUrl`. 
- Add `src/lib/projectVisuals.ts` to map categories and `visualTone`s to Tailwind-safe styles, icons, default badges and helper functions (`getProjectVisual`, initials/tone inference). 
- Update image resolution logic in `src/lib/projectGallery.ts` to prefer `image` → `thumbnail` → `cover` → `/galeria/<slug>.svg` → generated fallback. 
- Revise `src/components/ProjectCard.astro`, `src/components/FeaturedCases.astro` and `src/pages/proyectos/index.astro` to consume the new metadata, render real images when present, or build the themed fallback (category icon, initials, gradient, badges, subtle browser frame) when missing. 
- Update project detail preview selection (`src/pages/proyectos/[slug].astro`) to respect `image` and adjust `ProjectLinkPreview` usage, and add example metadata to existing MDX entries to demonstrate the system. 
- Add documentation `docs/portfolio-projects.md` describing the workflow, image priority and optional fields.

### Testing
- Ran `npm run build` (Astro build) and it completed successfully with static pages generated (build passed). 
- Ran `npm run format` (Prettier) and `git diff --check` with no blocking issues. 
- Started local dev (`astro dev`) and verified pages render locally; build produced the expected `/proyectos` and `/proyectos/[slug]` routes. 
- Tried a Playwright screenshot test but it failed due to `npm` registry access returning `403 Forbidden` when installing Playwright, so visual screenshot automation was not executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0099d6eb8c83288941e6154f85aba9)