### PR TITLE
Improve project demo preview performance (disable eager external iframes)

### DIFF
--- a/docs/performance-audit.md
+++ b/docs/performance-audit.md
@@ -211,3 +211,18 @@ Alcance sugerido:
 3. Modificar `ProjectLinkPreview` para usar preview estático por defecto y cargar demo externa solo con click o nueva pestaña.
 4. Dejar `astro:assets` preparado para covers raster locales, sin migrar todo el portfolio de golpe.
 5. Ejecutar `npm run build` y revisar tamaños de `dist/` antes/después.
+
+## Patch: previews estáticos para demos externas
+
+Se actualizó `src/components/ProjectLinkPreview.astro` para que las páginas de detalle de proyecto no carguen iframes externos automáticamente. El componente ahora renderiza por defecto una tarjeta estática con marco tipo navegador, dominio/título del proyecto, portada si existe y CTA `Abrir demo` con `target="_blank"` y `rel="noopener noreferrer"`.
+
+Beneficio esperado:
+
+- Evita descargar y ejecutar sitios completos de Vercel, GitHub Pages u otros dominios durante el render inicial del caso.
+- Reduce riesgo sobre LCP, INP, uso de red y consumo de CPU en mobile.
+- Mantiene la salida estática de Astro y no agrega React, hidratación ni librerías de lazy iframe.
+
+Uso restante de iframes:
+
+- `ProjectLinkPreview` conserva un modo opt-in `embedMode="iframe"` para casos excepcionales, pero queda deshabilitado por defecto.
+- No se detectan usos actuales que pasen `embedMode="iframe"`; las páginas de proyecto abren las demos mediante enlace externo.

--- a/src/components/ProjectLinkPreview.astro
+++ b/src/components/ProjectLinkPreview.astro
@@ -8,12 +8,19 @@ const {
   thumbnail = '',
   slug = '',
   eager = false,
+  embedMode = 'static',
 } = Astro.props;
 
 const displayCover = projectCoverImage({ slug, thumbnail, cover });
 const hasPreviewUrl = typeof url === 'string' && url.length > 0;
 const hasCustomCover = displayCover && displayCover !== '/og-default.png';
-const previewHost = hasPreviewUrl ? new URL(url).host.replace(/^www\./, '') : `marin.dev/caso/${slug}`;
+const shouldRenderIframe = hasPreviewUrl && embedMode === 'iframe';
+let previewHost = `marin.dev/caso/${slug}`;
+
+if (hasPreviewUrl) {
+  const parsedUrl = new URL(url);
+  previewHost = parsedUrl.host.replace(/^www\./, '');
+}
 ---
 <div class="relative">
   <div class="absolute -inset-4 rounded-[2rem] bg-cyan-electric/10 blur-3xl"></div>
@@ -26,7 +33,7 @@ const previewHost = hasPreviewUrl ? new URL(url).host.replace(/^www\./, '') : `m
     </div>
 
     <div class="relative mt-3 aspect-[4/3] overflow-hidden rounded-2xl border border-line bg-ink">
-      {hasPreviewUrl ? (
+      {shouldRenderIframe ? (
         <>
           <iframe
             src={url}
@@ -37,25 +44,20 @@ const previewHost = hasPreviewUrl ? new URL(url).host.replace(/^www\./, '') : `m
             sandbox="allow-scripts allow-same-origin allow-forms allow-popups"
           ></iframe>
           <div class="pointer-events-none absolute inset-x-0 bottom-0 h-20 bg-gradient-to-t from-ink/80 to-transparent"></div>
