### PR TITLE
Enforce no-auto-iframe policy for project demos

### DIFF
--- a/docs/mobile-scroll-performance.md
+++ b/docs/mobile-scroll-performance.md
@@ -7,7 +7,7 @@
 - Las superficies V2 usan muchas cards con `backdrop-blur`, sombras grandes, glows con `blur-2xl` / `blur-3xl`, pseudo-elementos con gradientes y transiciones de `transform`/`box-shadow`.
 - El shell global tenía capas decorativas `position: fixed` con grid y gradientes; en móviles esto puede repintarse durante scroll según navegador/GPU.
 - Las cards del portfolio sin imagen real generaban múltiples glows grandes y blurs dentro de cada card, multiplicando el coste cuando muchas cards entran al viewport.
-- `ProjectLinkPreview` puede renderizar iframes externos si se usa `embedMode="iframe"`; actualmente mantiene `loading="lazy"`, lo cual evita una carga ansiosa pesada pero puede seguir siendo un riesgo en páginas de detalle con demos externas.
+- `ProjectLinkPreview` aplica una política estricta **no-auto-iframe**: las demos externas nunca se cargan embebidas durante el render ni durante el scroll mobile; se muestran como previews estáticos con dominio visible y CTA `Abrir demo`.
 
 ## Changes made
 
@@ -17,11 +17,11 @@
 - En mobile, se reduce el coste de `backdrop-blur`, `blur-2xl`/`blur-3xl`, `shadow-premium` y `shadow-glow` manteniendo el look oscuro/premium.
 - Se ocultaron glows decorativos internos en cards reutilizables y cards de proyecto en mobile, manteniéndolos en desktop.
 - Se simplificaron glows del hero/mockup y el glow del `SectionHeader` en pantallas pequeñas.
+- Se eliminó el renderizado de iframes externos en `ProjectLinkPreview`; las demos se abren en una pestaña nueva para evitar descargar sitios completos de Vercel, GitHub Pages u otros dominios mientras el usuario navega el portfolio.
 
 ## Remaining risks
 
 - Páginas con muchas cards todavía tienen bastante HTML y muchas superficies con bordes/sombras; el coste debería bajar, pero conviene probar en dispositivos Android/iOS reales de gama media.
-- Los iframes externos siguen siendo un posible punto pesado si algún detalle de proyecto activa `embedMode="iframe"`; no se cambió a eager ni se eliminaron previews.
 - Algunas imágenes de proyecto siguen con `loading="lazy"`; esto es correcto para evitar carga inicial pesada, pero en redes lentas pueden aparecer placeholders o imágenes tarde. El objetivo de este patch fue pintura/scroll, no eager loading.
 - La navegación móvil sigue usando elementos `fixed` solo cuando el menú está disponible/abierto; no debería impactar el scroll normal, pero conviene verificar el overlay en dispositivos reales.
 
@@ -31,6 +31,6 @@
 2. Hacer scroll continuo desde el hero hasta los casos destacados y comprobar que las cards ya están visibles al entrar al viewport.
 3. Revisar que no haya saltos visuales ni aparición tardía de frames/cards en `Qué resuelvo`, `Casos`, `Demos por rubro`, `Proceso` y `Planes`.
 4. Abrir `/proyectos` y repetir scroll sobre la grilla completa de cards.
-5. Abrir un detalle de proyecto con demo externa y comprobar que el preview/iframe lazy no bloquea el scroll.
+5. Abrir un detalle de proyecto con demo externa y comprobar que solo aparece el preview estático, el dominio visible y el botón `Abrir demo` en nueva pestaña; no debe existir iframe en el HTML generado.
 6. Probar menú móvil: abrir/cerrar overlay y verificar que el bloqueo de scroll se restaura correctamente.
 7. Comparar desktop rápidamente para asegurar que los glows/hover premium se mantienen en pantallas `md` o mayores.

--- a/docs/performance-audit.md
+++ b/docs/performance-audit.md
@@ -222,7 +222,8 @@ Beneficio esperado:
 - Reduce riesgo sobre LCP, INP, uso de red y consumo de CPU en mobile.
 - Mantiene la salida estática de Astro y no agrega React, hidratación ni librerías de lazy iframe.
 
