### PR TITLE
Fix mobile overflow layout contracts

### DIFF
--- a/docs/mobile-layout-fixes.md
+++ b/docs/mobile-layout-fixes.md
@@ -1,0 +1,29 @@
+# Mobile layout overflow checks
+
+Use this note when reviewing Marin.dev on narrow Android/Chrome widths such as 360px, 375px, 390px and 430px. The goal is to find real intrinsic-width overflow instead of masking it with `body`/`html` overflow rules.
+
+## Console snippet
+
+Paste this in DevTools after the page has finished rendering:
+
+```js
+Array.from(document.querySelectorAll('body *')).filter(el => {
+  const r = el.getBoundingClientRect();
+  return r.width && (r.right > document.documentElement.clientWidth + 1 || r.left < -1);
+}).map(el => ({
+  tag: el.tagName,
+  class: el.className,
+  text: el.innerText?.slice(0, 80),
+  left: Math.round(el.getBoundingClientRect().left),
+  right: Math.round(el.getBoundingClientRect().right),
+  width: Math.round(el.getBoundingClientRect().width)
+}));
+```
+
+## What to check manually
+
+- Hero headline, eyebrow, badges, CTAs and trust strip are fully visible.
+- CTA buttons are full-width on mobile and return to content width on larger screens.
+- Badges can wrap/shrink without pushing the viewport.
+- Grid and flex children use `min-w-0` where content may otherwise force intrinsic overflow.
+- Decorative glows can be clipped by their own containers, but real text/buttons/cards should not be clipped.

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "astro build",
     "preview": "astro preview",
     "format": "prettier --write .",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "check:mobile-layout": "node scripts/check-mobile-layout-contract.mjs"
   },
   "dependencies": {
     "@astrojs/sitemap": "^3.1.4",

--- a/scripts/check-mobile-layout-contract.mjs
+++ b/scripts/check-mobile-layout-contract.mjs
@@ -1,0 +1,75 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const files = [
+  'src/layouts/BaseLayout.astro',
+  'src/styles/tailwind.css',
+  'src/components/HeroV2.astro',
+  'src/components/VisualBadge.astro',
+  'src/components/SectionHeader.astro',
+  'src/components/BrowserMockup.astro',
+  'src/components/ContactCTA.astro',
+  'src/components/FeaturedCases.astro',
+  'src/components/ProjectCard.astro',
+  'src/components/ProjectLinkPreview.astro',
+  'src/pages/proyectos/[slug].astro',
+  'src/pages/proyectos/index.astro',
+  'src/pages/servicios.astro',
+];
+
+const source = Object.fromEntries(
+  files.map((file) => [file, readFileSync(join(process.cwd(), file), 'utf8')]),
+);
+
+const checks = [
+  {
+    name: 'Do not mask layout issues with global horizontal overflow hiding',
+    pass: () => !Object.values(source).some((text) => /overflow-x\s*:\s*hidden|overflow-x-hidden/.test(text)),
+  },
+  {
+    name: 'Hero grid uses shrinkable minmax columns',
+    pass: () => source['src/components/HeroV2.astro'].includes('lg:grid-cols-[minmax(0,0.92fr)_minmax(0,1.08fr)]'),
+  },
+  {
+    name: 'Hero content column has min-w-0 and max-w-full',
+    pass: () => source['src/components/HeroV2.astro'].includes('relative z-10 min-w-0 max-w-full'),
+  },
+  {
+    name: 'Hero title uses a mobile fluid clamp and can break words',
+    pass: () => /<h1[^>]+break-words[^>]+text-\[clamp\(2\.25rem,10vw,3\.5rem\)\]/.test(source['src/components/HeroV2.astro']),
+  },
+  {
+    name: 'Hero primary and secondary CTAs are full-width on mobile',
+    pass: () => (source['src/components/HeroV2.astro'].match(/inline-flex min-h-12 w-full max-w-full/g) ?? []).length >= 2,
+  },
+  {
+    name: 'VisualBadge labels can shrink/wrap and use safer mobile tracking',
+    pass: () => {
+      const text = source['src/components/VisualBadge.astro'];
+      return text.includes('min-w-0 max-w-full') && text.includes('tracking-[0.1em]') && text.includes('<span class="min-w-0 break-words leading-5">{label}</span>');
+    },
+  },
+  {
+    name: 'SectionHeader root and eyebrow are width-safe',
+    pass: () => {
+      const text = source['src/components/SectionHeader.astro'];
+      return text.includes('relative flex min-w-0 max-w-full') && text.includes('flex w-full min-w-0 flex-wrap') && text.includes('tracking-[0.1em]');
+    },
+  },
+  {
+    name: 'Project/detail CTAs use full-width mobile buttons',
+    pass: () => source['src/pages/proyectos/[slug].astro'].includes('inline-flex w-full max-w-full') && source['src/components/ProjectCard.astro'].includes('inline-flex w-full max-w-full'),
+  },
+];
+
+const failures = checks.filter((check) => !check.pass());
+
+if (failures.length > 0) {
+  console.error('Mobile layout contract failed:');
+  for (const failure of failures) {
+    console.error(`- ${failure.name}`);
+  }
+  process.exit(1);
+}
+
+console.log(`Mobile layout contract passed (${checks.length} checks).`);

--- a/src/components/Badge.astro
+++ b/src/components/Badge.astro
@@ -10,4 +10,4 @@ const tones = {
 };
 const classes = tones[tone] ?? tones.default;
 ---
-<span class={`inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-medium shadow-sm backdrop-blur ${classes}`}>{label}</span>
+<span class={`inline-flex min-w-0 max-w-full items-center rounded-full border px-2.5 py-0.5 text-xs font-medium shadow-sm backdrop-blur ${classes}`}><span class="min-w-0 break-words leading-5">{label}</span></span>

--- a/src/components/BrowserMockup.astro
+++ b/src/components/BrowserMockup.astro
@@ -17,7 +17,7 @@ const sideCards = [
   { label: 'propuesta en 24h', value: 'alcance inicial', icon: 'speed', tone: 'cyan', className: 'right-6 bottom-8' },
 ];
 ---
-<div class="relative mx-auto w-full max-w-xl lg:max-w-2xl" role="group" aria-label="Mockup funcional de una web comercial">
+<div class="relative mx-auto min-w-0 max-w-full lg:max-w-2xl" role="group" aria-label="Mockup funcional de una web comercial">
   <div class="absolute -inset-5 rounded-[2rem] bg-brand-gradient opacity-10 blur-2xl md:opacity-20 md:blur-3xl" aria-hidden="true"></div>
   <div class="absolute left-8 top-8 hidden h-28 w-28 rounded-full bg-cyan-electric/15 blur-2xl md:block" aria-hidden="true"></div>
   <div class="absolute bottom-10 right-10 hidden h-32 w-32 rounded-full bg-violet-electric/15 blur-2xl md:block" aria-hidden="true"></div>
@@ -34,7 +34,7 @@ const sideCards = [
     </div>
   ))}
 
-  <div class="relative overflow-hidden rounded-3xl border border-line bg-surface-glow shadow-premium backdrop-blur">
+  <div class="relative min-w-0 overflow-hidden rounded-3xl border border-line bg-surface-glow shadow-premium backdrop-blur">
     <div class="flex min-w-0 items-center gap-2 border-b border-line bg-ink/65 px-4 py-3">
       <span class="h-3 w-3 shrink-0 rounded-full bg-red-400/80" aria-hidden="true"></span>
       <span class="h-3 w-3 shrink-0 rounded-full bg-amber-300/80" aria-hidden="true"></span>
