### PR TITLE
Harden mobile-safe visual components

### DIFF
--- a/docs/mobile-layout-fixes.md
+++ b/docs/mobile-layout-fixes.md
@@ -7,17 +7,22 @@ Use this note when reviewing Marin.dev on narrow Android/Chrome widths such as 3
 Paste this in DevTools after the page has finished rendering:
 
 ```js
-Array.from(document.querySelectorAll('body *')).filter(el => {
-  const r = el.getBoundingClientRect();
-  return r.width && (r.right > document.documentElement.clientWidth + 1 || r.left < -1);
-}).map(el => ({
-  tag: el.tagName,
-  class: el.className,
-  text: el.innerText?.slice(0, 80),
-  left: Math.round(el.getBoundingClientRect().left),
-  right: Math.round(el.getBoundingClientRect().right),
-  width: Math.round(el.getBoundingClientRect().width)
-}));
+Array.from(document.querySelectorAll("body *"))
+  .filter((el) => {
+    const r = el.getBoundingClientRect();
+    return (
+      r.width &&
+      (r.right > document.documentElement.clientWidth + 1 || r.left < -1)
+    );
+  })
+  .map((el) => ({
+    tag: el.tagName,
+    class: el.className,
+    text: el.innerText?.slice(0, 80),
+    left: Math.round(el.getBoundingClientRect().left),
+    right: Math.round(el.getBoundingClientRect().right),
+    width: Math.round(el.getBoundingClientRect().width),
+  }));
 ```
 
 ## What to check manually