-Uso restante de iframes:
+Política no-auto-iframe vigente:
 
-- `ProjectLinkPreview` conserva un modo opt-in `embedMode="iframe"` para casos excepcionales, pero queda deshabilitado por defecto.
-- No se detectan usos actuales que pasen `embedMode="iframe"`; las páginas de proyecto abren las demos mediante enlace externo.
+- `ProjectLinkPreview` ya no renderiza iframes ni acepta un modo `embedMode="iframe"`; las demos externas se presentan con preview estático, dominio visible y botón `Abrir demo`.
+- Las demos se abren en una pestaña nueva con `target="_blank"` y `rel="noopener noreferrer"` para preservar el enlace público sin descargar sitios completos de terceros durante el scroll mobile.
+- Cualquier excepción futura para iframes debe documentarse explícitamente como cambio de arquitectura/performance y no puede activarse por defecto en páginas de proyecto.

--- a/src/components/ProjectLinkPreview.astro
+++ b/src/components/ProjectLinkPreview.astro
@@ -8,14 +8,12 @@ const {
   thumbnail = '',
   slug = '',
   eager = false,
-  embedMode = 'static',
 } = Astro.props;
 
 const displayCover = projectCoverImage({ slug, thumbnail, cover });
 const hasPreviewUrl = typeof url === 'string' && url.length > 0;
 const isLocalCover = typeof displayCover === 'string' && displayCover.startsWith('/');
 const hasStaticCover = isLocalCover && displayCover !== '/og-default.png';
-const shouldRenderIframe = hasPreviewUrl && embedMode === 'iframe';
 let previewHost = `marin.dev/caso/${slug}`;
 
 if (hasPreviewUrl) {
@@ -34,19 +32,7 @@ if (hasPreviewUrl) {
     </div>
 
     <div class="relative mt-3 aspect-[4/3] min-w-0 overflow-hidden rounded-2xl border border-line bg-ink">
-      {shouldRenderIframe ? (
-        <>
-          <iframe
-            src={url}
-            title={`Vista previa navegable de ${title}`}
-            class="h-full w-full bg-white"
-            loading={eager ? 'eager' : 'lazy'}
-            referrerpolicy="no-referrer"
-            sandbox="allow-scripts allow-same-origin allow-forms allow-popups"
-          ></iframe>
-          <div class="pointer-events-none absolute inset-x-0 bottom-0 h-20 bg-gradient-to-t from-ink/80 to-transparent"></div>
-        </>
-      ) : hasStaticCover ? (
+      {hasStaticCover ? (
         <>
           <img
             src={displayCover}


### PR DESCRIPTION
### Motivation
- A performance audit showed external demo iframes can load full third-party sites while scrolling and harm mobile LCP/INP and CPU; the goal is to guarantee project pages never auto-load external demos. 

### Description
- Remove iframe rendering and the `embedMode` escape hatch from `src/components/ProjectLinkPreview.astro`, leaving only a static preview/fallback UI that shows the preview host/domain and an external CTA. 
- Keep static preview behavior, image fallback, stable `aspect-[4/3]` layout and existing `eager`/`lazy` image loading semantics so visual layout and paint remain stable. 
- Ensure the demo CTA opens the external URL with `target="_blank" rel="noopener noreferrer"` and preserve all demo links and project metadata. 
- Update documentation in `docs/mobile-scroll-performance.md` and `docs/performance-audit.md` to record the strict no-auto-iframe policy and the rationale for opening demos in a new tab.

### Testing
- Ran `npm run build` and the site built successfully (static pages generated; build completed without errors). 
- Performed repository searches (`rg`) to confirm there are no remaining automatic iframe renderings or `embedMode` usage in the built `dist` HTML and source components. 
- Manually inspected project detail usage (`src/pages/proyectos/[slug].astro`) to verify previews render statically and the external "Abrir demo" link remains present and functional.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02948539788328b1c84f91592a02d8)