### PR TITLE
Simplify mobile hero layout

### DIFF
--- a/src/components/HeroV2.astro
+++ b/src/components/HeroV2.astro
@@ -4,7 +4,14 @@ import IconBubble from './IconBubble.astro';
 import VisualBadge from './VisualBadge.astro';
 import { waLink, DEMO_WHATSAPP_MESSAGE } from '../lib/contact';
 
-const heroBadges = [
+const mobileHeroBadges = [
+  { label: 'WhatsApp guiado', icon: 'message', tone: 'emerald' },
+  { label: 'Agenda', icon: 'layout', tone: 'cyan' },
+  { label: 'Panel admin', icon: 'settings', tone: 'violet' },
+  { label: 'SEO', icon: 'speed', tone: 'amber' },
+];
+
+const desktopHeroBadges = [
   { label: 'WhatsApp guiado', icon: 'message', tone: 'emerald' },
   { label: 'Agenda / reservas', icon: 'layout', tone: 'cyan' },
   { label: 'Panel admin', icon: 'settings', tone: 'violet' },
@@ -16,35 +23,47 @@ const trustBadges = [
   { label: 'Pagos por hitos', icon: 'check', tone: 'emerald' },
   { label: 'Repo + deploy', icon: 'code', tone: 'violet' },
 ];
+
+const mobileFlow = [
+  { label: 'Consulta por WhatsApp', icon: 'message', tone: 'emerald' },
+  { label: 'Servicio elegido', icon: 'layout', tone: 'cyan' },
+  { label: 'Demo lista para compartir', icon: 'check', tone: 'violet' },
+];
 ---
-<section class="relative py-16 md:overflow-x-clip md:py-24" aria-labelledby="hero-title">
-  <div class="absolute left-1/2 top-10 -z-10 h-72 w-72 -translate-x-1/2 rounded-full bg-cyan-electric/15 blur-2xl md:bg-cyan-electric/20 md:blur-3xl" aria-hidden="true"></div>
-  <div class="absolute -right-24 top-32 -z-10 hidden h-64 w-64 rounded-full bg-violet-electric/15 blur-3xl md:block" aria-hidden="true"></div>
+<section class="relative py-12 sm:py-16 lg:overflow-x-clip lg:py-24" aria-labelledby="hero-title">
+  <div class="absolute left-1/2 top-10 -z-10 hidden h-72 w-72 -translate-x-1/2 rounded-full bg-cyan-electric/20 blur-3xl lg:block" aria-hidden="true"></div>
+  <div class="absolute -right-24 top-32 -z-10 hidden h-64 w-64 rounded-full bg-violet-electric/15 blur-3xl lg:block" aria-hidden="true"></div>
   <div class="absolute inset-x-0 top-0 -z-10 h-px bg-gradient-to-r from-transparent via-cyan-electric/40 to-transparent" aria-hidden="true"></div>
 
-  <div class="grid min-w-0 items-center gap-10 lg:grid-cols-[minmax(0,0.92fr)_minmax(0,1.08fr)] lg:gap-14">
+  <div class="grid min-w-0 items-center gap-8 lg:grid-cols-[minmax(0,0.92fr)_minmax(0,1.08fr)] lg:gap-14">
     <div class="relative z-10 min-w-0 max-w-full">
-      <div class="inline-flex min-w-0 max-w-full items-center gap-2 rounded-full sm:gap-3 border border-cyan-electric/25 bg-cyan-electric/10 px-3 py-2 shadow-[0_0_32px_rgba(34,211,238,0.12)] backdrop-blur sm:px-4">
+      <div class="inline-flex min-w-0 max-w-full items-center gap-2 rounded-full border border-cyan-electric/25 bg-cyan-electric/10 px-3 py-2 shadow-[0_0_22px_rgba(34,211,238,0.10)] sm:gap-3 sm:px-4 lg:shadow-[0_0_32px_rgba(34,211,238,0.12)] lg:backdrop-blur">
         <IconBubble icon="rocket" tone="cyan" size="sm" label="Conversión, tecnología y velocidad" />
-        <span class="min-w-0 text-xs font-semibold uppercase leading-5 tracking-[0.1em] text-cyan-100 sm:tracking-[0.2em]">
-          Marin.dev · demos, webs y sistemas comerciales
+        <span class="min-w-0 text-xs font-semibold uppercase leading-5 tracking-[0.08em] text-cyan-100 sm:tracking-[0.16em] lg:tracking-[0.2em]">
+          <span class="sm:hidden">Marin.dev · demos web</span>
+          <span class="hidden sm:inline">Marin.dev · demos, webs y sistemas comerciales</span>
         </span>
       </div>
 
-      <h1 id="hero-title" class="mt-6 max-w-full break-words text-[clamp(2.25rem,10vw,3.5rem)] font-semibold leading-[1.02] tracking-tight text-slate-50 sm:max-w-4xl sm:text-5xl lg:text-6xl">
+      <h1 id="hero-title" class="mt-5 max-w-full break-words text-[clamp(2.25rem,10vw,3.5rem)] font-semibold leading-[1.04] tracking-tight text-slate-50 sm:mt-6 sm:max-w-4xl sm:text-5xl lg:text-6xl lg:leading-[1.02]">
         Webs y demos comerciales que convierten visitas en consultas.
       </h1>
-      <p class="mt-6 max-w-2xl break-words text-base leading-8 text-muted-soft sm:text-lg">
-        Landings, demos y sistemas simples con mensaje claro, WhatsApp guiado y estructura lista para generar consultas.
+      <p class="mt-4 max-w-2xl break-words text-base leading-7 text-muted-soft sm:mt-6 sm:text-lg sm:leading-8">
+        Landings, demos y sistemas simples con WhatsApp, agenda y estructura clara para generar consultas.
       </p>
 
-      <div class="mt-6 flex min-w-0 max-w-full flex-wrap gap-2.5" aria-label="Funciones que puede incluir una demo o web comercial">
-        {heroBadges.map((badge) => (
+      <div class="mt-5 grid min-w-0 max-w-full grid-cols-1 gap-2.5 min-[360px]:grid-cols-2 sm:hidden" aria-label="Funciones que puede incluir una demo o web comercial">
+        {mobileHeroBadges.map((badge) => (
+          <VisualBadge label={badge.label} icon={badge.icon} tone={badge.tone} />
+        ))}
+      </div>
+      <div class="mt-6 hidden min-w-0 max-w-full flex-wrap gap-2.5 sm:flex" aria-label="Funciones que puede incluir una demo o web comercial">
+        {desktopHeroBadges.map((badge) => (
           <VisualBadge label={badge.label} icon={badge.icon} tone={badge.tone} />
         ))}
       </div>
 
-      <div class="mt-8 flex min-w-0 max-w-full flex-col gap-3 sm:flex-row">
+      <div class="mt-7 flex min-w-0 max-w-full flex-col gap-3 sm:mt-8 sm:flex-row">
         <a
           href={waLink(DEMO_WHATSAPP_MESSAGE)}
           target="_blank"
@@ -61,14 +80,40 @@ const trustBadges = [
         </a>
       </div>
 
-      <div class="mt-6 w-full max-w-full rounded-2xl border border-line bg-surface-glass/80 p-3 shadow-soft backdrop-blur sm:inline-flex sm:w-auto sm:items-center sm:gap-3 sm:rounded-full sm:px-4 sm:py-2">
+      <div class="mt-5 grid w-full max-w-full grid-cols-1 gap-2.5 sm:hidden" aria-label="Señales de confianza">
+        {trustBadges.map((badge) => (
+          <div class="flex min-w-0 items-center gap-2 rounded-2xl border border-line bg-surface-glass/75 px-3 py-2 shadow-soft">
+            <IconBubble icon={badge.icon} tone={badge.tone} size="sm" />
+            <span class="min-w-0 break-words text-sm font-semibold leading-5 text-muted-soft">{badge.label}</span>
+          </div>
+        ))}
+      </div>
+      <div class="mt-6 hidden w-full max-w-full rounded-2xl border border-line bg-surface-glass/80 p-3 shadow-soft backdrop-blur sm:inline-flex sm:w-auto sm:items-center sm:gap-3 sm:rounded-full sm:px-4 sm:py-2">
         <p class="break-words text-sm font-medium leading-6 text-muted-soft">
           Propuesta en 24h <span class="text-line-strong">•</span> pagos por hitos <span class="text-line-strong">•</span> repo + deploy
         </p>
       </div>
-
     </div>
 
-    <BrowserMockup trustBadges={trustBadges} />
+    <div class="lg:hidden" role="group" aria-label="Flujo compacto de una demo comercial">
+      <div class="rounded-3xl border border-line bg-surface-glass/80 p-4 shadow-soft">
+        <div class="flex items-center justify-between gap-3 border-b border-line pb-3">
+          <p class="text-sm font-semibold text-slate-50">Demo comercial</p>
+          <span class="rounded-full bg-brand-success/10 px-2.5 py-1 text-xs font-semibold text-emerald-100">Lista</span>
+        </div>
+        <div class="mt-4 space-y-3">
+          {mobileFlow.map((row) => (
+            <div class="flex min-w-0 items-center gap-3 rounded-2xl border border-line bg-ink/35 p-3">
+              <IconBubble icon={row.icon} tone={row.tone} size="sm" />
+              <span class="min-w-0 break-words text-sm font-semibold leading-5 text-slate-100">{row.label}</span>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+
+    <div class="hidden lg:block">
+      <BrowserMockup trustBadges={trustBadges} />
+    </div>
   </div>
 </section>


### PR DESCRIPTION
### Motivation
- Mobile hero was visually heavy and risked clipped content and slow paint on first view.  
- Keep the premium desktop hero intact while producing a lightweight, readable mobile-first experience.  
- Ensure the hero never hides CTAs or badges and follows the repo's mobile layout contract.

### Description
- Modified `src/components/HeroV2.astro` to add `mobileHeroBadges`, `desktopHeroBadges` and `mobileFlow` data and to implement a mobile-first layout that renders a compact HTML/CSS flow card below `lg` instead of the full mockup.  
- The full `BrowserMockup` is now hidden on mobile with `hidden lg:block` and decorative glows/overflow are only enabled at `lg` to reduce paint and avoid clipped absolute elements.  
- Eyebrow copy is responsive with a short label on small screens and the longer label from `sm+`, badges are limited to a compact grid on mobile, and CTAs are stacked full-width on mobile (`inline-flex ... w-full`) to prevent clipping.  
- The trust strip is converted to wrapped compact pills on mobile and the long inline sentence is only shown at `sm+`, and small spacing/typography tweaks (safe `clamp` sizing and adjusted leading/margins) improve wrapping and readability.

### Testing
- Ran `npm run check:mobile-layout` and it passed (mobile layout contract checks succeeded).  
- Ran `npm run build` and the static build completed successfully (site routes generated and build finished).  
- Ran `git diff --check` and there were no whitespace/merge conflicts reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a026af584108328be23d5dfcbbcc9c4)