@@ -27,3 +32,16 @@ Array.from(document.querySelectorAll('body *')).filter(el => {
 - Badges can wrap/shrink without pushing the viewport.
 - Grid and flex children use `min-w-0` where content may otherwise force intrinsic overflow.
 - Decorative glows can be clipped by their own containers, but real text/buttons/cards should not be clipped.
+
+## Mobile-safe component contract
+
+Reusable visual components must default to fluid, narrow-screen-safe behavior before adding desktop polish.
+
+- Grid and flex children that contain text, badges, CTAs or cards need `min-w-0` so intrinsic content cannot force the viewport wider.
+- Mobile CTAs should be `w-full` or at least `max-w-full`; only switch back to content-width buttons at `sm`/`md` and above.
+- Avoid long uppercase pills unless their inner label can shrink and wrap; use mobile-safe tracking first, then increase tracking on larger breakpoints.
+- Do not introduce large fixed widths below `md`; prefer `w-full`, `max-w-full`, `minmax(0, 1fr)` grids and responsive aspect ratios.
+- Do not use `overflow-hidden` on sections containing real text or interactive content unless the narrowest supported widths have been tested.
+- Decorative glows can be clipped inside their own card/mockup containers, but they must not be required for layout or readability.
+- Do not add iframes by default on mobile; use links, placeholders or explicitly tested lazy embeds instead.
+- Heavy effects such as large shadows, backdrop blur, transforms and hover glows should be reduced or disabled on mobile, then restored at desktop breakpoints.

--- a/scripts/check-mobile-layout-contract.mjs
+++ b/scripts/check-mobile-layout-contract.mjs
@@ -1,71 +1,108 @@
-import { readFileSync } from 'node:fs';
-import { join } from 'node:path';
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 
 const files = [
-  'src/layouts/BaseLayout.astro',
-  'src/styles/tailwind.css',
-  'src/components/HeroV2.astro',
-  'src/components/VisualBadge.astro',
-  'src/components/SectionHeader.astro',
-  'src/components/BrowserMockup.astro',
-  'src/components/ContactCTA.astro',
-  'src/components/FeaturedCases.astro',
-  'src/components/ProjectCard.astro',
-  'src/components/ProjectLinkPreview.astro',
-  'src/pages/proyectos/[slug].astro',
-  'src/pages/proyectos/index.astro',
-  'src/pages/servicios.astro',
+  "src/layouts/BaseLayout.astro",
+  "src/styles/tailwind.css",
+  "src/components/HeroV2.astro",
+  "src/components/VisualBadge.astro",
+  "src/components/SectionHeader.astro",
+  "src/components/BrowserMockup.astro",
+  "src/components/ContactCTA.astro",
+  "src/components/FeaturedCases.astro",
+  "src/components/ProjectCard.astro",
+  "src/components/ProjectLinkPreview.astro",
+  "src/pages/proyectos/[slug].astro",
+  "src/pages/proyectos/index.astro",
+  "src/pages/servicios.astro",
 ];
 
 const source = Object.fromEntries(
-  files.map((file) => [file, readFileSync(join(process.cwd(), file), 'utf8')]),
+  files.map((file) => [file, readFileSync(join(process.cwd(), file), "utf8")]),
 );
 
 const checks = [
   {
-    name: 'Do not mask layout issues with global horizontal overflow hiding',
-    pass: () => !Object.values(source).some((text) => /overflow-x\s*:\s*hidden|overflow-x-hidden/.test(text)),
+    name: "Do not mask layout issues with global horizontal overflow hiding",
+    pass: () =>
+      !Object.values(source).some((text) =>
+        /overflow-x\s*:\s*hidden|overflow-x-hidden/.test(text),
+      ),
   },
   {
-    name: 'Hero grid uses shrinkable minmax columns',
-    pass: () => source['src/components/HeroV2.astro'].includes('lg:grid-cols-[minmax(0,0.92fr)_minmax(0,1.08fr)]'),
+    name: "Hero grid uses shrinkable minmax columns",
+    pass: () =>
+      source["src/components/HeroV2.astro"].includes(
+        "lg:grid-cols-[minmax(0,0.92fr)_minmax(0,1.08fr)]",
+      ),
   },
   {
-    name: 'Hero content column has min-w-0 and max-w-full',
-    pass: () => source['src/components/HeroV2.astro'].includes('relative z-10 min-w-0 max-w-full'),
+    name: "Hero content column has min-w-0 and max-w-full",
+    pass: () =>
+      source["src/components/HeroV2.astro"].includes(
+        "relative z-10 min-w-0 max-w-full",
+      ),
   },
   {
-    name: 'Hero title uses a mobile fluid clamp and can break words',
-    pass: () => /<h1[^>]+break-words[^>]+text-\[clamp\(2\.25rem,10vw,3\.5rem\)\]/.test(source['src/components/HeroV2.astro']),
+    name: "Hero title uses a mobile fluid clamp and can break words",
+    pass: () =>
+      /<h1[^>]+break-words[^>]+text-\[clamp\(2\.25rem,10vw,3\.5rem\)\]/.test(
+        source["src/components/HeroV2.astro"],
+      ),
   },
   {
-    name: 'Hero primary and secondary CTAs are full-width on mobile',
-    pass: () => (source['src/components/HeroV2.astro'].match(/inline-flex min-h-12 w-full max-w-full/g) ?? []).length >= 2,
+    name: "Hero primary and secondary CTAs are full-width on mobile",
+    pass: () =>
+      (
+        source["src/components/HeroV2.astro"].match(
+          /inline-flex min-h-12 w-full max-w-full/g,
+        ) ?? []
+      ).length >= 2,
   },
   {
-    name: 'VisualBadge labels can shrink/wrap and use safer mobile tracking',
+    name: "VisualBadge labels can shrink/wrap and use safer mobile tracking",
     pass: () => {
-      const text = source['src/components/VisualBadge.astro'];
-      return text.includes('min-w-0 max-w-full') && text.includes('tracking-[0.1em]') && text.includes('<span class="min-w-0 break-words leading-5">{label}</span>');
+      const text = source["src/components/VisualBadge.astro"];
+      return (
+        text.includes("mobile-safe-pill") &&
+        text.includes("min-w-0 max-w-full") &&
+        text.includes("tracking-[0.06em]") &&
+        text.includes("sm:tracking-[0.14em]") &&
+        text.includes(
+          "mobile-safe-text min-w-0 flex-1 shrink break-words leading-5",
+        )
+      );
     },
   },
   {
-    name: 'SectionHeader root and eyebrow are width-safe',
+    name: "SectionHeader root and eyebrow are width-safe",
     pass: () => {
-      const text = source['src/components/SectionHeader.astro'];
-      return text.includes('relative flex min-w-0 max-w-full') && text.includes('flex w-full min-w-0 flex-wrap') && text.includes('tracking-[0.1em]');
+      const text = source["src/components/SectionHeader.astro"];
+      return (
+        text.includes("relative flex min-w-0 max-w-full") &&
+        text.includes("flex w-full min-w-0 flex-wrap") &&
+        text.includes("mobile-safe-pill") &&
+        text.includes("tracking-[0.06em]") &&
+        text.includes("mobile-safe-text max-w-full")
+      );
     },
   },
   {
-    name: 'Project/detail CTAs use full-width mobile buttons',
-    pass: () => source['src/pages/proyectos/[slug].astro'].includes('inline-flex w-full max-w-full') && source['src/components/ProjectCard.astro'].includes('inline-flex w-full max-w-full'),
+    name: "Project/detail CTAs use full-width mobile buttons",
+    pass: () =>
+      source["src/pages/proyectos/[slug].astro"].includes(
+        "inline-flex w-full max-w-full",
+      ) &&
+      source["src/components/ProjectCard.astro"].includes(
+        "inline-flex w-full max-w-full",
+      ),
   },
 ];
 
 const failures = checks.filter((check) => !check.pass());
 
 if (failures.length > 0) {
-  console.error('Mobile layout contract failed:');
+  console.error("Mobile layout contract failed:");
   for (const failure of failures) {
     console.error(`- ${failure.name}`);
   }

--- a/src/components/Badge.astro
+++ b/src/components/Badge.astro
@@ -1,6 +1,6 @@
 ---
 // Insignia simple para tags/stack compatible con el tema oscuro V2
-const { label, tone = 'default' } = Astro.props;
+const { label, tone = 'default', class: className = '' } = Astro.props;
 const tones = {
   default: 'border-line bg-surface-glass text-muted-bright',
   cyan: 'border-cyan-electric/30 bg-cyan-electric/10 text-cyan-100',
@@ -10,4 +10,4 @@ const tones = {
 };
 const classes = tones[tone] ?? tones.default;
 ---
-<span class={`inline-flex min-w-0 max-w-full items-center rounded-full border px-2.5 py-0.5 text-xs font-medium shadow-sm backdrop-blur ${classes}`}><span class="min-w-0 break-words leading-5">{label}</span></span>
+<span class={`mobile-safe-pill inline-flex min-w-0 max-w-full items-center rounded-full border px-2.5 py-0.5 text-xs font-medium shadow-sm backdrop-blur-none md:backdrop-blur ${classes} ${className}`}><span class="mobile-safe-text min-w-0 flex-1 shrink break-words leading-5">{label}</span></span>

--- a/src/components/GlowCard.astro
+++ b/src/components/GlowCard.astro
@@ -2,7 +2,7 @@
 const { as = 'div', class: className = '' } = Astro.props;
 const Tag = as;
 ---
-<Tag class={`group premium-interactive relative overflow-hidden rounded-3xl border border-line bg-surface-glow p-5 shadow-premium backdrop-blur hover:border-line-strong hover:shadow-premium-hover ${className}`}>
+<Tag class={`group premium-interactive mobile-card-lite relative min-w-0 overflow-hidden rounded-3xl border border-line bg-surface-glow p-5 shadow-premium backdrop-blur-none hover:border-line-strong hover:shadow-premium-hover md:backdrop-blur ${className}`}>
   <div class="pointer-events-none absolute inset-x-0 top-0 h-[0.0625rem] bg-gradient-to-r from-transparent via-cyan-electric/50 to-transparent opacity-70"></div>
   <div class="pointer-events-none absolute -right-14 -top-14 hidden h-32 w-32 rounded-full bg-cyan-electric/10 blur-3xl transition duration-300 group-hover:bg-cyan-electric/20 md:block"></div>
   <div class="relative">

--- a/src/components/IconBubble.astro
+++ b/src/components/IconBubble.astro
@@ -29,6 +29,6 @@ const iconSizes = {
   lg: 'lg',
 };
 ---
-<span class={`inline-flex shrink-0 items-center justify-center border backdrop-blur ${toneClasses[tone] ?? toneClasses.cyan} ${sizeClasses[size] ?? sizeClasses.md} ${className}`}>
+<span class={`inline-flex shrink-0 items-center justify-center border backdrop-blur-none md:backdrop-blur ${toneClasses[tone] ?? toneClasses.cyan} ${sizeClasses[size] ?? sizeClasses.md} ${className}`}>
   <Icon name={icon} size={iconSizes[size] ?? 'md'} label={label} />
 </span>

--- a/src/components/ProjectCard.astro
+++ b/src/components/ProjectCard.astro
@@ -93,7 +93,7 @@ const stackChips = Array.isArray(stack) ? stack.slice(0, STACK_LIMIT) : [];
 const copyFocus = highlight || solucion || problema;
 ---
 <article
-  class="group premium-interactive flex h-full min-w-0 flex-col overflow-hidden rounded-3xl border border-line bg-surface-glow shadow-premium backdrop-blur hover:-translate-y-1 hover:border-line-strong hover:shadow-premium-hover"
+  class="group premium-interactive mobile-card-lite flex h-full min-w-0 flex-col overflow-hidden rounded-3xl border border-line bg-surface-glow shadow-premium backdrop-blur-none hover:border-line-strong hover:shadow-premium-hover md:backdrop-blur"
 >
   <div class="relative min-w-0 overflow-hidden border-b border-line bg-ink/60">
     {hasImage ? (
@@ -114,7 +114,7 @@ const copyFocus = highlight || solucion || problema;
           <div class="absolute inset-0 bg-premium-grid bg-[length:2rem_2rem] opacity-45"></div>
           <div class={`absolute -left-16 top-4 hidden h-44 w-44 rounded-full blur-3xl transition duration-500 group-hover:opacity-90 md:block ${visualStyles.glowPrimary}`}></div>
           <div class={`absolute -right-16 bottom-0 hidden h-48 w-48 rounded-full blur-3xl transition duration-500 group-hover:opacity-90 md:block ${visualStyles.glowSecondary}`}></div>
-          <div class="absolute inset-x-5 top-5 flex min-w-0 items-center gap-2 rounded-2xl border border-line bg-surface-glass px-3 py-2 shadow-premium backdrop-blur">
+          <div class="absolute inset-x-5 top-5 flex min-w-0 items-center gap-2 rounded-2xl border border-line bg-surface-glass px-3 py-2 shadow-premium backdrop-blur-none md:backdrop-blur">
             <span class="h-2.5 w-2.5 rounded-full bg-rose-400/90"></span>
             <span class="h-2.5 w-2.5 rounded-full bg-amber-300/90"></span>
             <span class="h-2.5 w-2.5 rounded-full bg-brand-success/90"></span>
@@ -122,22 +122,22 @@ const copyFocus = highlight || solucion || problema;
             <span class={`h-2 w-12 rounded-full ${visualStyles.line}`}></span>
           </div>
           <div class="relative flex h-full min-w-0 flex-col justify-end p-5 pt-16">
-            <div class="min-w-0 rounded-3xl border border-line bg-surface-glass p-4 shadow-premium backdrop-blur">
+            <div class="mobile-card-lite min-w-0 rounded-3xl border border-line bg-surface-glass p-4 shadow-premium backdrop-blur-none md:backdrop-blur">
               <div class="flex min-w-0 items-center justify-between gap-3">
                 <div class={`flex h-14 w-14 shrink-0 items-center justify-center rounded-2xl border text-lg font-black tracking-tight ${visualStyles.iconShell}`}>
                   <span aria-hidden="true" class="text-xl leading-none">{visualSystem.category.icon}</span>
                   <span class="sr-only">{visualSystem.initials}</span>
                 </div>
                 <div class="min-w-0 text-right">
-                  <p class="break-words text-[0.68rem] font-semibold uppercase tracking-[0.1em] text-muted-soft sm:tracking-[0.22em]">Mini caso</p>
+                  <p class="mobile-safe-text break-words text-[0.68rem] font-semibold uppercase tracking-[0.06em] text-muted-soft sm:tracking-[0.18em]">Mini caso</p>
                   <p class={`mt-1 text-xs font-semibold ${visualStyles.accentText}`}>{visualSystem.initials}</p>
                 </div>
               </div>
-              <p class={`mt-4 break-words text-xs font-semibold uppercase tracking-[0.1em] sm:tracking-[0.2em] ${visualStyles.accentText}`}>{commercialType}</p>
-              <p class="mt-2 line-clamp-2 break-words text-lg font-semibold leading-tight text-slate-50">{title}</p>
+              <p class={`mobile-safe-text mt-4 break-words text-xs font-semibold uppercase tracking-[0.06em] sm:tracking-[0.18em] ${visualStyles.accentText}`}>{commercialType}</p>
+              <p class="mobile-safe-text mt-2 line-clamp-2 break-words text-lg font-semibold leading-tight text-slate-50">{title}</p>
               <div class="mt-4 flex flex-wrap gap-2" aria-hidden="true">
                 {visualPills.map((item: string) => (
-                  <span class={`rounded-full border px-2 py-1 text-[0.68rem] font-semibold ${visualStyles.chip}`}>{item}</span>
+                  <span class={`mobile-safe-pill max-w-full rounded-full border px-2 py-1 text-[0.68rem] font-semibold ${visualStyles.chip}`}>{item}</span>
                 ))}
               </div>
             </div>
@@ -154,17 +154,17 @@ const copyFocus = highlight || solucion || problema;
     </div>
   </div>
 
-  <div class="relative z-10 flex min-h-[24rem] min-w-0 flex-1 flex-col p-5 sm:p-6">
+  <div class="relative z-10 flex min-w-0 flex-1 flex-col p-5 sm:p-6 md:min-h-[24rem]">
     <div>
-      <p class="break-words text-xs font-semibold uppercase tracking-[0.1em] text-muted sm:tracking-[0.22em]">{businessLabel}</p>
-      <h3 class="mt-2 break-words text-xl font-semibold tracking-tight text-slate-50 transition group-hover:text-cyan-electric">
+      <p class="mobile-safe-text break-words text-xs font-semibold uppercase tracking-[0.06em] text-muted sm:tracking-[0.18em]">{businessLabel}</p>
+      <h3 class="mobile-safe-text mt-2 break-words text-xl font-semibold tracking-tight text-slate-50 transition group-hover:text-cyan-electric">
         <a href={resolvedCaseUrl} class="focus-visible:outline-none">{title}</a>
       </h3>
-      {resumen && <p class="mt-3 line-clamp-3 text-sm leading-6 text-muted-soft">{resumen}</p>}
+      {resumen && <p class="mobile-safe-text mt-3 line-clamp-3 text-sm leading-6 text-muted-soft">{resumen}</p>}
     </div>
 
     {copyFocus && (
-      <div class="mt-5 min-w-0 rounded-2xl border border-line bg-ink/35 p-4 text-sm leading-6 text-muted-soft">
+      <div class="mobile-safe-text mt-5 min-w-0 rounded-2xl border border-line bg-ink/35 p-4 text-sm leading-6 text-muted-soft">
         {highlight ? (
           <p><span class="font-semibold text-slate-50">Clave:</span> {highlight}</p>
         ) : (
@@ -187,14 +187,14 @@ const copyFocus = highlight || solucion || problema;
     )}
 
     {benefit && (
-      <p class="mt-5 min-w-0 break-words rounded-2xl border border-brand-success/20 bg-brand-success/10 p-3 text-sm leading-6 text-emerald-100">
+      <p class="mobile-safe-text mt-5 min-w-0 break-words rounded-2xl border border-brand-success/20 bg-brand-success/10 p-3 text-sm leading-6 text-emerald-100">
         <span class="font-semibold">Resultado / beneficio:</span> {benefit}
       </p>
     )}
 
     {stackChips.length > 0 && (
       <div class="mt-5 border-t border-line pt-4">
-        <p class="break-words text-[0.68rem] font-semibold uppercase tracking-[0.1em] text-muted sm:tracking-[0.2em]">Tecnologías</p>
+        <p class="mobile-safe-text break-words text-[0.68rem] font-semibold uppercase tracking-[0.06em] text-muted sm:tracking-[0.18em]">Tecnologías</p>
         <div class="mt-2 flex min-w-0 flex-wrap gap-2">
           {stackChips.map((item: string) => <Badge label={item} tone="violet" />)}
         </div>

--- a/src/components/SectionHeader.astro
+++ b/src/components/SectionHeader.astro
@@ -18,9 +18,9 @@ const eyebrowAlignment = isCenter ? 'justify-center' : 'justify-start';
   <div class={`flex w-full min-w-0 flex-wrap items-center gap-3 ${eyebrowAlignment}`}>
     {icon && <IconBubble icon={icon} tone="cyan" size="sm" label={eyebrow ?? title ?? 'Sección'} />}
     {eyebrow && (
-      <p class="inline-flex min-w-0 max-w-full items-center rounded-full border border-line bg-surface-glass px-3 py-1 text-xs font-semibold uppercase tracking-[0.1em] text-cyan-electric shadow-[inset_0_1px_0_rgba(255,255,255,0.06)] backdrop-blur sm:w-fit sm:tracking-[0.22em]">
+      <p class="mobile-safe-pill inline-flex min-w-0 max-w-full items-center rounded-full border border-line bg-surface-glass px-3 py-1 text-xs font-semibold uppercase tracking-[0.06em] text-cyan-electric shadow-[inset_0_1px_0_rgba(255,255,255,0.06)] backdrop-blur-none sm:w-fit sm:tracking-[0.18em] md:backdrop-blur">
         <span class="mr-2 h-1.5 w-1.5 rounded-full bg-cyan-electric shadow-[0_0_14px_rgba(34,211,238,0.7)]" aria-hidden="true"></span>
-        <span class="min-w-0 break-words leading-5">{eyebrow}</span>
+        <span class="mobile-safe-text min-w-0 flex-1 shrink break-words leading-5">{eyebrow}</span>
       </p>
     )}
   </div>
@@ -28,14 +28,14 @@ const eyebrowAlignment = isCenter ? 'justify-center' : 'justify-start';
   <div class="relative min-w-0 max-w-full">
     <div class={`pointer-events-none absolute -inset-x-4 -inset-y-3 -z-10 hidden rounded-3xl bg-gradient-to-r from-cyan-electric/10 via-blue-electric/5 to-violet-electric/10 blur-2xl sm:block ${isCenter ? 'opacity-60' : 'opacity-45'}`}></div>
     {title && (
-      <h2 class="max-w-full break-words text-3xl font-semibold tracking-tight text-slate-50 sm:text-4xl lg:text-5xl">
+      <h2 class="mobile-safe-text max-w-full text-balance break-words text-3xl font-semibold tracking-tight text-slate-50 sm:text-4xl lg:text-5xl">
         {title}
       </h2>
     )}
   </div>
 
   {description && (
-    <p class={`max-w-full break-words text-base leading-7 text-muted-soft sm:text-lg ${isCenter ? 'mx-auto sm:max-w-2xl' : 'sm:max-w-copy'}`}>
+    <p class={`mobile-safe-text max-w-full break-words text-base leading-7 text-muted-soft sm:text-lg ${isCenter ? 'mx-auto sm:max-w-2xl' : 'sm:max-w-copy'}`}>
       {description}
     </p>
   )}

--- a/src/components/VisualBadge.astro
+++ b/src/components/VisualBadge.astro
@@ -6,6 +6,7 @@ const {
   icon,
   tone = 'neutral',
   size = 'sm',
+  compact = false,
   class: className = '',
 } = Astro.props;
 
@@ -18,11 +19,11 @@ const toneClasses = {
 };
 
 const sizeClasses = {
-  sm: 'gap-1.5 px-2.5 py-1 text-[0.72rem]',
-  md: 'gap-2 px-3 py-1.5 text-xs',
+  sm: compact ? 'gap-1 px-2 py-0.5 text-[0.68rem]' : 'gap-1.5 px-2.5 py-1 text-[0.72rem]',
+  md: compact ? 'gap-1.5 px-2.5 py-1 text-[0.72rem]' : 'gap-2 px-3 py-1.5 text-xs',
 };
 ---
-<span class={`inline-flex min-w-0 max-w-full items-center rounded-full border font-semibold uppercase tracking-[0.1em] backdrop-blur sm:w-fit sm:tracking-[0.16em] ${toneClasses[tone] ?? toneClasses.neutral} ${sizeClasses[size] ?? sizeClasses.sm} ${className}`}>
+<span class={`mobile-safe-pill inline-flex min-w-0 max-w-full items-center rounded-full border font-semibold uppercase tracking-[0.06em] backdrop-blur-none sm:w-fit sm:tracking-[0.14em] md:backdrop-blur ${toneClasses[tone] ?? toneClasses.neutral} ${sizeClasses[size] ?? sizeClasses.sm} ${className}`}>
   {icon && <Icon name={icon} size="sm" />}
-  <span class="min-w-0 break-words leading-5">{label}</span>
+  <span class="mobile-safe-text min-w-0 flex-1 shrink break-words leading-5">{label}</span>
 </span>

--- a/src/components/VisualCard.astro
+++ b/src/components/VisualCard.astro
@@ -17,7 +17,7 @@ const attrs = href ? { href } : {};
 ---
 <Tag
   {...attrs}
-  class={`group premium-interactive block h-full min-w-0 overflow-hidden rounded-3xl border border-line bg-surface-glow p-5 shadow-premium backdrop-blur hover:border-line-strong hover:shadow-premium-hover focus-visible:outline-cyan-electric ${className}`}
+  class={`group premium-interactive mobile-card-lite block h-full min-w-0 overflow-hidden rounded-3xl border border-line bg-surface-glow p-5 shadow-premium backdrop-blur-none hover:border-line-strong hover:shadow-premium-hover focus-visible:outline-cyan-electric md:backdrop-blur ${className}`}
 >
   <div class="pointer-events-none absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-cyan-electric/50 to-transparent opacity-70"></div>
   <div class="pointer-events-none absolute -right-16 -top-16 hidden h-32 w-32 rounded-full bg-cyan-electric/10 blur-3xl transition duration-300 group-hover:bg-cyan-electric/20 md:block"></div>
@@ -25,12 +25,12 @@ const attrs = href ? { href } : {};
   <div class="relative flex h-full min-w-0 flex-col gap-4">
     <div class="flex min-w-0 items-start justify-between gap-4">
       {icon && <IconBubble icon={icon} tone={tone} size="md" />}
-      {badge && <VisualBadge label={badge} tone={tone} />}
+      {badge && <VisualBadge label={badge} tone={tone} compact />}
     </div>
 
     <div class="min-w-0">
-      {title && <h3 class="break-words text-lg font-semibold tracking-tight text-slate-50">{title}</h3>}
-      {description && <p class="mt-3 text-sm leading-6 text-muted-soft">{description}</p>}
+      {title && <h3 class="mobile-safe-text break-words text-lg font-semibold tracking-tight text-slate-50">{title}</h3>}
+      {description && <p class="mobile-safe-text mt-3 text-sm leading-6 text-muted-soft">{description}</p>}
     </div>
 
     <slot />

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -131,15 +131,41 @@
     color: #67e8f9;
   }
 
+  .mobile-safe-text {
+    min-width: 0;
+    max-width: 100%;
+    overflow-wrap: anywhere;
+    word-break: normal;
+  }
+
+  .mobile-safe-pill {
+    min-width: 0;
+    max-width: 100%;
+    white-space: normal;
+  }
+
+  .mobile-safe-pill > * {
+    min-width: 0;
+  }
+
+  .mobile-card-lite {
+    min-width: 0;
+  }
+
+  .safe-grid {
+    display: grid;
+    min-width: 0;
+  }
+
+  .safe-grid > * {
+    min-width: 0;
+  }
+
   .premium-interactive {
     position: relative;
-    transform: translateZ(0);
     transition:
-      transform 260ms ease,
-      border-color 260ms ease,
-      box-shadow 260ms ease,
-      background-color 260ms ease;
-    will-change: transform;
+      border-color 180ms ease,
+      background-color 180ms ease;
   }
 
   .premium-interactive::before {
@@ -265,7 +291,19 @@
     }
   }
 
-  @media (hover: hover) {
+  @media (min-width: 48rem) {
+    .premium-interactive {
+      transform: translateZ(0);
+      transition:
+        transform 260ms ease,
+        border-color 260ms ease,
+        box-shadow 260ms ease,
+        background-color 260ms ease;
+      will-change: transform;
+    }
+  }
+
+  @media (hover: hover) and (min-width: 48rem) {
     .premium-interactive:hover {
       transform: translate3d(0, -0.25rem, 0);
     }
@@ -297,15 +335,18 @@
 
     .premium-interactive {
       transform: none;
-      transition:
-        border-color 180ms ease,
-        background-color 180ms ease;
       will-change: auto;
     }
 
     .premium-interactive::before,
     .premium-button::after {
       display: none;
+    }
+
+    .mobile-card-lite {
+      box-shadow:
+        0 0.875rem 2rem -1.5rem rgba(15, 23, 42, 0.9),
+        0 0 0 0.0625rem rgba(148, 163, 184, 0.08);
     }
 
     .float-soft {


### PR DESCRIPTION
### Motivation
- Prevent intrinsic-width overflow and mobile clipping by making reusable visual primitives shrinkable and fluid by default while preserving the V2 premium look on desktop.
- Reduce mobile paint cost and visual noise by disabling heavy effects (backdrop-blur, large transforms/will-change, oversized shadows) on narrow screens.
- Provide a small automated contract and docs to avoid regressions when future patches add new UI components.

### Description
- Added minimal mobile-safety utilities in `src/styles/tailwind.css` (`.mobile-safe-text`, `.mobile-safe-pill`, `.mobile-card-lite`, `.safe-grid`) and moved `premium-interactive` transforms/will-change to desktop-only breakpoints to reduce mobile paint cost.
- Made `VisualBadge` and `Badge` shrink/wrap safe (`min-w-0`, `max-w-full`, shrinkable label span), added an optional `compact` mode to `VisualBadge`, and lowered mobile letter-spacing so long labels never push the viewport (`src/components/VisualBadge.astro`, `src/components/Badge.astro`).
- Hardened `SectionHeader` to be width-safe (root + eyebrow row use `min-w-0`, eyebrow and heading use `mobile-safe-*` helpers and smaller mobile tracking) in `src/components/SectionHeader.astro`.
- Reduced mobile heaviness for cards and related visuals by disabling backdrop-blur on mobile and using `.mobile-card-lite` (applied to `GlowCard`, `VisualCard`, `ProjectCard`) and adjusted `IconBubble` to avoid mobile blur; kept desktop polish at `md`+ breakpoints (`src/components/GlowCard.astro`, `src/components/VisualCard.astro`, `src/components/IconBubble.astro`, `src/components/ProjectCard.astro`).
- Documented the contract in `docs/mobile-layout-fixes.md` under “Mobile-safe component contract” and updated `scripts/check-mobile-layout-contract.mjs` to assert the new defaults so CI can catch regressions.

### Testing
- Ran the mobile-layout contract check with `npm run check:mobile-layout`, which passed after updates to the script and components.
- Built the site with `npm run build`, which completed successfully and generated the static output (14 pages built).
- Attempted formatting with `npx prettier --write` for changed files; Prettier formatted docs and CSS but reported no parser for `.astro` files in this repo configuration (informational only).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02826e928c832887c94be1dd691b8b)