-          <a
-            href={url}
-            target="_blank"
-            rel="noopener noreferrer"
-            class="absolute bottom-4 left-4 inline-flex items-center gap-2 rounded-xl border border-line bg-ink/80 px-4 py-2 text-xs font-semibold text-slate-50 shadow-premium backdrop-blur transition hover:-translate-y-0.5 hover:border-cyan-electric/40 hover:text-cyan-electric"
-          >
-            Abrir demo real <span aria-hidden="true">↗</span>
-          </a>
         </>
       ) : hasCustomCover ? (
-        <img
-          src={displayCover}
-          alt={`Mockup o portada de ${title}`}
-          width="1200"
-          height="900"
-          class="h-full w-full object-cover"
-          loading={eager ? 'eager' : 'lazy'}
-          decoding="async"
-        />
+        <>
+          <img
+            src={displayCover}
+            alt={`Preview estático de ${title}`}
+            width="1200"
+            height="900"
+            class="h-full w-full object-cover"
+            loading={eager ? 'eager' : 'lazy'}
+            decoding="async"
+          />
+          <div class="pointer-events-none absolute inset-0 bg-gradient-to-t from-ink via-ink/15 to-transparent"></div>
+        </>
       ) : (
         <div class="relative flex h-full flex-col justify-between overflow-hidden p-5">
           <div class="absolute inset-0 bg-premium-grid bg-[length:2rem_2rem] opacity-45"></div>
@@ -65,9 +67,40 @@ const previewHost = hasPreviewUrl ? new URL(url).host.replace(/^www\./, '') : `m
             <p class="text-xs font-semibold uppercase tracking-[0.2em] text-cyan-electric">Preview del caso</p>
             <p class="mt-2 text-lg font-semibold leading-tight text-slate-50">{title}</p>
           </div>
-          <p class="relative text-xs leading-5 text-muted-soft">Agregá un link de demo para generar una vista previa embebida sin cargar una galería manual.</p>
+          <div class="relative grid gap-3 rounded-2xl border border-line bg-ink/45 p-4 shadow-premium backdrop-blur">
+            <div class="h-2 rounded-full bg-slate-600/70"></div>
+            <div class="h-2 w-4/5 rounded-full bg-slate-700/80"></div>
+            <div class="mt-2 grid grid-cols-3 gap-2">
+              <div class="h-12 rounded-xl border border-cyan-electric/20 bg-cyan-electric/10"></div>
+              <div class="h-12 rounded-xl border border-brand-blue/20 bg-brand-blue/10"></div>
+              <div class="h-12 rounded-xl border border-brand-violet/20 bg-brand-violet/10"></div>
+            </div>
+          </div>
         </div>
       )}
+
+      <div class="absolute inset-x-0 bottom-0 p-4">
+        <div class="rounded-2xl border border-line bg-ink/85 p-4 shadow-premium backdrop-blur">
+          <p class="text-xs font-semibold uppercase tracking-[0.2em] text-cyan-electric">{hasPreviewUrl ? 'Demo externa' : 'Preview estático'}</p>
+          <div class="mt-2 flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+            <div class="min-w-0">
+              <p class="truncate text-base font-semibold text-slate-50">{title || previewHost}</p>
+              <p class="mt-1 truncate text-xs text-muted-soft">{previewHost}</p>
+            </div>
+            {hasPreviewUrl && (
+              <a
+                href={url}
+                target="_blank"
+                rel="noopener noreferrer"
+                class="inline-flex shrink-0 items-center justify-center gap-2 rounded-xl border border-line bg-slate-50 px-4 py-2 text-xs font-semibold text-ink shadow-premium transition hover:-translate-y-0.5 hover:border-cyan-electric/40 hover:bg-white"
+                aria-label={`Abrir demo externa de ${title} en una pestaña nueva`}
+              >
+                Abrir demo <span aria-hidden="true">↗</span>
+              </a>
+            )}
+          </div>
+        </div>
+      </div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
### Motivation
- Project detail pages were eagerly embedding external demo sites via `iframe`, which risks harming LCP/INP and mobile network/CPU usage when third-party sites load above the fold. 
- The intent is to keep Astro's static output and low runtime cost while preserving access to live demos. 
- Replace automatic iframe loading with a lightweight static preview by default and allow embedding only by explicit opt-in.

### Description
- Updated `src/components/ProjectLinkPreview.astro` to add an `embedMode` prop (default `'static'`) and to only render an `<iframe>` when `embedMode === 'iframe'` (opt-in). 
- Replaced the default live embed with a polished static preview that shows the project cover if available or a lightweight CSS/SVG fallback mock browser frame, and preserves the premium visual styling. 
- Added a clear CTA `Abrir demo` that opens the demo URL in a new tab with `target="_blank"` and `rel="noopener noreferrer"` so users can still visit the live demo without auto-loading it. 
- Documented the change and expected performance benefits in `docs/performance-audit.md` and kept all routes/content intact (no React/hydration added).

### Testing
- Ran `npm run build` and the static build completed successfully with all pages generated (build passed). 
- Searched the generated output with `rg -n "<iframe" dist` and confirmed there are no `iframe` tags in `dist` (no external iframes loaded in build). 
- Searched source for opt-in usage with `rg -n "embedMode=\"iframe\"" src/pages src/components` and confirmed no project pages opt into iframe mode (embed remains opt-in). 
- Verified repository checks (`git diff --check`) produced no whitespace or syntax issues.

Files changed:
- `src/components/ProjectLinkPreview.astro`
- `docs/performance-audit.md`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00dc8dbcc08328a2d55754de78b5d5)