@@ -43,21 +43,21 @@ const sideCards = [
       <span class="hidden shrink-0 rounded-full bg-brand-success/10 px-2.5 py-1 text-xs font-semibold text-emerald-100 sm:inline-flex">Deploy activo</span>
     </div>
 
-    <div class="relative p-4 sm:p-6">
+    <div class="relative min-w-0 p-4 sm:p-6">
       <div class="absolute right-6 top-6 hidden rounded-full border border-cyan-electric/25 bg-cyan-electric/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.16em] text-cyan-100 sm:block">
         Flujo de conversión
       </div>
 
-      <section class="rounded-3xl border border-line bg-ink/45 p-5 sm:p-6">
-        <div class="max-w-sm">
-          <p class="text-xs font-semibold uppercase tracking-[0.22em] text-cyan-electric">Web comercial</p>
-          <h3 class="mt-3 text-2xl font-semibold tracking-tight text-slate-50 sm:text-3xl">De visita a consulta</h3>
+      <section class="min-w-0 rounded-3xl border border-line bg-ink/45 p-5 sm:p-6">
+        <div class="max-w-sm min-w-0">
+          <p class="break-words text-xs font-semibold uppercase tracking-[0.1em] text-cyan-electric sm:tracking-[0.22em]">Web comercial</p>
+          <h3 class="mt-3 break-words text-2xl font-semibold tracking-tight text-slate-50 sm:text-3xl">De visita a consulta</h3>
           <p class="mt-3 text-sm leading-6 text-muted-soft">Mensaje claro, prueba visual y próximo paso simple.</p>
         </div>
 
-        <div class="mt-6 grid grid-cols-2 gap-3 lg:grid-cols-4">
+        <div class="mt-6 grid min-w-0 grid-cols-2 gap-3 lg:grid-cols-4">
           {modules.map((module) => (
-            <article class="premium-interactive rounded-2xl border border-line bg-surface-glass p-3 shadow-soft hover:border-cyan-electric/30 sm:p-4">
+            <article class="premium-interactive min-w-0 rounded-2xl border border-line bg-surface-glass p-3 shadow-soft hover:border-cyan-electric/30 sm:p-4">
               <IconBubble icon={module.icon} tone={module.tone} size="sm" />
               <h4 class="mt-3 text-sm font-semibold text-slate-50">{module.title}</h4>
               <p class="mt-1 hidden text-xs leading-5 text-muted-soft sm:block">{module.detail}</p>
@@ -66,21 +66,21 @@ const sideCards = [
         </div>
       </section>
 
-      <div class="mt-4 grid gap-3 sm:grid-cols-[0.95fr_1.05fr]">
-        <div class="rounded-2xl border border-line bg-surface-glass p-4">
-          <p class="text-xs font-semibold uppercase tracking-[0.18em] text-muted">Performance</p>
+      <div class="mt-4 grid min-w-0 gap-3 sm:grid-cols-[minmax(0,0.95fr)_minmax(0,1.05fr)]">
+        <div class="min-w-0 rounded-2xl border border-line bg-surface-glass p-4">
+          <p class="break-words text-xs font-semibold uppercase tracking-[0.1em] text-muted sm:tracking-[0.18em]">Performance</p>
           <div class="mt-3 space-y-2">
             {['Carga rápida', 'SEO base', 'Mobile first'].map((item, index) => (
               <div class="flex items-center gap-3">
                 <span class={`h-2 w-2 rounded-full ${index === 0 ? 'bg-cyan-electric' : index === 1 ? 'bg-violet-electric' : 'bg-brand-success'}`} aria-hidden="true"></span>
-                <span class="text-sm font-medium text-slate-50">{item}</span>
+                <span class="min-w-0 break-words text-sm font-medium text-slate-50">{item}</span>
               </div>
             ))}
           </div>
         </div>
 
-        <div class="rounded-2xl border border-emerald-300/20 bg-emerald-400/10 p-4">
-          <p class="text-xs font-semibold uppercase tracking-[0.18em] text-emerald-100">Nueva consulta</p>
+        <div class="min-w-0 rounded-2xl border border-emerald-300/20 bg-emerald-400/10 p-4">
+          <p class="break-words text-xs font-semibold uppercase tracking-[0.1em] text-emerald-100 sm:tracking-[0.18em]">Nueva consulta</p>
           <p class="mt-2 text-sm leading-6 text-muted-soft">“Quiero una demo. Rubro: estética. Objetivo: más reservas.”</p>
         </div>
       </div>

--- a/src/components/ContactCTA.astro
+++ b/src/components/ContactCTA.astro
@@ -58,14 +58,14 @@ const contactMethods = [
   },
 ].filter(Boolean);
 ---
-<section class="py-16 md:py-24">
-  <div class="premium-interactive halo-sweep relative overflow-hidden rounded-[2rem] border border-line bg-surface-glow p-5 shadow-premium backdrop-blur sm:p-7 md:p-10 lg:p-12">
+<section class="min-w-0 py-16 md:py-24">
+  <div class="premium-interactive halo-sweep relative min-w-0 overflow-hidden rounded-[2rem] border border-line bg-surface-glow p-5 shadow-premium backdrop-blur sm:p-7 md:p-10 lg:p-12">
     <div class="absolute inset-x-8 -top-24 h-56 rounded-full bg-cyan-electric/20 blur-3xl" aria-hidden="true"></div>
     <div class="absolute -bottom-28 right-0 h-56 w-56 rounded-full bg-brand-violet/20 blur-3xl" aria-hidden="true"></div>
     <div class="absolute left-1/2 top-0 h-px w-3/4 -translate-x-1/2 bg-gradient-to-r from-transparent via-cyan-electric/60 to-transparent" aria-hidden="true"></div>
 
-    <div class="relative grid gap-9 lg:grid-cols-[minmax(0,1.05fr)_minmax(20rem,0.8fr)] lg:items-center">
-      <div>
+    <div class="relative grid min-w-0 gap-9 lg:grid-cols-[minmax(0,1.05fr)_minmax(0,0.8fr)] lg:items-center">
+      <div class="min-w-0 max-w-full">
         <SectionHeader
           eyebrow={eyebrow}
           title={title}
@@ -74,16 +74,16 @@ const contactMethods = [
           align="left"
         />
 
-        <div class="mt-6 flex flex-wrap gap-2">
+        <div class="mt-6 flex min-w-0 max-w-full flex-wrap gap-2">
           {trustBadges.map((badge) => <VisualBadge label={badge.label} icon={badge.icon} tone={badge.tone} />)}
         </div>
 
-        <div class="mt-8 flex flex-col gap-3 sm:flex-row">
+        <div class="mt-8 flex min-w-0 max-w-full flex-col gap-3 sm:flex-row">
           <a
             href={waLink(primaryMessage)}
             target="_blank"
             rel="noopener noreferrer"
-            class="premium-button inline-flex min-h-12 items-center justify-center gap-2 rounded-2xl bg-brand-gradient px-6 py-3 text-sm font-semibold text-white shadow-glow hover:-translate-y-0.5 hover:shadow-premium-hover sm:min-w-64"
+            class="premium-button inline-flex min-h-12 w-full max-w-full items-center justify-center gap-2 whitespace-normal rounded-2xl bg-brand-gradient px-5 py-3 text-center text-sm font-semibold leading-5 text-white shadow-glow hover:-translate-y-0.5 hover:shadow-premium-hover sm:w-auto sm:min-w-64 sm:px-6"
           >
             <Icon name="message" size="sm" />
             {primaryLabel}
@@ -91,7 +91,7 @@ const contactMethods = [
           {secondaryLabel && secondaryHref && (
             <a
               href={secondaryHref}
-              class="premium-button inline-flex min-h-12 items-center justify-center gap-2 rounded-2xl border border-line bg-surface-glass px-6 py-3 text-sm font-semibold text-slate-50 hover:-translate-y-0.5 hover:border-line-strong hover:text-cyan-electric"
+              class="premium-button inline-flex min-h-12 w-full max-w-full items-center justify-center gap-2 whitespace-normal rounded-2xl border border-line bg-surface-glass px-5 py-3 text-center text-sm font-semibold leading-5 text-slate-50 hover:-translate-y-0.5 hover:border-line-strong hover:text-cyan-electric sm:w-auto sm:px-6"
             >
               {secondaryLabel}
               <Icon name="arrow" size="sm" />
@@ -99,21 +99,21 @@ const contactMethods = [
           )}
         </div>
 
-        <div class="mt-7 grid gap-3 sm:grid-cols-3">
+        <div class="mt-7 grid min-w-0 gap-3 sm:grid-cols-3">
           {contactMethods.map((method) => (
             <a
               href={method.href}
               target={method.external ? '_blank' : undefined}
               rel={method.external ? 'noopener noreferrer' : undefined}
-              class="group rounded-2xl border border-line bg-surface-glass p-4 text-left transition duration-300 hover:-translate-y-0.5 hover:border-line-strong hover:bg-surface-850/80"
+              class="group min-w-0 rounded-2xl border border-line bg-surface-glass p-4 text-left transition duration-300 hover:-translate-y-0.5 hover:border-line-strong hover:bg-surface-850/80"
             >
               <span class={`inline-flex size-10 items-center justify-center rounded-xl bg-gradient-to-br ${method.tone} text-cyan-100 ring-1 ring-white/10`}>
                 <Icon name={method.icon} size="sm" />
               </span>
-              <span class="mt-3 block text-sm font-semibold text-slate-50">{method.label}</span>
+              <span class="mt-3 block min-w-0 break-words text-sm font-semibold text-slate-50">{method.label}</span>
               {method.helper && <span class="mt-1 block truncate text-xs text-cyan-100/80">{method.helper}</span>}
               <span class="mt-2 block text-xs leading-5 text-muted-soft">{method.description}</span>
-              <span class="mt-3 inline-flex items-center gap-1.5 text-xs font-semibold text-cyan-electric group-hover:text-cyan-100">
+              <span class="mt-3 inline-flex max-w-full items-center gap-1.5 text-xs font-semibold text-cyan-electric group-hover:text-cyan-100">
                 {method.cta}
                 <Icon name="arrow" size="sm" />
               </span>

--- a/src/components/Container.astro
+++ b/src/components/Container.astro
@@ -1,6 +1,6 @@
 ---
 const { class: className = '' } = Astro.props;
 ---
-<div class={`mx-auto w-full max-w-content px-4 sm:px-6 lg:px-8 ${className}`}>
+<div class={`mx-auto w-full max-w-content min-w-0 px-4 sm:px-6 lg:px-8 ${className}`}>
   <slot />
 </div>

--- a/src/components/ConversionFlow.astro
+++ b/src/components/ConversionFlow.astro
@@ -3,9 +3,9 @@ import GlowCard from './GlowCard.astro';
 import SectionHeader from './SectionHeader.astro';
 import { conversionFlow } from '../data/conversionFlow';
 ---
-<section class="py-14 md:py-20" aria-label="Flujo de conversión comercial">
-  <div class="grid gap-8 lg:grid-cols-[0.9fr_1.1fr] lg:items-start">
-    <div>
+<section class="min-w-0 py-14 md:py-20" aria-label="Flujo de conversión comercial">
+  <div class="grid min-w-0 gap-8 lg:grid-cols-[minmax(0,0.9fr)_minmax(0,1.1fr)] lg:items-start">
+    <div class="min-w-0">
       <SectionHeader
         eyebrow="Criterio CRO simple"
         title="Cómo una visita se convierte en consulta."
@@ -16,17 +16,17 @@ import { conversionFlow } from '../data/conversionFlow';
       </div>
     </div>
 
-    <div class="grid gap-4">
+    <div class="grid min-w-0 gap-4">
       {conversionFlow.map((item) => (
         <GlowCard class="relative overflow-hidden">
           <div class="absolute -right-8 -top-10 h-28 w-28 rounded-full bg-cyan-electric/10 blur-2xl" aria-hidden="true"></div>
-          <div class="relative flex flex-col gap-4 sm:flex-row sm:items-start">
+          <div class="relative flex min-w-0 flex-col gap-4 sm:flex-row sm:items-start">
             <span class="inline-flex h-11 w-11 shrink-0 items-center justify-center rounded-2xl border border-cyan-electric/25 bg-cyan-electric/10 text-sm font-bold text-cyan-electric">
               {item.step}
             </span>
-            <div>
-              <p class="text-xs font-semibold uppercase tracking-[0.18em] text-brand-success">{item.signal}</p>
-              <h3 class="mt-2 text-xl font-semibold tracking-tight text-slate-50">{item.title}</h3>
+            <div class="min-w-0">
+              <p class="break-words text-xs font-semibold uppercase tracking-[0.1em] text-brand-success sm:tracking-[0.18em]">{item.signal}</p>
+              <h3 class="mt-2 break-words text-xl font-semibold tracking-tight text-slate-50">{item.title}</h3>
               <p class="mt-2 text-sm leading-6 text-muted-soft">{item.description}</p>
             </div>
           </div>

--- a/src/components/FeaturedCases.astro
+++ b/src/components/FeaturedCases.astro
@@ -5,10 +5,10 @@ import { DEMO_WHATSAPP_MESSAGE, waLink } from '../lib/contact';
 
 const { projects = [] } = Astro.props;
 ---
-<section id="casos" class="relative scroll-mt-24 overflow-hidden border-t border-line/70 py-14 md:py-20">
+<section id="casos" class="relative min-w-0 scroll-mt-24 overflow-hidden border-t border-line/70 py-14 md:py-20">
   <div class="absolute -right-28 top-8 -z-10 h-60 w-60 rounded-full bg-violet-electric/10 blur-3xl" aria-hidden="true"></div>
-  <div class="flex flex-col gap-6 md:flex-row md:items-end md:justify-between">
-    <div class="space-y-5">
+  <div class="flex min-w-0 flex-col gap-6 md:flex-row md:items-end md:justify-between">
+    <div class="min-w-0 space-y-5">
       <SectionHeader
         eyebrow="Portfolio"
         title="Proyectos y demos pensados para vender mejor"
@@ -17,13 +17,13 @@ const { projects = [] } = Astro.props;
       />
 
     </div>
-    <a href="/proyectos" class="premium-button inline-flex w-fit items-center gap-2 rounded-2xl border border-line bg-surface-glass px-5 py-3 text-sm font-semibold text-cyan-electric hover:-translate-y-0.5 hover:border-line-strong">
+    <a href="/proyectos" class="premium-button inline-flex w-full max-w-full items-center justify-center gap-2 rounded-2xl border border-line bg-surface-glass px-5 py-3 text-center text-sm font-semibold text-cyan-electric hover:-translate-y-0.5 hover:border-line-strong sm:w-fit">
       Ver portfolio completo <span aria-hidden="true">→</span>
     </a>
   </div>
 
   {projects.length > 0 ? (
-    <div class="mt-8 grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+    <div class="mt-8 grid min-w-0 gap-6 sm:grid-cols-2 lg:grid-cols-3">
       {projects.map((p) => (
         <ProjectCard
           title={p.data.title}
@@ -61,11 +61,11 @@ const { projects = [] } = Astro.props;
     </div>
   )}
 
-  <div class="mt-10 flex flex-col gap-4 rounded-3xl border border-line bg-surface-glass p-5 shadow-premium backdrop-blur sm:flex-row sm:items-center sm:justify-between">
-    <p class="text-sm leading-6 text-muted-soft">
+  <div class="mt-10 flex min-w-0 flex-col gap-4 rounded-3xl border border-line bg-surface-glass p-5 shadow-premium backdrop-blur sm:flex-row sm:items-center sm:justify-between">
+    <p class="min-w-0 break-words text-sm leading-6 text-muted-soft">
       <span class="font-semibold text-slate-50">¿Querés algo parecido?</span> Mandame tu Instagram o web y vemos una demo posible.
     </p>
-    <a href={waLink(DEMO_WHATSAPP_MESSAGE)} target="_blank" rel="noreferrer" class="premium-button inline-flex w-fit items-center justify-center gap-2 rounded-2xl bg-brand-gradient px-5 py-3 text-sm font-semibold text-white shadow-glow">
+    <a href={waLink(DEMO_WHATSAPP_MESSAGE)} target="_blank" rel="noreferrer" class="premium-button inline-flex w-full max-w-full items-center justify-center gap-2 rounded-2xl bg-brand-gradient px-5 py-3 text-center text-sm font-semibold text-white shadow-glow sm:w-fit">
       Pedir una demo <span aria-hidden="true">↗</span>
     </a>
   </div>

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -14,7 +14,7 @@ const footerLinks = [
 ---
 <footer class="mt-20 border-t border-line bg-ink/75 backdrop-blur">
   <Container class="py-10 text-sm text-muted-soft">
-    <div class="grid gap-8 md:grid-cols-[1.05fr_1fr] md:items-center">
+    <div class="grid min-w-0 gap-8 md:grid-cols-[minmax(0,1.05fr)_minmax(0,1fr)] md:items-center">
       <div>
         <p class="text-base font-semibold text-slate-50">Marin.dev</p>
         <p class="mt-2 max-w-xl leading-6">
@@ -22,13 +22,13 @@ const footerLinks = [
         </p>
       </div>
 
-      <nav class="flex flex-wrap gap-2 md:justify-end" aria-label="Links de contacto y sitio">
+      <nav class="flex min-w-0 flex-wrap gap-2 md:justify-end" aria-label="Links de contacto y sitio">
         {footerLinks.map((link) => (
           <a
             href={link.href}
             target={link.external ? '_blank' : undefined}
             rel={link.external ? 'noopener noreferrer' : undefined}
-            class="inline-flex items-center gap-1.5 rounded-full border border-line bg-surface-glass px-3 py-1.5 text-xs font-medium transition hover:-translate-y-0.5 hover:border-line-strong hover:text-cyan-100"
+            class="inline-flex min-w-0 max-w-full items-center gap-1.5 rounded-full border border-line bg-surface-glass px-3 py-1.5 text-xs font-medium transition hover:-translate-y-0.5 hover:border-line-strong hover:text-cyan-100"
           >
             <Icon name={link.icon} size="sm" />
             <span>{link.label}</span>
@@ -39,7 +39,7 @@ const footerLinks = [
 
     <div class="mt-8 flex flex-col gap-3 border-t border-line pt-6 text-xs text-muted sm:flex-row sm:items-center sm:justify-between">
       <p>© {new Date().getFullYear()} Diego Marin. Todos los derechos reservados.</p>
-      <p class="inline-flex items-center gap-2">
+      <p class="inline-flex min-w-0 items-center gap-2">
         <span class="size-2 rounded-full bg-brand-success shadow-[0_0_1.125rem_rgba(52,211,153,0.55)]"></span>
         Sitio rápido, simple y fácil de mantener.
       </p>

--- a/src/components/HeroV2.astro
+++ b/src/components/HeroV2.astro
@@ -17,52 +17,52 @@ const trustBadges = [
   { label: 'Repo + deploy', icon: 'code', tone: 'violet' },
 ];
 ---
-<section class="relative overflow-hidden py-16 md:py-24" aria-labelledby="hero-title">
+<section class="relative py-16 md:overflow-x-clip md:py-24" aria-labelledby="hero-title">
   <div class="absolute left-1/2 top-10 -z-10 h-72 w-72 -translate-x-1/2 rounded-full bg-cyan-electric/15 blur-2xl md:bg-cyan-electric/20 md:blur-3xl" aria-hidden="true"></div>
   <div class="absolute -right-24 top-32 -z-10 hidden h-64 w-64 rounded-full bg-violet-electric/15 blur-3xl md:block" aria-hidden="true"></div>
   <div class="absolute inset-x-0 top-0 -z-10 h-px bg-gradient-to-r from-transparent via-cyan-electric/40 to-transparent" aria-hidden="true"></div>
 
-  <div class="grid items-center gap-10 lg:grid-cols-[0.92fr_1.08fr] lg:gap-14">
-    <div class="relative z-10">
-      <div class="inline-flex max-w-full items-center gap-3 rounded-full border border-cyan-electric/25 bg-cyan-electric/10 px-3 py-2 shadow-[0_0_32px_rgba(34,211,238,0.12)] backdrop-blur sm:px-4">
+  <div class="grid min-w-0 items-center gap-10 lg:grid-cols-[minmax(0,0.92fr)_minmax(0,1.08fr)] lg:gap-14">
+    <div class="relative z-10 min-w-0 max-w-full">
+      <div class="inline-flex min-w-0 max-w-full items-center gap-2 rounded-full sm:gap-3 border border-cyan-electric/25 bg-cyan-electric/10 px-3 py-2 shadow-[0_0_32px_rgba(34,211,238,0.12)] backdrop-blur sm:px-4">
         <IconBubble icon="rocket" tone="cyan" size="sm" label="Conversión, tecnología y velocidad" />
-        <span class="truncate text-xs font-semibold uppercase tracking-[0.18em] text-cyan-100 sm:tracking-[0.2em]">
+        <span class="min-w-0 text-xs font-semibold uppercase leading-5 tracking-[0.1em] text-cyan-100 sm:tracking-[0.2em]">
           Marin.dev · demos, webs y sistemas comerciales
         </span>
       </div>
 
-      <h1 id="hero-title" class="mt-6 max-w-4xl text-4xl font-semibold tracking-tight text-slate-50 sm:text-5xl lg:text-6xl">
+      <h1 id="hero-title" class="mt-6 max-w-full break-words text-[clamp(2.25rem,10vw,3.5rem)] font-semibold leading-[1.02] tracking-tight text-slate-50 sm:max-w-4xl sm:text-5xl lg:text-6xl">
         Webs y demos comerciales que convierten visitas en consultas.
       </h1>
-      <p class="mt-6 max-w-2xl text-base leading-8 text-muted-soft sm:text-lg">
+      <p class="mt-6 max-w-2xl break-words text-base leading-8 text-muted-soft sm:text-lg">
         Landings, demos y sistemas simples con mensaje claro, WhatsApp guiado y estructura lista para generar consultas.
       </p>
 
-      <div class="mt-6 flex flex-wrap gap-2.5" aria-label="Funciones que puede incluir una demo o web comercial">
+      <div class="mt-6 flex min-w-0 max-w-full flex-wrap gap-2.5" aria-label="Funciones que puede incluir una demo o web comercial">
         {heroBadges.map((badge) => (
           <VisualBadge label={badge.label} icon={badge.icon} tone={badge.tone} />
         ))}
       </div>
 
-      <div class="mt-8 flex flex-col gap-3 sm:flex-row">
+      <div class="mt-8 flex min-w-0 max-w-full flex-col gap-3 sm:flex-row">
         <a
           href={waLink(DEMO_WHATSAPP_MESSAGE)}
           target="_blank"
           rel="noopener noreferrer"
-          class="premium-button inline-flex min-h-12 items-center justify-center rounded-2xl bg-brand-gradient px-6 py-3 text-sm font-semibold text-white shadow-glow hover:-translate-y-0.5 hover:shadow-premium-hover"
+          class="premium-button inline-flex min-h-12 w-full max-w-full items-center justify-center whitespace-normal rounded-2xl bg-brand-gradient px-5 py-3 text-center text-sm font-semibold leading-5 text-white shadow-glow hover:-translate-y-0.5 hover:shadow-premium-hover sm:w-auto sm:px-6"
         >
           Quiero una demo para mi negocio
         </a>
         <a
           href="#casos"
-          class="premium-button inline-flex min-h-12 items-center justify-center rounded-2xl border border-line bg-surface-glass px-6 py-3 text-sm font-semibold text-slate-50 backdrop-blur hover:-translate-y-0.5 hover:border-line-strong hover:text-cyan-electric"
+          class="premium-button inline-flex min-h-12 w-full max-w-full items-center justify-center whitespace-normal rounded-2xl border border-line bg-surface-glass px-5 py-3 text-center text-sm font-semibold leading-5 text-slate-50 backdrop-blur hover:-translate-y-0.5 hover:border-line-strong hover:text-cyan-electric sm:w-auto sm:px-6"
         >
           Ver proyectos
         </a>
       </div>
 
-      <div class="mt-6 rounded-2xl border border-line bg-surface-glass/80 p-3 shadow-soft backdrop-blur sm:inline-flex sm:items-center sm:gap-3 sm:rounded-full sm:px-4 sm:py-2">
-        <p class="text-sm font-medium text-muted-soft">
+      <div class="mt-6 w-full max-w-full rounded-2xl border border-line bg-surface-glass/80 p-3 shadow-soft backdrop-blur sm:inline-flex sm:w-auto sm:items-center sm:gap-3 sm:rounded-full sm:px-4 sm:py-2">
+        <p class="break-words text-sm font-medium leading-6 text-muted-soft">
           Propuesta en 24h <span class="text-line-strong">•</span> pagos por hitos <span class="text-line-strong">•</span> repo + deploy
         </p>
       </div>

--- a/src/components/OutcomeGrid.astro
+++ b/src/components/OutcomeGrid.astro
@@ -5,7 +5,7 @@ import { outcomes } from '../data/outcomes';
 
 ---
 
-<section id="que-resuelvo" class="relative scroll-mt-24 overflow-hidden border-t border-line/70 py-14 md:py-20">
+<section id="que-resuelvo" class="relative min-w-0 scroll-mt-24 overflow-hidden border-t border-line/70 py-14 md:py-20">
   <div class="absolute -left-28 top-10 -z-10 h-56 w-56 rounded-full bg-cyan-electric/10 blur-3xl" aria-hidden="true"></div>
   <div class="absolute -right-32 bottom-10 -z-10 h-64 w-64 rounded-full bg-violet-electric/10 blur-3xl" aria-hidden="true"></div>
 
@@ -16,7 +16,7 @@ import { outcomes } from '../data/outcomes';
     icon="target"
   />
 
-  <div class="mt-8 grid gap-4 sm:grid-cols-2 lg:grid-cols-4 lg:gap-5">
+  <div class="mt-8 grid min-w-0 gap-4 sm:grid-cols-2 lg:grid-cols-4 lg:gap-5">
     {
       outcomes.map((item) => (
         <VisualCard

--- a/src/components/PricingPlans.astro
+++ b/src/components/PricingPlans.astro
@@ -134,10 +134,10 @@ const chooserItems = plans.map(({ name, chooser, comparison, tone }) => ({
     align="center"
   />
 
-  <div class="mx-auto mt-8 grid max-w-5xl gap-3 rounded-3xl border border-line bg-surface-glass p-3 text-sm text-muted-soft shadow-premium backdrop-blur md:grid-cols-2 xl:grid-cols-4">
+  <div class="mx-auto mt-8 grid min-w-0 max-w-5xl gap-3 rounded-3xl border border-line bg-surface-glass p-3 text-sm text-muted-soft shadow-premium backdrop-blur md:grid-cols-2 xl:grid-cols-4">
     {chooserItems.map((item) => (
-      <div class="group rounded-2xl border border-line bg-ink/35 px-4 py-3 transition hover:-translate-y-0.5 hover:border-line-strong hover:bg-surface-glass">
-        <div class="flex items-center justify-between gap-3">
+      <div class="group min-w-0 rounded-2xl border border-line bg-ink/35 px-4 py-3 transition hover:-translate-y-0.5 hover:border-line-strong hover:bg-surface-glass">
+        <div class="flex min-w-0 items-center justify-between gap-3">
           <VisualBadge label={item.chooser} icon="target" tone={item.tone} />
           <span class="h-px min-w-8 flex-1 bg-gradient-to-r from-line-strong to-transparent" aria-hidden="true"></span>
         </div>
@@ -147,10 +147,10 @@ const chooserItems = plans.map(({ name, chooser, comparison, tone }) => ({
     ))}
   </div>
 
-  <div class="mt-10 grid grid-cols-1 gap-6 lg:grid-cols-2 xl:grid-cols-4">
+  <div class="mt-10 grid min-w-0 grid-cols-1 gap-6 lg:grid-cols-2 xl:grid-cols-4">
     {plans.map((plan) => (
       <GlowCard
-        class={`relative flex h-full flex-col overflow-hidden ${plan.featured ? 'border-cyan-electric/40 shadow-glow' : ''}`}
+        class={`relative flex h-full min-w-0 flex-col overflow-hidden ${plan.featured ? 'border-cyan-electric/40 shadow-glow' : ''}`}
       >
         <div
           class={`absolute inset-x-0 top-0 h-1 bg-gradient-to-r ${
@@ -161,16 +161,16 @@ const chooserItems = plans.map(({ name, chooser, comparison, tone }) => ({
           aria-hidden="true"
         ></div>
 
-        <div class="flex items-start justify-between gap-4">
+        <div class="flex min-w-0 items-start justify-between gap-4">
           <IconBubble icon={plan.icon} tone={plan.tone} size="lg" />
-          <div class="flex flex-col items-end gap-2">
+          <div class="flex min-w-0 flex-col items-end gap-2">
             <Badge label={plan.badge} tone={plan.featured ? 'success' : 'cyan'} />
             <VisualBadge label={plan.chooser} icon="speed" tone={plan.tone} size="sm" />
           </div>
         </div>
 
         <div class="mt-5">
-          <h3 class="text-2xl font-semibold tracking-tight text-slate-50">{plan.name}</h3>
+          <h3 class="break-words text-2xl font-semibold tracking-tight text-slate-50">{plan.name}</h3>
           <p class="mt-3 text-sm leading-6 text-muted-soft">{plan.positioning}</p>
           <div class="mt-5 flex flex-wrap items-end gap-x-3 gap-y-1">
             <p class="text-2xl font-semibold text-slate-50">{plan.price}</p>
@@ -179,39 +179,39 @@ const chooserItems = plans.map(({ name, chooser, comparison, tone }) => ({
           <p class="mt-1 text-xs text-muted-soft">Precio estimado. Cotización final según alcance.</p>
         </div>
 
-        <div class="mt-5 flex flex-wrap gap-2">
+        <div class="mt-5 flex min-w-0 flex-wrap gap-2">
           {plan.attributes.map((attribute) => (
             <VisualBadge label={attribute.label} icon={attribute.icon} tone={plan.tone} />
           ))}
         </div>
 
         <div class="mt-6 rounded-2xl border border-line bg-ink/45 p-4">
-          <div class="flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.18em] text-cyan-electric">
+          <div class="flex min-w-0 items-center gap-2 text-xs font-semibold uppercase tracking-[0.1em] text-cyan-electric sm:tracking-[0.18em]">
             <Icon name="check" size="sm" />
             <span>Incluye</span>
           </div>
           <ul class="mt-4 space-y-3 text-sm leading-6 text-muted-soft">
             {plan.deliverables.map((deliverable) => (
-              <li class="flex gap-3">
+              <li class="flex min-w-0 gap-3">
                 <span
                   class="mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded-full border border-brand-success/25 bg-brand-success/10 text-brand-success"
                   aria-hidden="true"
                 >
                   <Icon name="check" size="sm" strokeWidth={2.2} />
                 </span>
-                <span>{deliverable}</span>
+                <span class="min-w-0 break-words">{deliverable}</span>
               </li>
             ))}
           </ul>
         </div>
 
         <div class="mt-5 rounded-2xl border border-cyan-electric/15 bg-cyan-electric/5 p-4">
-          <p class="text-xs font-semibold uppercase tracking-[0.18em] text-cyan-electric">Ideal para</p>
+          <p class="break-words text-xs font-semibold uppercase tracking-[0.1em] text-cyan-electric sm:tracking-[0.18em]">Ideal para</p>
           <p class="mt-2 text-sm leading-6 text-muted-soft">{plan.forWho}</p>
         </div>
 
         <div class="mt-5 rounded-2xl border border-line bg-surface-glass p-4">
-          <p class="text-xs font-semibold uppercase tracking-[0.18em] text-muted">Resuelve</p>
+          <p class="break-words text-xs font-semibold uppercase tracking-[0.1em] text-muted sm:tracking-[0.18em]">Resuelve</p>
           <p class="mt-2 text-sm leading-6 text-muted-soft">{plan.solves}</p>
           <p class="mt-3 text-xs font-medium text-slate-300">Tiempo estimado: {plan.time}</p>
         </div>
@@ -222,7 +222,7 @@ const chooserItems = plans.map(({ name, chooser, comparison, tone }) => ({
             href={waLink(SERVICE_WHATSAPP_MESSAGE(plan.name))}
             target="_blank"
             rel="noopener noreferrer"
-            class={`inline-flex w-full items-center justify-center gap-2 rounded-2xl px-5 py-3 text-sm font-semibold transition hover:-translate-y-0.5 ${
+            class={`inline-flex w-full max-w-full items-center justify-center gap-2 rounded-2xl px-5 py-3 text-center text-sm font-semibold transition hover:-translate-y-0.5 ${
               plan.featured
                 ? 'bg-brand-gradient text-white shadow-glow hover:shadow-premium-hover'
                 : 'border border-line bg-surface-glass text-slate-50 hover:border-line-strong hover:text-cyan-electric'

--- a/src/components/ProcessSteps.astro
+++ b/src/components/ProcessSteps.astro
@@ -3,14 +3,14 @@ import GlowCard from './GlowCard.astro';
 import SectionHeader from './SectionHeader.astro';
 import { processSteps } from '../data/process';
 ---
-<section class="py-14 md:py-20">
+<section class="min-w-0 py-14 md:py-20">
   <SectionHeader
     eyebrow="Proceso"
     title="De Instagram o idea suelta a una web lista para compartir."
     description="Un proceso corto, con avances revisables y foco en consultas, reservas o ventas."
     align="center"
   />
-  <div class="mt-10 grid gap-5 md:grid-cols-2 lg:grid-cols-4">
+  <div class="mt-10 grid min-w-0 gap-5 md:grid-cols-2 lg:grid-cols-4">
     {processSteps.map((item) => (
       <GlowCard class="h-full">
         <span class="inline-flex h-10 w-10 items-center justify-center rounded-2xl bg-brand-gradient text-sm font-bold text-white">{item.step}</span>

--- a/src/components/ProductizedServices.astro
+++ b/src/components/ProductizedServices.astro
@@ -13,33 +13,33 @@ const serviceBadges = [
   { label: 'Integraciones', icon: 'settings', tone: 'amber' },
 ];
 ---
-<section id="planes" class="relative scroll-mt-24 overflow-hidden rounded-[2rem] border border-line/80 bg-surface-glow px-4 py-14 shadow-premium md:px-6 md:py-20">
+<section id="planes" class="relative min-w-0 scroll-mt-24 overflow-hidden rounded-[2rem] border border-line/80 bg-surface-glow px-4 py-14 shadow-premium md:px-6 md:py-20">
   <div class="absolute -left-24 top-10 -z-10 h-56 w-56 rounded-full bg-cyan-electric/10 blur-3xl" aria-hidden="true"></div>
-  <div class="flex flex-col gap-5 lg:flex-row lg:items-end lg:justify-between">
+  <div class="flex min-w-0 flex-col gap-5 lg:flex-row lg:items-end lg:justify-between">
     <SectionHeader
       eyebrow="Servicios"
       title="Soluciones empaquetadas para avanzar rápido"
       description="Paquetes claros para definir alcance, prioridad comercial y próximos pasos sin perder semanas."
       icon="layout"
     />
-    <div class="flex flex-wrap gap-2 lg:max-w-md lg:justify-end">
+    <div class="flex min-w-0 max-w-full flex-wrap gap-2 lg:max-w-md lg:justify-end">
       {serviceBadges.map((badge) => <VisualBadge label={badge.label} icon={badge.icon} tone={badge.tone} />)}
     </div>
   </div>
-  <div class="mt-8 grid gap-6 md:grid-cols-2 xl:grid-cols-4">
+  <div class="mt-8 grid min-w-0 gap-6 md:grid-cols-2 xl:grid-cols-4">
     {productizedServices.map((service) => (
       <GlowCard class={`h-full ${service.featured ? 'border-cyan-electric/35' : ''}`}>
-        <div class="flex items-center justify-between gap-3">
+        <div class="flex min-w-0 items-center justify-between gap-3">
           <Badge label={service.tag} tone={service.featured ? 'success' : 'cyan'} />
           {service.featured && <span class="text-xs font-semibold uppercase tracking-[0.18em] text-brand-success">Recomendado</span>}
         </div>
-        <h3 class="mt-5 text-2xl font-semibold tracking-tight text-slate-50">{service.name}</h3>
+        <h3 class="mt-5 break-words text-2xl font-semibold tracking-tight text-slate-50">{service.name}</h3>
         <p class="mt-3 text-sm leading-6 text-muted-soft">{service.description}</p>
         <ul class="mt-5 space-y-3 text-sm text-muted-soft">
           {service.deliverables.map((item) => (
-            <li class="flex gap-3">
+            <li class="flex min-w-0 gap-3">
               <span class="mt-2 h-1.5 w-1.5 shrink-0 rounded-full bg-cyan-electric" aria-hidden="true"></span>
-              <span>{item}</span>
+              <span class="min-w-0 break-words">{item}</span>
             </li>
           ))}
         </ul>
@@ -47,7 +47,7 @@ const serviceBadges = [
           href={waLink(SERVICE_WHATSAPP_MESSAGE(service.name))}
           target="_blank"
           rel="noopener noreferrer"
-          class="premium-button mt-6 inline-flex w-full items-center justify-center rounded-2xl border border-line bg-surface-glass px-5 py-3 text-sm font-semibold text-slate-50 hover:-translate-y-0.5 hover:border-line-strong hover:text-cyan-electric"
+          class="premium-button mt-6 inline-flex w-full max-w-full items-center justify-center rounded-2xl border border-line bg-surface-glass px-5 py-3 text-center text-sm font-semibold text-slate-50 hover:-translate-y-0.5 hover:border-line-strong hover:text-cyan-electric"
         >
           Consultar este paquete
         </a>

--- a/src/components/ProjectCard.astro
+++ b/src/components/ProjectCard.astro
@@ -93,9 +93,9 @@ const stackChips = Array.isArray(stack) ? stack.slice(0, STACK_LIMIT) : [];
 const copyFocus = highlight || solucion || problema;
 ---
 <article
-  class="group premium-interactive flex h-full flex-col overflow-hidden rounded-3xl border border-line bg-surface-glow shadow-premium backdrop-blur hover:-translate-y-1 hover:border-line-strong hover:shadow-premium-hover"
+  class="group premium-interactive flex h-full min-w-0 flex-col overflow-hidden rounded-3xl border border-line bg-surface-glow shadow-premium backdrop-blur hover:-translate-y-1 hover:border-line-strong hover:shadow-premium-hover"
 >
-  <div class="relative overflow-hidden border-b border-line bg-ink/60">
+  <div class="relative min-w-0 overflow-hidden border-b border-line bg-ink/60">
     {hasImage ? (
       <a href={resolvedCaseUrl} class="block focus-visible:outline-none" aria-label={`Abrir caso de ${title}`}>
         <img
@@ -110,31 +110,31 @@ const copyFocus = highlight || solucion || problema;
       </a>
     ) : (
       <a href={resolvedCaseUrl} class="block focus-visible:outline-none" aria-label={`Abrir caso de ${title}`}>
-        <div class={`relative aspect-[16/10] overflow-hidden bg-ink ${visualStyles.gradient}`}>
+        <div class={`relative aspect-[16/10] min-w-0 overflow-hidden bg-ink ${visualStyles.gradient}`}>
           <div class="absolute inset-0 bg-premium-grid bg-[length:2rem_2rem] opacity-45"></div>
           <div class={`absolute -left-16 top-4 hidden h-44 w-44 rounded-full blur-3xl transition duration-500 group-hover:opacity-90 md:block ${visualStyles.glowPrimary}`}></div>
           <div class={`absolute -right-16 bottom-0 hidden h-48 w-48 rounded-full blur-3xl transition duration-500 group-hover:opacity-90 md:block ${visualStyles.glowSecondary}`}></div>
-          <div class="absolute inset-x-5 top-5 flex items-center gap-2 rounded-2xl border border-line bg-surface-glass px-3 py-2 shadow-premium backdrop-blur">
+          <div class="absolute inset-x-5 top-5 flex min-w-0 items-center gap-2 rounded-2xl border border-line bg-surface-glass px-3 py-2 shadow-premium backdrop-blur">
             <span class="h-2.5 w-2.5 rounded-full bg-rose-400/90"></span>
             <span class="h-2.5 w-2.5 rounded-full bg-amber-300/90"></span>
             <span class="h-2.5 w-2.5 rounded-full bg-brand-success/90"></span>
             <span class="ml-2 h-2 flex-1 rounded-full bg-slate-700/80"></span>
             <span class={`h-2 w-12 rounded-full ${visualStyles.line}`}></span>
           </div>
-          <div class="relative flex h-full flex-col justify-end p-5 pt-16">
-            <div class="rounded-3xl border border-line bg-surface-glass p-4 shadow-premium backdrop-blur">
-              <div class="flex items-center justify-between gap-3">
+          <div class="relative flex h-full min-w-0 flex-col justify-end p-5 pt-16">
+            <div class="min-w-0 rounded-3xl border border-line bg-surface-glass p-4 shadow-premium backdrop-blur">
+              <div class="flex min-w-0 items-center justify-between gap-3">
                 <div class={`flex h-14 w-14 shrink-0 items-center justify-center rounded-2xl border text-lg font-black tracking-tight ${visualStyles.iconShell}`}>
                   <span aria-hidden="true" class="text-xl leading-none">{visualSystem.category.icon}</span>
                   <span class="sr-only">{visualSystem.initials}</span>
                 </div>
-                <div class="text-right">
-                  <p class="text-[0.68rem] font-semibold uppercase tracking-[0.22em] text-muted-soft">Mini caso</p>
+                <div class="min-w-0 text-right">
+                  <p class="break-words text-[0.68rem] font-semibold uppercase tracking-[0.1em] text-muted-soft sm:tracking-[0.22em]">Mini caso</p>
                   <p class={`mt-1 text-xs font-semibold ${visualStyles.accentText}`}>{visualSystem.initials}</p>
                 </div>
               </div>
-              <p class={`mt-4 text-xs font-semibold uppercase tracking-[0.2em] ${visualStyles.accentText}`}>{commercialType}</p>
-              <p class="mt-2 line-clamp-2 text-lg font-semibold leading-tight text-slate-50">{title}</p>
+              <p class={`mt-4 break-words text-xs font-semibold uppercase tracking-[0.1em] sm:tracking-[0.2em] ${visualStyles.accentText}`}>{commercialType}</p>
+              <p class="mt-2 line-clamp-2 break-words text-lg font-semibold leading-tight text-slate-50">{title}</p>
               <div class="mt-4 flex flex-wrap gap-2" aria-hidden="true">
                 {visualPills.map((item: string) => (
                   <span class={`rounded-full border px-2 py-1 text-[0.68rem] font-semibold ${visualStyles.chip}`}>{item}</span>
@@ -147,24 +147,24 @@ const copyFocus = highlight || solucion || problema;
     )}
 
     <div class="pointer-events-none absolute inset-x-0 bottom-0 h-24 bg-gradient-to-t from-ink/95 to-transparent"></div>
-    <div class="absolute left-4 top-4 flex flex-wrap gap-2">
+    <div class="absolute inset-x-4 top-4 flex min-w-0 flex-wrap gap-2">
       {isStarProject && <Badge label="Proyecto estrella" tone="success" />}
       <Badge label={commercialType} tone="cyan" />
       {status && <Badge label={statusLabels[status] ?? status} tone={statusTone[status] ?? 'default'} />}
     </div>
   </div>
 
-  <div class="relative z-10 flex min-h-[24rem] flex-1 flex-col p-5 sm:p-6">
+  <div class="relative z-10 flex min-h-[24rem] min-w-0 flex-1 flex-col p-5 sm:p-6">
     <div>
-      <p class="text-xs font-semibold uppercase tracking-[0.22em] text-muted">{businessLabel}</p>
-      <h3 class="mt-2 text-xl font-semibold tracking-tight text-slate-50 transition group-hover:text-cyan-electric">
+      <p class="break-words text-xs font-semibold uppercase tracking-[0.1em] text-muted sm:tracking-[0.22em]">{businessLabel}</p>
+      <h3 class="mt-2 break-words text-xl font-semibold tracking-tight text-slate-50 transition group-hover:text-cyan-electric">
         <a href={resolvedCaseUrl} class="focus-visible:outline-none">{title}</a>
       </h3>
       {resumen && <p class="mt-3 line-clamp-3 text-sm leading-6 text-muted-soft">{resumen}</p>}
     </div>
 
     {copyFocus && (
-      <div class="mt-5 rounded-2xl border border-line bg-ink/35 p-4 text-sm leading-6 text-muted-soft">
+      <div class="mt-5 min-w-0 rounded-2xl border border-line bg-ink/35 p-4 text-sm leading-6 text-muted-soft">
         {highlight ? (
           <p><span class="font-semibold text-slate-50">Clave:</span> {highlight}</p>
         ) : (
@@ -181,38 +181,38 @@ const copyFocus = highlight || solucion || problema;
     )}
 
     {primaryChips.length > 0 && (
-      <div class="mt-5 flex flex-wrap gap-2" aria-label="Categorías y funcionalidades">
+      <div class="mt-5 flex min-w-0 max-w-full flex-wrap gap-2" aria-label="Categorías y funcionalidades">
         {primaryChips.slice(0, FEATURE_LIMIT).map((item: string) => <Badge label={item} />)}
       </div>
     )}
 
     {benefit && (
-      <p class="mt-5 rounded-2xl border border-brand-success/20 bg-brand-success/10 p-3 text-sm leading-6 text-emerald-100">
+      <p class="mt-5 min-w-0 break-words rounded-2xl border border-brand-success/20 bg-brand-success/10 p-3 text-sm leading-6 text-emerald-100">
         <span class="font-semibold">Resultado / beneficio:</span> {benefit}
       </p>
     )}
 
     {stackChips.length > 0 && (
       <div class="mt-5 border-t border-line pt-4">
-        <p class="text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-muted">Tecnologías</p>
-        <div class="mt-2 flex flex-wrap gap-2">
+        <p class="break-words text-[0.68rem] font-semibold uppercase tracking-[0.1em] text-muted sm:tracking-[0.2em]">Tecnologías</p>
+        <div class="mt-2 flex min-w-0 flex-wrap gap-2">
           {stackChips.map((item: string) => <Badge label={item} tone="violet" />)}
         </div>
       </div>
     )}
 
-    <div class="mt-auto flex flex-wrap items-center gap-3 pt-6">
-      <a href={resolvedCaseUrl} class="premium-button inline-flex items-center gap-2 rounded-2xl bg-brand-gradient px-4 py-2.5 text-sm font-semibold text-white shadow-glow">
+    <div class="mt-auto flex min-w-0 flex-col items-stretch gap-3 pt-6 sm:flex-row sm:flex-wrap sm:items-center">
+      <a href={resolvedCaseUrl} class="premium-button inline-flex w-full max-w-full items-center justify-center gap-2 rounded-2xl bg-brand-gradient px-4 py-2.5 text-center text-sm font-semibold text-white shadow-glow sm:w-auto">
         {ctaLabel}
         <span aria-hidden="true" class="transition duration-300 group-hover:translate-x-1">→</span>
       </a>
       {demoUrl && (
-        <a href={demoUrl} target="_blank" rel="noreferrer" class="inline-flex items-center gap-1.5 rounded-2xl border border-line bg-surface-glass px-4 py-2.5 text-sm font-semibold text-cyan-electric transition hover:border-line-strong hover:bg-surface-800/70">
+        <a href={demoUrl} target="_blank" rel="noreferrer" class="inline-flex w-full max-w-full items-center justify-center gap-1.5 rounded-2xl border border-line bg-surface-glass px-4 py-2.5 text-center text-sm font-semibold text-cyan-electric transition hover:border-line-strong hover:bg-surface-800/70 sm:w-auto">
           Ver demo <span aria-hidden="true">↗</span>
         </a>
       )}
       {!demoUrl && repoUrl && (
-        <a href={repoUrl} target="_blank" rel="noreferrer" class="inline-flex items-center gap-1.5 rounded-2xl border border-line bg-surface-glass px-4 py-2.5 text-sm font-semibold text-cyan-electric transition hover:border-line-strong hover:bg-surface-800/70">
+        <a href={repoUrl} target="_blank" rel="noreferrer" class="inline-flex w-full max-w-full items-center justify-center gap-1.5 rounded-2xl border border-line bg-surface-glass px-4 py-2.5 text-center text-sm font-semibold text-cyan-electric transition hover:border-line-strong hover:bg-surface-800/70 sm:w-auto">
           Ver repo <span aria-hidden="true">↗</span>
         </a>
       )}

--- a/src/components/ProjectLinkPreview.astro
+++ b/src/components/ProjectLinkPreview.astro
@@ -22,17 +22,17 @@ if (hasPreviewUrl) {
   previewHost = parsedUrl.host.replace(/^www\./, '');
 }
 ---
-<div class="relative">
+<div class="relative min-w-0 max-w-full">
   <div class="absolute -inset-4 rounded-[2rem] bg-cyan-electric/10 blur-3xl"></div>
-  <div class="relative overflow-hidden rounded-3xl border border-line bg-surface-glow p-3 shadow-premium">
-    <div class="flex items-center gap-2 border-b border-line px-2 pb-3">
+  <div class="relative min-w-0 overflow-hidden rounded-3xl border border-line bg-surface-glow p-3 shadow-premium">
+    <div class="flex min-w-0 items-center gap-2 border-b border-line px-2 pb-3">
       <span class="h-2.5 w-2.5 rounded-full bg-red-400/80"></span>
       <span class="h-2.5 w-2.5 rounded-full bg-amber-300/80"></span>
       <span class="h-2.5 w-2.5 rounded-full bg-emerald-400/80"></span>
-      <span class="ml-2 truncate rounded-full border border-line bg-ink/60 px-3 py-1 text-xs text-muted">{previewHost}</span>
+      <span class="ml-2 min-w-0 flex-1 truncate rounded-full border border-line bg-ink/60 px-3 py-1 text-xs text-muted">{previewHost}</span>
     </div>
 
-    <div class="relative mt-3 aspect-[4/3] overflow-hidden rounded-2xl border border-line bg-ink">
+    <div class="relative mt-3 aspect-[4/3] min-w-0 overflow-hidden rounded-2xl border border-line bg-ink">
       {shouldRenderIframe ? (
         <>
           <iframe
@@ -59,15 +59,15 @@ if (hasPreviewUrl) {
           <div class="pointer-events-none absolute inset-0 bg-gradient-to-t from-ink via-ink/15 to-transparent"></div>
         </>
       ) : (
-        <div class="relative flex h-full flex-col justify-between overflow-hidden p-5">
+        <div class="relative flex h-full min-w-0 flex-col justify-between overflow-hidden p-5">
           <div class="absolute inset-0 bg-premium-grid bg-[length:2rem_2rem] opacity-45"></div>
           <div class="absolute -left-16 top-6 h-40 w-40 rounded-full bg-cyan-electric/20 blur-3xl"></div>
           <div class="absolute -right-14 bottom-0 h-44 w-44 rounded-full bg-brand-violet/20 blur-3xl"></div>
           <div class="relative rounded-2xl border border-line bg-surface-glass p-4 shadow-premium backdrop-blur">
-            <p class="text-xs font-semibold uppercase tracking-[0.2em] text-cyan-electric">Preview del caso</p>
-            <p class="mt-2 text-lg font-semibold leading-tight text-slate-50">{title}</p>
+            <p class="break-words text-xs font-semibold uppercase tracking-[0.1em] text-cyan-electric sm:tracking-[0.2em]">Preview del caso</p>
+            <p class="mt-2 break-words text-lg font-semibold leading-tight text-slate-50">{title}</p>
           </div>
-          <div class="relative grid gap-3 rounded-2xl border border-line bg-ink/45 p-4 shadow-premium backdrop-blur">
+          <div class="relative grid min-w-0 gap-3 rounded-2xl border border-line bg-ink/45 p-4 shadow-premium backdrop-blur">
             <div class="h-2 rounded-full bg-slate-600/70"></div>
             <div class="h-2 w-4/5 rounded-full bg-slate-700/80"></div>
             <div class="mt-2 grid grid-cols-3 gap-2">
@@ -81,8 +81,8 @@ if (hasPreviewUrl) {
 
       <div class="absolute inset-x-0 bottom-0 p-4">
         <div class="rounded-2xl border border-line bg-ink/85 p-4 shadow-premium backdrop-blur">
-          <p class="text-xs font-semibold uppercase tracking-[0.2em] text-cyan-electric">{hasPreviewUrl ? 'Demo externa' : 'Preview estático'}</p>
-          <div class="mt-2 flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+          <p class="break-words text-xs font-semibold uppercase tracking-[0.1em] text-cyan-electric sm:tracking-[0.2em]">{hasPreviewUrl ? 'Demo externa' : 'Preview estático'}</p>
+          <div class="mt-2 flex min-w-0 flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
             <div class="min-w-0">
               <p class="truncate text-base font-semibold text-slate-50">{title || previewHost}</p>
               <p class="mt-1 truncate text-xs text-muted-soft">{previewHost}</p>
@@ -92,7 +92,7 @@ if (hasPreviewUrl) {
                 href={url}
                 target="_blank"
                 rel="noopener noreferrer"
-                class="inline-flex shrink-0 items-center justify-center gap-2 rounded-xl border border-line bg-slate-50 px-4 py-2 text-xs font-semibold text-ink shadow-premium transition hover:-translate-y-0.5 hover:border-cyan-electric/40 hover:bg-white"
+                class="inline-flex w-full max-w-full items-center justify-center gap-2 rounded-xl border border-line bg-slate-50 px-4 py-2 text-center text-xs font-semibold text-ink shadow-premium transition hover:-translate-y-0.5 hover:border-cyan-electric/40 hover:bg-white sm:w-auto sm:shrink-0"
                 aria-label={`Abrir demo externa de ${title} en una pestaña nueva`}
               >
                 Abrir demo <span aria-hidden="true">↗</span>

--- a/src/components/SectionHeader.astro
+++ b/src/components/SectionHeader.astro
@@ -14,28 +14,28 @@ const isCenter = align === 'center';
 const alignment = isCenter ? 'mx-auto items-center text-center' : 'items-start text-left';
 const eyebrowAlignment = isCenter ? 'justify-center' : 'justify-start';
 ---
-<header class={`relative flex max-w-3xl flex-col gap-4 ${alignment} ${className}`}>
-  <div class={`flex w-full items-center gap-3 ${eyebrowAlignment}`}>
+<header class={`relative flex min-w-0 max-w-full flex-col gap-4 sm:max-w-3xl ${alignment} ${className}`}>
+  <div class={`flex w-full min-w-0 flex-wrap items-center gap-3 ${eyebrowAlignment}`}>
     {icon && <IconBubble icon={icon} tone="cyan" size="sm" label={eyebrow ?? title ?? 'Sección'} />}
     {eyebrow && (
-      <p class="inline-flex w-fit items-center rounded-full border border-line bg-surface-glass px-3 py-1 text-xs font-semibold uppercase tracking-[0.22em] text-cyan-electric shadow-[inset_0_1px_0_rgba(255,255,255,0.06)] backdrop-blur">
+      <p class="inline-flex min-w-0 max-w-full items-center rounded-full border border-line bg-surface-glass px-3 py-1 text-xs font-semibold uppercase tracking-[0.1em] text-cyan-electric shadow-[inset_0_1px_0_rgba(255,255,255,0.06)] backdrop-blur sm:w-fit sm:tracking-[0.22em]">
         <span class="mr-2 h-1.5 w-1.5 rounded-full bg-cyan-electric shadow-[0_0_14px_rgba(34,211,238,0.7)]" aria-hidden="true"></span>
-        {eyebrow}
+        <span class="min-w-0 break-words leading-5">{eyebrow}</span>
       </p>
     )}
   </div>
 
-  <div class="relative">
+  <div class="relative min-w-0 max-w-full">
     <div class={`pointer-events-none absolute -inset-x-4 -inset-y-3 -z-10 hidden rounded-3xl bg-gradient-to-r from-cyan-electric/10 via-blue-electric/5 to-violet-electric/10 blur-2xl sm:block ${isCenter ? 'opacity-60' : 'opacity-45'}`}></div>
     {title && (
-      <h2 class="text-3xl font-semibold tracking-tight text-slate-50 sm:text-4xl lg:text-5xl">
+      <h2 class="max-w-full break-words text-3xl font-semibold tracking-tight text-slate-50 sm:text-4xl lg:text-5xl">
         {title}
       </h2>
     )}
   </div>
 
   {description && (
-    <p class={`text-base leading-7 text-muted-soft sm:text-lg ${isCenter ? 'mx-auto max-w-2xl' : 'max-w-copy'}`}>
+    <p class={`max-w-full break-words text-base leading-7 text-muted-soft sm:text-lg ${isCenter ? 'mx-auto sm:max-w-2xl' : 'sm:max-w-copy'}`}>
       {description}
     </p>
   )}

--- a/src/components/SocialProofStrip.astro
+++ b/src/components/SocialProofStrip.astro
@@ -2,15 +2,15 @@
 import IconBubble from './IconBubble.astro';
 import { capabilityStrip } from '../data/site';
 ---
-<section class="py-6 md:py-8" aria-label="Capacidades comerciales">
-  <div class="rounded-3xl border border-line bg-surface-glass p-3 shadow-premium backdrop-blur">
-    <div class="grid gap-3 sm:grid-cols-2 lg:grid-cols-5">
+<section class="min-w-0 py-6 md:py-8" aria-label="Capacidades comerciales">
+  <div class="min-w-0 rounded-3xl border border-line bg-surface-glass p-3 shadow-premium backdrop-blur">
+    <div class="grid min-w-0 gap-3 sm:grid-cols-2 lg:grid-cols-5">
       {capabilityStrip.map((item, index) => (
-        <article class="group premium-interactive relative overflow-hidden rounded-2xl border border-line bg-ink/35 p-4 hover:border-cyan-electric/35 hover:bg-ink/55">
+        <article class="group premium-interactive relative min-w-0 overflow-hidden rounded-2xl border border-line bg-ink/35 p-4 hover:border-cyan-electric/35 hover:bg-ink/55">
           <div class="absolute right-3 top-3 text-[2.5rem] font-black leading-none text-slate-50/[0.03]" aria-hidden="true">
             0{index + 1}
           </div>
-          <div class="relative flex items-start gap-3">
+          <div class="relative flex min-w-0 items-start gap-3">
             <IconBubble icon={item.icon} tone={item.tone} size="sm" />
             <div class="min-w-0">
               <h2 class="text-sm font-semibold text-slate-50">{item.title}</h2>

--- a/src/components/VerticalDemos.astro
+++ b/src/components/VerticalDemos.astro
@@ -6,32 +6,32 @@ import SectionHeader from './SectionHeader.astro';
 import { verticalDemos } from '../data/verticals';
 import { waLink } from '../lib/contact';
 ---
-<section class="py-14 md:py-20">
+<section class="min-w-0 py-14 md:py-20">
   <SectionHeader
     eyebrow="Demos por rubro"
     title="Una demo concreta vende mejor que una explicación abstracta."
     description="Cada rubro necesita ver su oferta, reservas y WhatsApp ordenados como los usaría un cliente real."
     icon="layout"
   />
-  <div class="mt-8 grid gap-5 md:grid-cols-2">
+  <div class="mt-8 grid min-w-0 gap-5 md:grid-cols-2">
     {verticalDemos.map((demo) => (
       <GlowCard class="h-full">
-        <div class="flex items-start gap-4">
+        <div class="flex min-w-0 items-start gap-4">
           <IconBubble icon={demo.icon ?? 'briefcase'} tone={demo.tone ?? 'cyan'} size="md" />
           <div class="min-w-0 flex-1">
             <p class="text-sm font-semibold text-cyan-electric">{demo.name}</p>
-            <h3 class="mt-2 text-xl font-semibold tracking-tight text-slate-50">Demo comercial lista para mostrar</h3>
+            <h3 class="mt-2 break-words text-xl font-semibold tracking-tight text-slate-50">Demo comercial lista para mostrar</h3>
           </div>
         </div>
 
-        <div class="mt-5 grid gap-3 text-sm leading-6 text-muted-soft">
-          <p class="rounded-2xl border border-line bg-ink/35 p-3"><strong class="text-slate-50">Hoy:</strong> {demo.problem}</p>
-          <p class="rounded-2xl border border-line bg-ink/35 p-3"><strong class="text-slate-50">Se ordena con:</strong> {demo.solution}</p>
+        <div class="mt-5 grid min-w-0 gap-3 text-sm leading-6 text-muted-soft">
+          <p class="min-w-0 break-words rounded-2xl border border-line bg-ink/35 p-3"><strong class="text-slate-50">Hoy:</strong> {demo.problem}</p>
+          <p class="min-w-0 break-words rounded-2xl border border-line bg-ink/35 p-3"><strong class="text-slate-50">Se ordena con:</strong> {demo.solution}</p>
         </div>
 
-        <div class="mt-5 flex flex-wrap gap-2" aria-label={`Funciones para ${demo.name}`}>
+        <div class="mt-5 flex min-w-0 max-w-full flex-wrap gap-2" aria-label={`Funciones para ${demo.name}`}>
           {demo.features.slice(0, 3).map((feature) => (
-            <span class="rounded-full border border-line bg-ink/45 px-3 py-1 text-xs font-semibold text-muted-bright">{feature}</span>
+            <span class="min-w-0 max-w-full rounded-full border border-line bg-ink/45 px-3 py-1 text-xs font-semibold text-muted-bright">{feature}</span>
           ))}
         </div>
 
@@ -39,7 +39,7 @@ import { waLink } from '../lib/contact';
           href={waLink(`Hola Diego, quiero una demo para este rubro: ${demo.name}.\n\nObjetivo: [más consultas / reservas / ventas]\nHoy tengo: [Instagram / web / nada]\nLink de referencia: [Instagram o web]`)}
           target="_blank"
           rel="noopener noreferrer"
-          class="premium-button mt-6 inline-flex w-fit items-center gap-2 rounded-2xl border border-line bg-surface-glass px-4 py-2 text-sm font-semibold text-slate-50 hover:-translate-y-0.5 hover:border-cyan-electric/35 hover:text-cyan-electric"
+          class="premium-button mt-6 inline-flex w-full max-w-full items-center justify-center gap-2 rounded-2xl border border-line bg-surface-glass px-4 py-2 text-center text-sm font-semibold text-slate-50 hover:-translate-y-0.5 hover:border-cyan-electric/35 hover:text-cyan-electric sm:w-fit"
         >
           Pedir demo <Icon name="arrow" size="sm" />
         </a>

--- a/src/components/VisualBadge.astro
+++ b/src/components/VisualBadge.astro
@@ -22,7 +22,7 @@ const sizeClasses = {
   md: 'gap-2 px-3 py-1.5 text-xs',
 };
 ---
-<span class={`inline-flex w-fit items-center rounded-full border font-semibold uppercase tracking-[0.16em] backdrop-blur ${toneClasses[tone] ?? toneClasses.neutral} ${sizeClasses[size] ?? sizeClasses.sm} ${className}`}>
+<span class={`inline-flex min-w-0 max-w-full items-center rounded-full border font-semibold uppercase tracking-[0.1em] backdrop-blur sm:w-fit sm:tracking-[0.16em] ${toneClasses[tone] ?? toneClasses.neutral} ${sizeClasses[size] ?? sizeClasses.sm} ${className}`}>
   {icon && <Icon name={icon} size="sm" />}
-  <span>{label}</span>
+  <span class="min-w-0 break-words leading-5">{label}</span>
 </span>

--- a/src/components/VisualCard.astro
+++ b/src/components/VisualCard.astro
@@ -17,19 +17,19 @@ const attrs = href ? { href } : {};
 ---
 <Tag
   {...attrs}
-  class={`group premium-interactive block h-full overflow-hidden rounded-3xl border border-line bg-surface-glow p-5 shadow-premium backdrop-blur hover:border-line-strong hover:shadow-premium-hover focus-visible:outline-cyan-electric ${className}`}
+  class={`group premium-interactive block h-full min-w-0 overflow-hidden rounded-3xl border border-line bg-surface-glow p-5 shadow-premium backdrop-blur hover:border-line-strong hover:shadow-premium-hover focus-visible:outline-cyan-electric ${className}`}
 >
   <div class="pointer-events-none absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-cyan-electric/50 to-transparent opacity-70"></div>
   <div class="pointer-events-none absolute -right-16 -top-16 hidden h-32 w-32 rounded-full bg-cyan-electric/10 blur-3xl transition duration-300 group-hover:bg-cyan-electric/20 md:block"></div>
 
-  <div class="relative flex h-full flex-col gap-4">
-    <div class="flex items-start justify-between gap-4">
+  <div class="relative flex h-full min-w-0 flex-col gap-4">
+    <div class="flex min-w-0 items-start justify-between gap-4">
       {icon && <IconBubble icon={icon} tone={tone} size="md" />}
       {badge && <VisualBadge label={badge} tone={tone} />}
     </div>
 
-    <div>
-      {title && <h3 class="text-lg font-semibold tracking-tight text-slate-50">{title}</h3>}
+    <div class="min-w-0">
+      {title && <h3 class="break-words text-lg font-semibold tracking-tight text-slate-50">{title}</h3>}
       {description && <p class="mt-3 text-sm leading-6 text-muted-soft">{description}</p>}
     </div>
 

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -143,10 +143,10 @@ const faqJsonLd = {
 
     <link rel="icon" href="/favicon.svg" />
   </head>
-  <body class="theme-v2 v2-shell min-h-screen bg-ink text-slate-50 antialiased overflow-x-hidden overscroll-contain">
+  <body class="theme-v2 v2-shell min-h-screen bg-ink text-slate-50 antialiased overscroll-contain">
     <a href="#contenido" class="sr-only focus:not-sr-only focus:fixed focus:left-4 focus:top-4 focus:z-[100] focus:rounded-lg focus:bg-slate-50 focus:px-4 focus:py-2 focus:text-sm focus:font-semibold focus:text-ink">Saltar al contenido</a>
     <Nav />
-    <main id="contenido" class="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
+    <main id="contenido" class="mx-auto min-w-0 max-w-6xl px-4 sm:px-6 lg:px-8">
       <slot />
     </main>
     <Footer />

--- a/src/pages/contacto.astro
+++ b/src/pages/contacto.astro
@@ -79,17 +79,17 @@ const contactCards = [
 ---
 <BaseLayout {title} {description} {url} {image}>
   <Container class="py-12 md:py-16 lg:py-20">
-    <section class="relative overflow-hidden rounded-[2.25rem] border border-line bg-surface-glass p-5 shadow-premium backdrop-blur md:p-8 lg:p-10">
+    <section class="relative min-w-0 overflow-hidden rounded-[2.25rem] border border-line bg-surface-glass p-5 shadow-premium backdrop-blur md:p-8 lg:p-10">
       <div class="pointer-events-none absolute -left-20 top-8 h-64 w-64 rounded-full bg-cyan-electric/15 blur-3xl"></div>
       <div class="pointer-events-none absolute -right-24 bottom-6 h-72 w-72 rounded-full bg-violet-electric/15 blur-3xl"></div>
 
-      <div class="relative grid gap-8 lg:grid-cols-[0.88fr_1.12fr] lg:items-start">
-        <aside class="space-y-6">
-          <div>
-            <p class="inline-flex rounded-full border border-cyan-electric/30 bg-cyan-electric/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.22em] text-cyan-100">
+      <div class="relative grid min-w-0 gap-8 lg:grid-cols-[minmax(0,0.88fr)_minmax(0,1.12fr)] lg:items-start">
+        <aside class="min-w-0 space-y-6">
+          <div class="min-w-0">
+            <p class="inline-flex min-w-0 max-w-full rounded-full border border-cyan-electric/30 bg-cyan-electric/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.1em] text-cyan-100 sm:tracking-[0.22em]">
               Contacto guiado
             </p>
-            <h1 class="mt-5 text-3xl font-semibold tracking-tight text-slate-50 sm:text-4xl lg:text-5xl">
+            <h1 class="mt-5 break-words text-3xl font-semibold tracking-tight text-slate-50 sm:text-4xl lg:text-5xl">
               Contame qué querés mejorar y te digo el mejor camino
             </h1>
             <p class="mt-5 text-base leading-7 text-muted-soft sm:text-lg">
@@ -97,16 +97,16 @@ const contactCards = [
             </p>
           </div>
 
-          <div class="grid gap-3 sm:grid-cols-3 lg:grid-cols-1">
-            <div class="rounded-2xl border border-line bg-ink/45 p-4">
+          <div class="grid min-w-0 gap-3 sm:grid-cols-3 lg:grid-cols-1">
+            <div class="min-w-0 rounded-2xl border border-line bg-ink/45 p-4">
               <p class="text-sm font-semibold text-slate-50">1. Me pasás contexto</p>
               <p class="mt-1 text-sm leading-6 text-muted-soft">Rubro, link actual y objetivo principal.</p>
             </div>
-            <div class="rounded-2xl border border-line bg-ink/45 p-4">
+            <div class="min-w-0 rounded-2xl border border-line bg-ink/45 p-4">
               <p class="text-sm font-semibold text-slate-50">2. Ordeno la oportunidad</p>
               <p class="mt-1 text-sm leading-6 text-muted-soft">Te digo si conviene demo, landing o sistema simple.</p>
             </div>
-            <div class="rounded-2xl border border-line bg-ink/45 p-4">
+            <div class="min-w-0 rounded-2xl border border-line bg-ink/45 p-4">
               <p class="text-sm font-semibold text-slate-50">3. Hablamos por WhatsApp</p>
               <p class="mt-1 text-sm leading-6 text-muted-soft">Sin formulario frío ni datos sensibles.</p>
             </div>
@@ -116,9 +116,9 @@ const contactCards = [
             <p class="text-sm font-semibold text-slate-50">Canales directos</p>
             <div class="mt-4 space-y-3">
               {contactCards.map((card) => (
-                <a class="group/contact flex items-center justify-between gap-4 rounded-2xl border border-line bg-white/[0.04] px-4 py-3 text-sm transition hover:-translate-y-0.5 hover:border-cyan-electric/40 hover:bg-cyan-electric/10" href={card.href} target={card.href.startsWith("http") ? "_blank" : undefined} rel={card.href.startsWith("http") ? "noopener noreferrer" : undefined}>
-                  <span>
-                    <span class="block font-medium text-slate-100">{card.label}</span>
+                <a class="group/contact flex min-w-0 items-center justify-between gap-4 rounded-2xl border border-line bg-white/[0.04] px-4 py-3 text-sm transition hover:-translate-y-0.5 hover:border-cyan-electric/40 hover:bg-cyan-electric/10" href={card.href} target={card.href.startsWith("http") ? "_blank" : undefined} rel={card.href.startsWith("http") ? "noopener noreferrer" : undefined}>
+                  <span class="min-w-0">
+                    <span class="block break-words font-medium text-slate-100">{card.label}</span>
                     <span class="mt-0.5 block text-muted-soft">{card.value}</span>
                   </span>
                   <span class="text-cyan-100 transition group-hover/contact:translate-x-1" aria-hidden="true">→</span>
@@ -128,13 +128,13 @@ const contactCards = [
           </GlowCard>
         </aside>
 
-        <form id="contacto" class="rounded-[2rem] border border-line bg-ink/70 p-5 shadow-premium backdrop-blur md:p-7" aria-describedby="contacto-ayuda">
-          <div class="flex flex-col gap-3 border-b border-line pb-5 sm:flex-row sm:items-start sm:justify-between">
-            <div>
-              <p class="text-sm font-semibold uppercase tracking-[0.18em] text-cyan-electric">Armá el mensaje</p>
-              <h2 class="mt-2 text-2xl font-semibold tracking-tight text-slate-50">Te abre WhatsApp con todo ordenado</h2>
+        <form id="contacto" class="min-w-0 rounded-[2rem] border border-line bg-ink/70 p-5 shadow-premium backdrop-blur md:p-7" aria-describedby="contacto-ayuda">
+          <div class="flex min-w-0 flex-col gap-3 border-b border-line pb-5 sm:flex-row sm:items-start sm:justify-between">
+            <div class="min-w-0">
+              <p class="break-words text-sm font-semibold uppercase tracking-[0.1em] text-cyan-electric sm:tracking-[0.18em]">Armá el mensaje</p>
+              <h2 class="mt-2 break-words text-2xl font-semibold tracking-tight text-slate-50">Te abre WhatsApp con todo ordenado</h2>
             </div>
-            <span class="w-fit rounded-full border border-emerald-300/20 bg-emerald-300/10 px-3 py-1 text-xs font-semibold text-emerald-200">
+            <span class="inline-flex min-w-0 max-w-full rounded-full border border-emerald-300/20 bg-emerald-300/10 px-3 py-1 text-xs font-semibold text-emerald-200">
               Sin backend
             </span>
           </div>

--- a/src/pages/proyectos/[slug].astro
+++ b/src/pages/proyectos/[slug].astro
@@ -55,45 +55,45 @@ const whatsappText = `Hola Diego, quiero algo parecido a ${title}.\n\nRubro: [ru
 ---
 <BaseLayout title={`${title} | Caso Marin.dev`} description={resumen} image={previewImage} url={`/proyectos/${proyecto.slug}`}>
   <Container class="py-12 sm:py-16">
-    <article>
-      <header class="grid gap-8 lg:grid-cols-[minmax(0,1fr)_28rem] lg:items-center">
-        <div>
-          <div class="flex flex-wrap gap-2">
+    <article class="min-w-0">
+      <header class="grid min-w-0 gap-8 lg:grid-cols-[minmax(0,1fr)_minmax(0,28rem)] lg:items-center">
+        <div class="min-w-0">
+          <div class="flex min-w-0 max-w-full flex-wrap gap-2">
             {(tipo || sector) && <Badge label={tipo || sector} tone="cyan" />}
             {status && <Badge label={statusLabels[status] ?? status} tone={statusTone[status] ?? 'default'} />}
           </div>
-          <h1 class="mt-5 max-w-4xl text-4xl font-semibold tracking-tight text-slate-50 sm:text-5xl lg:text-6xl">{title}</h1>
-          {resumen && <p class="mt-5 max-w-3xl text-lg leading-8 text-muted-soft">{resumen}</p>}
+          <h1 class="mt-5 max-w-full break-words text-[clamp(2.25rem,10vw,3.5rem)] font-semibold leading-[1.04] tracking-tight text-slate-50 sm:max-w-4xl sm:text-5xl lg:text-6xl">{title}</h1>
+          {resumen && <p class="mt-5 max-w-3xl break-words text-lg leading-8 text-muted-soft">{resumen}</p>}
 
-          <dl class="mt-7 grid gap-3 text-sm text-muted-soft sm:grid-cols-3">
+          <dl class="mt-7 grid min-w-0 gap-3 text-sm text-muted-soft sm:grid-cols-3">
             {sector && (
-              <div class="rounded-2xl border border-line bg-surface-glass p-4">
+              <div class="min-w-0 rounded-2xl border border-line bg-surface-glass p-4">
                 <dt class="font-semibold text-slate-50">Rubro</dt>
                 <dd class="mt-1">{sector}</dd>
               </div>
             )}
             {rol && (
-              <div class="rounded-2xl border border-line bg-surface-glass p-4">
+              <div class="min-w-0 rounded-2xl border border-line bg-surface-glass p-4">
                 <dt class="font-semibold text-slate-50">Rol</dt>
                 <dd class="mt-1">{rol}</dd>
               </div>
             )}
             {fecha && (
-              <div class="rounded-2xl border border-line bg-surface-glass p-4">
+              <div class="min-w-0 rounded-2xl border border-line bg-surface-glass p-4">
                 <dt class="font-semibold text-slate-50">Fecha</dt>
                 <dd class="mt-1">{fecha}</dd>
               </div>
             )}
           </dl>
 
-          <div class="mt-8 flex flex-wrap gap-3">
+          <div class="mt-8 flex min-w-0 flex-col gap-3 sm:flex-row sm:flex-wrap">
             {demoUrl && (
-              <a href={demoUrl} target="_blank" rel="noopener noreferrer" class="inline-flex items-center justify-center rounded-xl bg-brand-gradient px-5 py-3 text-sm font-semibold text-white shadow-glow transition hover:-translate-y-0.5">
+              <a href={demoUrl} target="_blank" rel="noopener noreferrer" class="inline-flex w-full max-w-full items-center justify-center rounded-xl bg-brand-gradient px-5 py-3 text-center text-sm font-semibold text-white shadow-glow transition hover:-translate-y-0.5 sm:w-auto">
                 Ver demo
               </a>
             )}
             {repoUrl && (
-              <a href={repoUrl} target="_blank" rel="noopener noreferrer" class="inline-flex items-center justify-center rounded-xl border border-line bg-surface-glass px-5 py-3 text-sm font-semibold text-slate-50 transition hover:border-line-strong hover:bg-surface-850">
+              <a href={repoUrl} target="_blank" rel="noopener noreferrer" class="inline-flex w-full max-w-full items-center justify-center rounded-xl border border-line bg-surface-glass px-5 py-3 text-center text-sm font-semibold text-slate-50 transition hover:border-line-strong hover:bg-surface-850 sm:w-auto">
                 Ver archivos
               </a>
             )}
@@ -103,47 +103,47 @@ const whatsappText = `Hola Diego, quiero algo parecido a ${title}.\n\nRubro: [ru
         <ProjectLinkPreview title={title} url={demoUrl} cover={image || cover} thumbnail={thumbnail} slug={proyecto.slug} eager />
       </header>
 
-      <section class="mt-12 grid gap-5 lg:grid-cols-3">
+      <section class="mt-12 grid min-w-0 gap-5 lg:grid-cols-3">
         {idealPara && (
           <GlowCard>
-            <p class="text-sm font-semibold uppercase tracking-[0.2em] text-cyan-electric">Contexto</p>
-            <h2 class="mt-3 text-xl font-semibold text-slate-50">Para qué negocio sirve</h2>
+            <p class="break-words text-sm font-semibold uppercase tracking-[0.1em] text-cyan-electric sm:tracking-[0.2em]">Contexto</p>
+            <h2 class="mt-3 break-words text-xl font-semibold text-slate-50">Para qué negocio sirve</h2>
             <p class="mt-3 text-sm leading-6 text-muted-soft">{idealPara}</p>
           </GlowCard>
         )}
         {problema && (
           <GlowCard>
-            <p class="text-sm font-semibold uppercase tracking-[0.2em] text-cyan-electric">Problema</p>
-            <h2 class="mt-3 text-xl font-semibold text-slate-50">Problema detectado</h2>
+            <p class="break-words text-sm font-semibold uppercase tracking-[0.1em] text-cyan-electric sm:tracking-[0.2em]">Problema</p>
+            <h2 class="mt-3 break-words text-xl font-semibold text-slate-50">Problema detectado</h2>
             <p class="mt-3 text-sm leading-6 text-muted-soft">{problema}</p>
           </GlowCard>
         )}
         {solucion && (
           <GlowCard>
-            <p class="text-sm font-semibold uppercase tracking-[0.2em] text-cyan-electric">Solución</p>
-            <h2 class="mt-3 text-xl font-semibold text-slate-50">Qué se construyó</h2>
+            <p class="break-words text-sm font-semibold uppercase tracking-[0.1em] text-cyan-electric sm:tracking-[0.2em]">Solución</p>
+            <h2 class="mt-3 break-words text-xl font-semibold text-slate-50">Qué se construyó</h2>
             <p class="mt-3 text-sm leading-6 text-muted-soft">{solucion}</p>
           </GlowCard>
         )}
       </section>
 
       {(features.length > 0 || impacto || resultado) && (
-        <section class="mt-8 grid gap-5 lg:grid-cols-[minmax(0,1fr)_24rem]">
+        <section class="mt-8 grid min-w-0 gap-5 lg:grid-cols-[minmax(0,1fr)_minmax(0,24rem)]">
           {features.length > 0 && (
-            <div class="rounded-3xl border border-line bg-surface-glass p-6 shadow-premium backdrop-blur">
-              <p class="text-sm font-semibold uppercase tracking-[0.2em] text-cyan-electric">Qué incluye</p>
-              <div class="mt-5 grid gap-3 sm:grid-cols-2">
+            <div class="min-w-0 rounded-3xl border border-line bg-surface-glass p-6 shadow-premium backdrop-blur">
+              <p class="break-words text-sm font-semibold uppercase tracking-[0.1em] text-cyan-electric sm:tracking-[0.2em]">Qué incluye</p>
+              <div class="mt-5 grid min-w-0 gap-3 sm:grid-cols-2">
                 {features.map((feature) => (
-                  <div class="rounded-2xl border border-line bg-ink/35 p-4 text-sm font-medium text-muted-bright">{feature}</div>
+                  <div class="min-w-0 break-words rounded-2xl border border-line bg-ink/35 p-4 text-sm font-medium text-muted-bright">{feature}</div>
                 ))}
               </div>
             </div>
           )}
 
           {(impacto || resultado) && (
-            <div class="rounded-3xl border border-brand-success/20 bg-brand-success/10 p-6 shadow-premium">
-              <p class="text-sm font-semibold uppercase tracking-[0.2em] text-emerald-200">Impacto / resultado</p>
-              {resultado && <p class="mt-4 text-2xl font-semibold text-slate-50">{resultado}</p>}
+            <div class="min-w-0 rounded-3xl border border-brand-success/20 bg-brand-success/10 p-6 shadow-premium">
+              <p class="break-words text-sm font-semibold uppercase tracking-[0.1em] text-emerald-200 sm:tracking-[0.2em]">Impacto / resultado</p>
+              {resultado && <p class="mt-4 break-words text-2xl font-semibold text-slate-50">{resultado}</p>}
               {impacto && <p class="mt-4 text-sm leading-6 text-emerald-50/90">{impacto}</p>}
             </div>
           )}
@@ -151,24 +151,24 @@ const whatsappText = `Hola Diego, quiero algo parecido a ${title}.\n\nRubro: [ru
       )}
 
       {stack.length > 0 && (
-        <section class="mt-8 rounded-3xl border border-line bg-surface-glass p-6 shadow-premium backdrop-blur">
-          <p class="text-sm font-semibold uppercase tracking-[0.2em] text-cyan-electric">Herramientas usadas</p>
-          <div class="mt-4 flex flex-wrap gap-2">
+        <section class="mt-8 min-w-0 rounded-3xl border border-line bg-surface-glass p-6 shadow-premium backdrop-blur">
+          <p class="break-words text-sm font-semibold uppercase tracking-[0.1em] text-cyan-electric sm:tracking-[0.2em]">Herramientas usadas</p>
+          <div class="mt-4 flex min-w-0 max-w-full flex-wrap gap-2">
             {stack.map((s) => <Badge label={s} />)}
           </div>
         </section>
       )}
 
-      <section class="prose-dark mt-10 max-w-none rounded-3xl border border-line bg-surface-glass p-6 leading-7 shadow-premium backdrop-blur">
+      <section class="prose-dark mt-10 max-w-none min-w-0 break-words rounded-3xl border border-line bg-surface-glass p-6 leading-7 shadow-premium backdrop-blur">
         <Content />
       </section>
 
       <section class="mt-10 rounded-3xl border border-line bg-brand-gradient p-[1px] shadow-glow">
-        <div class="rounded-3xl bg-ink/90 p-6 text-center sm:p-8">
-          <p class="text-sm font-semibold uppercase tracking-[0.2em] text-cyan-100">Último paso</p>
-          <h2 class="mt-3 text-2xl font-semibold text-slate-50">¿Querés algo parecido para tu negocio?</h2>
+        <div class="min-w-0 rounded-3xl bg-ink/90 p-6 text-center sm:p-8">
+          <p class="break-words text-sm font-semibold uppercase tracking-[0.1em] text-cyan-100 sm:tracking-[0.2em]">Último paso</p>
+          <h2 class="mt-3 break-words text-2xl font-semibold text-slate-50">¿Querés algo parecido para tu negocio?</h2>
           <p class="mx-auto mt-3 max-w-2xl text-sm leading-6 text-muted-soft">Mandame tu rubro, tu Instagram o web actual y el objetivo comercial. Te digo qué demo, web o herramienta simple tendría más sentido construir primero.</p>
-          <a href={waLink(whatsappText)} target="_blank" rel="noopener noreferrer" class="mt-6 inline-flex items-center justify-center rounded-xl bg-slate-50 px-5 py-3 text-sm font-semibold text-ink transition hover:-translate-y-0.5 hover:bg-white">
+          <a href={waLink(whatsappText)} target="_blank" rel="noopener noreferrer" class="mt-6 inline-flex w-full max-w-full items-center justify-center rounded-xl bg-slate-50 px-5 py-3 text-center text-sm font-semibold text-ink transition hover:-translate-y-0.5 hover:bg-white sm:w-auto">
             Quiero algo parecido
           </a>
         </div>

--- a/src/pages/proyectos/index.astro
+++ b/src/pages/proyectos/index.astro
@@ -24,19 +24,19 @@ const proyectos = (await getCollection('proyectos')).sort(byCommercialPriority);
   description="Portfolio comercial de Marin.dev: demos, webs y herramientas simples pensadas para recibir consultas, reservas o ventas."
 >
   <Container class="py-14 sm:py-20">
-    <div class="grid gap-8 lg:grid-cols-[minmax(0,1fr)_22rem] lg:items-end">
+    <div class="grid min-w-0 gap-8 lg:grid-cols-[minmax(0,1fr)_minmax(0,22rem)] lg:items-end">
       <SectionHeader
         eyebrow="Portfolio"
         title="Proyectos y demos pensados para vender mejor"
         description="No son solo sitios lindos: cada pieza está diseñada para ordenar el mensaje, reducir fricción y llevar al usuario hacia una consulta o acción concreta."
       />
-      <div class="rounded-3xl border border-line bg-surface-glass p-5 text-sm leading-6 text-muted-soft shadow-premium backdrop-blur">
+      <div class="min-w-0 rounded-3xl border border-line bg-surface-glass p-5 text-sm leading-6 text-muted-soft shadow-premium backdrop-blur">
         <p class="font-semibold text-slate-50">Criterio de orden</p>
         <p class="mt-2">Primero aparecen los casos destacados y con mayor prioridad comercial; después, los más recientes.</p>
       </div>
     </div>
 
-    <div class="mt-10 grid gap-6 md:grid-cols-2 xl:grid-cols-3">
+    <div class="mt-10 grid min-w-0 gap-6 md:grid-cols-2 xl:grid-cols-3">
       {proyectos.map((p) => (
         <ProjectCard
           title={p.data.title}
@@ -69,12 +69,12 @@ const proyectos = (await getCollection('proyectos')).sort(byCommercialPriority);
       ))}
     </div>
 
-    <div class="mt-10 flex flex-col gap-4 rounded-3xl border border-line bg-surface-glass p-5 shadow-premium backdrop-blur sm:flex-row sm:items-center sm:justify-between">
-      <div>
-        <p class="font-semibold text-slate-50">¿Querés algo parecido para tu negocio?</p>
+    <div class="mt-10 flex min-w-0 flex-col gap-4 rounded-3xl border border-line bg-surface-glass p-5 shadow-premium backdrop-blur sm:flex-row sm:items-center sm:justify-between">
+      <div class="min-w-0">
+        <p class="break-words font-semibold text-slate-50">¿Querés algo parecido para tu negocio?</p>
         <p class="mt-1 text-sm leading-6 text-muted-soft">Compartime tu Instagram, web o idea y te digo cómo convertirla en una demo accionable.</p>
       </div>
-      <a href={waLink(DEMO_WHATSAPP_MESSAGE)} target="_blank" rel="noreferrer" class="premium-button inline-flex w-fit items-center justify-center gap-2 rounded-2xl bg-brand-gradient px-5 py-3 text-sm font-semibold text-white shadow-glow">
+      <a href={waLink(DEMO_WHATSAPP_MESSAGE)} target="_blank" rel="noreferrer" class="premium-button inline-flex w-full max-w-full items-center justify-center gap-2 rounded-2xl bg-brand-gradient px-5 py-3 text-center text-sm font-semibold text-white shadow-glow sm:w-fit">
         Pedir una demo <span aria-hidden="true">↗</span>
       </a>
     </div>

--- a/src/pages/servicios.astro
+++ b/src/pages/servicios.astro
@@ -17,19 +17,19 @@ const serviceHighlights = [
 ];
 ---
 <BaseLayout {title} {description} {url} {image}>
-  <section class="relative overflow-hidden py-16 md:py-24">
+  <section class="relative min-w-0 overflow-hidden py-16 md:py-24">
     <div class="absolute left-1/2 top-10 h-48 w-48 -translate-x-1/2 rounded-full bg-cyan-electric/15 blur-3xl" aria-hidden="true"></div>
-    <div class="relative mx-auto max-w-4xl text-center">
-      <p class="text-sm font-semibold uppercase tracking-[0.24em] text-cyan-electric">Servicios Marin.dev</p>
-      <h1 class="mt-4 text-4xl font-semibold tracking-tight text-slate-50 md:text-6xl">
+    <div class="relative mx-auto min-w-0 max-w-4xl text-center">
+      <p class="break-words text-sm font-semibold uppercase tracking-[0.1em] text-cyan-electric sm:tracking-[0.24em]">Servicios Marin.dev</p>
+      <h1 class="mt-4 break-words text-[clamp(2.25rem,10vw,3.5rem)] font-semibold leading-[1.04] tracking-tight text-slate-50 md:text-6xl">
         Productos digitales simples para vender, reservar u operar mejor.
       </h1>
       <p class="mx-auto mt-5 max-w-2xl text-base leading-7 text-muted-soft md:text-lg">
         No arranco desde “necesitás una web”. Arranco desde el objetivo: validar una idea, captar consultas, ordenar reservas o crear una herramienta interna liviana.
       </p>
-      <div class="mt-8 flex flex-wrap justify-center gap-3">
+      <div class="mt-8 flex min-w-0 max-w-full flex-wrap justify-center gap-3">
         {serviceHighlights.map((item) => (
-          <span class="rounded-full border border-line bg-surface-glass px-4 py-2 text-sm text-muted-soft shadow-sm backdrop-blur">
+          <span class="min-w-0 max-w-full rounded-full border border-line bg-surface-glass px-4 py-2 text-sm text-muted-soft shadow-sm backdrop-blur">
             {item}
           </span>
         ))}
@@ -37,14 +37,14 @@ const serviceHighlights = [
     </div>
   </section>
 
-  <section class="grid gap-6 rounded-[2rem] border border-line bg-surface-glow p-6 shadow-premium backdrop-blur md:grid-cols-[0.9fr_1.1fr] md:p-8">
-    <div>
-      <p class="text-sm font-semibold uppercase tracking-[0.22em] text-cyan-electric">Cómo elegir</p>
-      <h2 class="mt-3 text-2xl font-semibold tracking-tight text-slate-50 md:text-4xl">
+  <section class="grid min-w-0 gap-6 rounded-[2rem] border border-line bg-surface-glow p-6 shadow-premium backdrop-blur md:grid-cols-[minmax(0,0.9fr)_minmax(0,1.1fr)] md:p-8">
+    <div class="min-w-0">
+      <p class="break-words text-sm font-semibold uppercase tracking-[0.1em] text-cyan-electric sm:tracking-[0.22em]">Cómo elegir</p>
+      <h2 class="mt-3 break-words text-2xl font-semibold tracking-tight text-slate-50 md:text-4xl">
         Elegí el punto de partida. Después ajustamos el alcance real.
       </h2>
     </div>
-    <div class="space-y-4 text-sm leading-6 text-muted-soft md:text-base">
+    <div class="min-w-0 space-y-4 text-sm leading-6 text-muted-soft md:text-base">
       <p>
         Los planes no son moldes cerrados: son formas de ordenar la conversación para que sepas qué estás comprando, qué problema resuelve y qué entregables esperar.
       </p>

--- a/src/pages/sobre-mi.astro
+++ b/src/pages/sobre-mi.astro
@@ -75,12 +75,12 @@ const stack = [
   <section class="relative overflow-hidden py-16 md:py-24">
     <div class="pointer-events-none absolute left-1/2 top-10 h-64 w-64 -translate-x-1/2 rounded-full bg-cyan-electric/15 blur-3xl" aria-hidden="true"></div>
     <Container class="relative px-0">
-      <div class="grid items-center gap-10 lg:grid-cols-[1.08fr_0.92fr]">
+      <div class="grid min-w-0 items-center gap-10 lg:grid-cols-[minmax(0,1.08fr)_minmax(0,0.92fr)]">
         <div class="max-w-3xl">
-          <p class="inline-flex w-fit items-center rounded-full border border-line bg-surface-glass px-3 py-1 text-xs font-semibold uppercase tracking-[0.22em] text-cyan-electric">
+          <p class="inline-flex min-w-0 max-w-full items-center rounded-full border border-line bg-surface-glass px-3 py-1 text-xs font-semibold uppercase tracking-[0.1em] text-cyan-electric sm:w-fit sm:tracking-[0.22em]">
             Diego Marin · Marin.dev
           </p>
-          <h1 class="mt-6 text-4xl font-semibold tracking-tight text-slate-50 sm:text-5xl lg:text-6xl">
+          <h1 class="break-words mt-6 text-4xl font-semibold tracking-tight text-slate-50 sm:text-5xl lg:text-6xl">
             No construyo solo páginas: diseño demos y sistemas simples para vender con más claridad.
           </h1>
           <p class="mt-6 max-w-2xl text-base leading-8 text-muted-soft sm:text-lg">
@@ -119,7 +119,7 @@ const stack = [
               <p class="text-xs uppercase tracking-[0.2em] text-muted">Entrada</p>
               <p class="mt-2 text-sm font-medium text-slate-100">Instagram, web actual, idea o problema operativo</p>
             </div>
-            <div class="grid gap-3 sm:grid-cols-2">
+            <div class="grid min-w-0 gap-3 sm:grid-cols-2">
               <div class="rounded-2xl border border-line bg-surface-glass p-4">
                 <p class="text-2xl font-semibold text-cyan-electric">CTA</p>
                 <p class="mt-1 text-sm text-muted-soft">Consulta guiada por WhatsApp</p>
@@ -141,10 +141,10 @@ const stack = [
 
   <section class="py-12 md:py-16">
     <Container class="px-0">
-      <div class="grid gap-4 md:grid-cols-3">
+      <div class="grid min-w-0 gap-4 md:grid-cols-3">
         {principles.map((principle) => (
           <GlowCard>
-            <h2 class="text-xl font-semibold text-slate-50">{principle.title}</h2>
+            <h2 class="break-words text-xl font-semibold text-slate-50">{principle.title}</h2>
             <p class="mt-3 text-sm leading-7 text-muted-soft">{principle.description}</p>
           </GlowCard>
         ))}
@@ -154,17 +154,17 @@ const stack = [
 
   <section class="py-12 md:py-16">
     <Container class="px-0">
-      <div class="grid gap-8 lg:grid-cols-[0.8fr_1.2fr]">
-        <div>
-          <p class="text-sm font-semibold uppercase tracking-[0.22em] text-cyan-electric">Cómo pienso los proyectos</p>
-          <h2 class="mt-4 text-3xl font-semibold tracking-tight text-slate-50 md:text-4xl">
+      <div class="grid min-w-0 gap-8 lg:grid-cols-[minmax(0,0.8fr)_minmax(0,1.2fr)]">
+        <div class="min-w-0">
+          <p class="break-words text-sm font-semibold uppercase tracking-[0.1em] text-cyan-electric sm:tracking-[0.22em]">Cómo pienso los proyectos</p>
+          <h2 class="break-words mt-4 text-3xl font-semibold tracking-tight text-slate-50 md:text-4xl">
             Una buena web no empieza en el diseño: empieza en la decisión que querés facilitar.
           </h2>
           <p class="mt-4 text-base leading-7 text-muted-soft">
             Por eso trabajo con preguntas simples: qué vendés, quién necesita confiar en vos, qué objeción aparece antes de consultar y cuál es el próximo paso más fácil para el usuario.
           </p>
         </div>
-        <div class="grid gap-4 sm:grid-cols-2">
+        <div class="grid min-w-0 gap-4 sm:grid-cols-2">
           {problems.map((problem) => (
             <div class="rounded-3xl border border-line bg-surface-glass p-5 text-sm leading-7 text-muted-soft shadow-soft">
               {problem}
@@ -177,21 +177,21 @@ const stack = [
 
   <section class="py-12 md:py-16">
     <Container class="px-0">
-      <div class="mb-8 max-w-3xl">
-        <p class="text-sm font-semibold uppercase tracking-[0.22em] text-cyan-electric">Forma de trabajo</p>
-        <h2 class="mt-4 text-3xl font-semibold tracking-tight text-slate-50 md:text-4xl">
+      <div class="mb-8 min-w-0 max-w-3xl">
+        <p class="text-sm font-semibold uppercase tracking-[0.1em] text-cyan-electric sm:tracking-[0.22em]">Forma de trabajo</p>
+        <h2 class="break-words mt-4 text-3xl font-semibold tracking-tight text-slate-50 md:text-4xl">
           Hitos claros, repo ordenado, deploy visible y comunicación directa.
         </h2>
       </div>
-      <div class="grid gap-4 md:grid-cols-2">
+      <div class="grid min-w-0 gap-4 md:grid-cols-2">
         {workflow.map((item) => (
           <GlowCard class="p-6">
-            <div class="flex gap-4">
+            <div class="flex min-w-0 gap-4">
               <span class="flex h-11 w-11 shrink-0 items-center justify-center rounded-2xl border border-cyan-electric/25 bg-cyan-electric/10 text-sm font-semibold text-cyan-electric">
                 {item.step}
               </span>
-              <div>
-                <h3 class="text-lg font-semibold text-slate-50">{item.title}</h3>
+              <div class="min-w-0">
+                <h3 class="break-words text-lg font-semibold text-slate-50">{item.title}</h3>
                 <p class="mt-2 text-sm leading-7 text-muted-soft">{item.description}</p>
               </div>
             </div>
@@ -203,10 +203,10 @@ const stack = [
 
   <section class="py-12 md:py-16">
     <Container class="px-0">
-      <div class="grid gap-8 lg:grid-cols-[0.85fr_1.15fr]">
-        <div>
-          <p class="text-sm font-semibold uppercase tracking-[0.22em] text-cyan-electric">Stack técnico</p>
-          <h2 class="mt-4 text-3xl font-semibold tracking-tight text-slate-50 md:text-4xl">
+      <div class="grid min-w-0 gap-8 lg:grid-cols-[minmax(0,0.85fr)_minmax(0,1.15fr)]">
+        <div class="min-w-0">
+          <p class="break-words text-sm font-semibold uppercase tracking-[0.1em] text-cyan-electric sm:tracking-[0.22em]">Stack técnico</p>
+          <h2 class="break-words mt-4 text-3xl font-semibold tracking-tight text-slate-50 md:text-4xl">
             La tecnología acompaña al objetivo, no al revés.
           </h2>
           <p class="mt-4 text-base leading-7 text-muted-soft">
@@ -214,9 +214,9 @@ const stack = [
           </p>
         </div>
         <GlowCard class="p-6">
-          <div class="flex flex-wrap gap-3">
+          <div class="flex min-w-0 flex-wrap gap-3">
             {stack.map((item) => (
-              <span class="rounded-full border border-line bg-ink/40 px-4 py-2 text-sm font-medium text-muted-soft">
+              <span class="min-w-0 max-w-full rounded-full border border-line bg-ink/40 px-4 py-2 text-sm font-medium text-muted-soft">
                 {item}
               </span>
             ))}

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -20,7 +20,6 @@
 
   body {
     min-width: 20rem;
-    overflow-x: hidden;
     background:
       radial-gradient(
         circle at 14% 0%,
@@ -34,6 +33,7 @@
       ),
       linear-gradient(180deg, #050816 0%, #070a12 42%, #080b14 100%);
     color: var(--color-text);
+    overflow-wrap: break-word;
     text-rendering: optimizeLegibility;
   }
 
@@ -57,6 +57,12 @@
   canvas {
     max-width: 100%;
   }
+
+  *,
+  ::before,
+  ::after {
+    box-sizing: border-box;
+  }
 }
 
 @layer components {
@@ -72,8 +78,15 @@
     z-index: -2;
     pointer-events: none;
     background-image:
-      linear-gradient(rgba(148, 163, 184, 0.045) 0.0625rem, transparent 0.0625rem),
-      linear-gradient(90deg, rgba(148, 163, 184, 0.045) 0.0625rem, transparent 0.0625rem);
+      linear-gradient(
+        rgba(148, 163, 184, 0.045) 0.0625rem,
+        transparent 0.0625rem
+      ),
+      linear-gradient(
+        90deg,
+        rgba(148, 163, 184, 0.045) 0.0625rem,
+        transparent 0.0625rem
+      );
     background-size: 3rem 3rem;
     mask-image: linear-gradient(
       to bottom,
@@ -136,7 +149,11 @@
     z-index: 0;
     pointer-events: none;
     background:
-      radial-gradient(circle at 20% 0%, rgba(34, 211, 238, 0.16), transparent 32%),
+      radial-gradient(
+        circle at 20% 0%,
+        rgba(34, 211, 238, 0.16),
+        transparent 32%
+      ),
       linear-gradient(135deg, rgba(255, 255, 255, 0.08), transparent 42%);
     opacity: 0;
     transition: opacity 260ms ease;
@@ -164,7 +181,12 @@
     inset: -35% -70%;
     z-index: 0;
     pointer-events: none;
-    background: linear-gradient(110deg, transparent 35%, rgba(255, 255, 255, 0.26), transparent 65%);
+    background: linear-gradient(
+      110deg,
+      transparent 35%,
+      rgba(255, 255, 255, 0.26),
+      transparent 65%
+    );
     transform: translateX(-55%) rotate(8deg);
     opacity: 0;
     transition:
@@ -211,7 +233,13 @@
     position: absolute;
     inset: auto 12% -0.0625rem;
     height: 0.0625rem;
-    background: linear-gradient(90deg, transparent, rgba(34, 211, 238, 0.65), rgba(139, 92, 246, 0.45), transparent);
+    background: linear-gradient(
+      90deg,
+      transparent,
+      rgba(34, 211, 238, 0.65),
+      rgba(139, 92, 246, 0.45),
+      transparent
+    );
     opacity: 0.7;
   }
 
@@ -255,8 +283,16 @@
       position: absolute;
       height: 64rem;
       background:
-        radial-gradient(circle at 18% 6%, rgba(34, 211, 238, 0.12), transparent 18rem),
-        radial-gradient(circle at 86% 24%, rgba(139, 92, 246, 0.08), transparent 20rem);
+        radial-gradient(
+          circle at 18% 6%,
+          rgba(34, 211, 238, 0.12),
+          transparent 18rem
+        ),
+        radial-gradient(
+          circle at 86% 24%,
+          rgba(139, 92, 246, 0.08),
+          transparent 20rem
+        );
     }
 
     .premium-interactive {
@@ -276,7 +312,14 @@
       animation: none;
     }
 
-    .theme-v2 :where(.backdrop-blur, .backdrop-blur-sm, .backdrop-blur-md, .backdrop-blur-lg, .backdrop-blur-xl) {
+    .theme-v2
+      :where(
+        .backdrop-blur,
+        .backdrop-blur-sm,
+        .backdrop-blur-md,
+        .backdrop-blur-lg,
+        .backdrop-blur-xl
+      ) {
       --tw-backdrop-blur: blur(0);
     }
 
@@ -285,9 +328,15 @@
     }
 
     .theme-v2 :where(.shadow-premium, .shadow-glow) {
-      --tw-shadow: 0 1rem 2.75rem -1.75rem rgba(15, 23, 42, 0.82), 0 0 0 0.0625rem rgba(148, 163, 184, 0.08);
-      --tw-shadow-colored: 0 1rem 2.75rem -1.75rem var(--tw-shadow-color), 0 0 0 0.0625rem var(--tw-shadow-color);
-      box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+      --tw-shadow:
+        0 1rem 2.75rem -1.75rem rgba(15, 23, 42, 0.82),
+        0 0 0 0.0625rem rgba(148, 163, 184, 0.08);
+      --tw-shadow-colored:
+        0 1rem 2.75rem -1.75rem var(--tw-shadow-color),
+        0 0 0 0.0625rem var(--tw-shadow-color);
+      box-shadow:
+        var(--tw-ring-offset-shadow, 0 0 #0000),
+        var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
     }
   }
 


### PR DESCRIPTION
### Motivation

- Fix a real mobile clipping/overflow bug on the homepage hero (Android/Chrome) so headline, badges, CTAs and trust strip never get cut off by the viewport. 
- Implement a robust mobile layout contract across core components so intrinsic-width content cannot push the page wider than the viewport. 
- Prefer component-level fixes (shrink/wrap) over document-level masking (`overflow-x:hidden`).

### Description

- Hardened the hero and surrounding layout by adding `min-w-0` / `max-w-full` to the hero grid and content column, switching the hero `h1` to a fluid clamp (`text-[clamp(2.25rem,10vw,3.5rem)]`), and making CTAs full-width on mobile with `sm:w-auto`; file: `src/components/HeroV2.astro`.
- Made badge and header primitives shrink/wrap safely by replacing fragile `w-fit` and large tracking on mobile with `min-w-0`, `max-w-full`, reduced mobile tracking and label spans that can break (`src/components/VisualBadge.astro`, `src/components/SectionHeader.astro`).
- Applied `min-w-0` / `minmax(0,...)` grid/flex fixes across mockups, cards and CTAs so grid children can shrink: `BrowserMockup.astro`, `ProjectCard.astro`, `ContactCTA.astro`, `FeaturedCases.astro`, `ProjectLinkPreview.astro`, `ProductizedServices.astro`, `VerticalDemos.astro`, `PricingPlans.astro`, `OutcomeGrid.astro`, etc.
- Removed the global `overflow-x: hidden` body fallback and added safer text wrapping (`overflow-wrap: break-word`) so overflow must be fixed at component level; files: `src/styles/tailwind.css`, `src/layouts/BaseLayout.astro`.
- Added `docs/mobile-layout-fixes.md` with a DevTools console snippet to detect elements wider than the viewport and a short QA checklist for mobile widths 360/375/390/430px.

### Testing

- `npm run build` executed successfully and produced the static pages (`14 page(s) built`); build output returned no errors.
- `git diff --check` produced no line-check errors after changes.
- `npm run lint` failed due to repo ESLint configuration (ESLint v9 present but no `eslint.config.*`), so linting was not completed in this patch; this is a repo-tooling issue and was reported.
- Formatting attempt with `prettier` showed that `.astro` files lack a configured parser in this environment (Prettier warnings), but CSS/docs were formatted; this does not affect the runtime build.

Files touched (high level): `src/components/HeroV2.astro`, `src/components/VisualBadge.astro`, `src/components/SectionHeader.astro`, `src/components/BrowserMockup.astro`, `src/components/ContactCTA.astro`, `src/components/FeaturedCases.astro`, `src/components/ProjectCard.astro`, `src/components/ProjectLinkPreview.astro`, `src/components/ProductizedServices.astro`, `src/components/VerticalDemos.astro`, `src/components/PricingPlans.astro`, `src/components/OutcomeGrid.astro`, `src/components/VisualCard.astro`, `src/components/ProjectLinkPreview.astro`, `src/components/Container.astro`, `src/layouts/BaseLayout.astro`, `src/pages/*` (several), `src/styles/tailwind.css`, and `docs/mobile-layout-fixes.md`.

Next steps (recommended manual QA): open the site in Android/Chrome (360, 375, 390, 430px) and run the snippet from `docs/mobile-layout-fixes.md` to confirm no elements exceed viewport width and verify hero headline, badges, CTAs and trust strip are fully visible.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02543dc6708328a8decd4b54fbc4b6)