### PR TITLE
Add mobile regression audit guardrails

### DIFF
--- a/docs/mobile-regression-checklist.md
+++ b/docs/mobile-regression-checklist.md
@@ -1,0 +1,104 @@
+# Mobile layout regression checklist
+
+Use this checklist before deploying visual changes to Marin.dev, especially patches that touch the hero, project cards, badges, CTAs, previews, navigation or section wrappers. The goal is to catch narrow-viewport regressions without adding browser automation or heavy dependencies.
+
+## Required viewport widths
+
+Test every route below at these viewport widths in browser DevTools:
+
+- `360px` — small Android / tightest supported layout.
+- `375px` — common iPhone width.
+- `390px` — modern iPhone width.
+- `430px` — large mobile width before tablet layouts.
+
+Keep the device height realistic enough to scroll through the full page. Refresh after changing each width so CSS, lazy content and menu state are evaluated from a clean render.
+
+## Required pages
+
+- `/`
+- `/proyectos`
+- One project detail page, for example `/proyectos/vetcare` or any current project slug.
+- `/servicios`
+- `/contacto`
+
+## Manual layout checks
+
+For each page and viewport width:
+
+- [ ] There is no horizontal scroll on initial load or after scrolling to the bottom.
+- [ ] The hero title is fully visible and does not crop on the left or right edge.
+- [ ] Badges, pills and eyebrow labels wrap or shrink safely instead of forcing the viewport wider.
+- [ ] CTA buttons are fully visible; text does not clip and tap targets remain usable.
+- [ ] Cards, project previews, mockups and pricing/service panels are not clipped.
+- [ ] Project previews do not load live iframes by default on mobile.
+- [ ] Sticky navigation does not repaint heavily while scrolling.
+- [ ] The mobile menu opens and closes cleanly without leaving the body fixed, locked or horizontally shifted.
+- [ ] There is no visible right-edge cropping, especially in glow wrappers, grids, browser mockups and CTA rows.
+
+## DevTools overflow detection snippet
+
+Paste this in the browser console after the page has rendered. A clean page should return an empty array, or only decorative elements that are intentionally isolated and cannot affect text, CTAs or cards.
+
+```js
+Array.from(document.querySelectorAll("body *"))
+  .filter((el) => {
+    const r = el.getBoundingClientRect();
+    return (
+      r.width &&
+      (r.right > document.documentElement.clientWidth + 1 || r.left < -1)
+    );
+  })
+  .map((el) => ({
+    tag: el.tagName,
+    class: String(el.className).slice(0, 160),
+    text: el.innerText?.replace(/\s+/g, " ").slice(0, 100),
+    left: Math.round(el.getBoundingClientRect().left),
+    right: Math.round(el.getBoundingClientRect().right),
+    width: Math.round(el.getBoundingClientRect().width),
+  }));
+```
+
+### How to interpret results
+
+- Prioritize elements with readable text, CTAs, nav items, cards, forms and project previews.
+- Decorative halos can extend inside a clipped visual wrapper, but they should not appear as body-level overflow or hide real content.
+- If an element appears in the list, check whether it needs `min-w-0`, `max-w-full`, `w-full` on mobile, safer tracking, a wrapping flex row, or a responsive grid using `minmax(0, 1fr)`.
+
+## Repo search checklist
+
+Run these searches before approving a mobile-facing visual patch. They are intentionally simple and should be reviewed manually.
+
+```bash
+rg -n "<iframe|iframe" src
+rg -n "embedMode=\"iframe\"|embedMode='iframe'" src
+rg -n "(^|[^a-z:])w-\[" src/components src/pages src/layouts
+rg -n "(^|[^a-z:])min-w-\[" src/components src/pages src/layouts
+rg -n "<section[^>]*overflow-hidden|overflow-hidden[^\n]*<section|overflow-hidden" src/components src/pages src/layouts
+rg -n "inline-flex" src/components src/pages src/layouts
+```
+
+When reviewing the output, pay special attention to:
+
+- `w-[...]` or `min-w-[...]` utilities without a responsive prefix such as `sm:`, `md:` or `lg:`.
+- `overflow-hidden` on major sections that contain real text, CTAs or cards rather than purely decorative wrappers.
+- `inline-flex` CTA anchors/buttons that do not also include `w-full` or `max-w-full` for mobile.
+- Any accidental `iframe` or `embedMode="iframe"` usage in project previews.
+
+## Lightweight automated audit
+
+Run the warning-only source scan after build:
+
+```bash
+npm run audit:mobile-patterns
+```
+
+The script is not a replacement for browser testing. It flags risky source patterns so reviewers know where to look during the manual checks above.
+
+## Recommended pre-deploy sequence
+
+```bash
+npm run build
+npm run audit:mobile-patterns
+```
+
+Then complete the viewport checklist for the required pages before merging or deploying visual patches.

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "preview": "astro preview",
     "format": "prettier --write .",
     "lint": "eslint .",
-    "check:mobile-layout": "node scripts/check-mobile-layout-contract.mjs"
+    "check:mobile-layout": "node scripts/check-mobile-layout-contract.mjs",
+    "audit:mobile-patterns": "node scripts/audit-mobile-patterns.mjs"
   },
   "dependencies": {
     "@astrojs/sitemap": "^3.1.4",

--- a/scripts/audit-mobile-patterns.mjs
+++ b/scripts/audit-mobile-patterns.mjs
@@ -1,0 +1,188 @@
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join, relative } from "node:path";
+
+const ROOTS = ["src/components", "src/pages", "src/layouts"];
+const EXTENSIONS = new Set([".astro", ".js", ".jsx", ".mjs", ".ts", ".tsx"]);
+const CTA_FILE_HINT =
+  /(Hero|CTA|Nav|Footer|Pricing|Service|Project|Card|Contact|Button)/i;
+
+function walk(dir) {
+  const entries = readdirSync(dir, { withFileTypes: true });
+  return entries.flatMap((entry) => {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) return walk(path);
+    const dot = entry.name.lastIndexOf(".");
+    const extension = dot >= 0 ? entry.name.slice(dot) : "";
+    return EXTENSIONS.has(extension) ? [path] : [];
+  });
+}
+
+function lineNumberForOffset(source, offset) {
+  return source.slice(0, offset).split("\n").length;
+}
+
+function lineAt(source, lineNumber) {
+  return source.split("\n")[lineNumber - 1]?.trim() ?? "";
+}
+
+function warn(warnings, file, line, rule, detail) {
+  warnings.push({ file, line, rule, detail });
+}
+
+function hasMobileWidthGuard(classText) {
+  return /(?:^|\s)(?:w-full|max-w-full|sm:w-auto|md:w-auto|lg:w-auto)(?:\s|$)/.test(
+    classText,
+  );
+}
+
+function analyzeClassAttribute(source, file, warnings) {
+  const classAttributePattern =
+    /class(?::list)?\s*=\s*(?:"([\s\S]*?)"|'([\s\S]*?)'|`([\s\S]*?)`|\{`([\s\S]*?)`\})/g;
+  let match;
+
+  while ((match = classAttributePattern.exec(source)) !== null) {
+    const classText = (
+      match[1] ??
+      match[2] ??
+      match[3] ??
+      match[4] ??
+      ""
+    ).replace(/\s+/g, " ");
+    const line = lineNumberForOffset(source, match.index);
+    const tagStart = source.lastIndexOf("<", match.index);
+    const tagPrefix =
+      tagStart >= 0 ? source.slice(tagStart + 1, match.index).trim() : "";
+    const tagName =
+      tagPrefix.match(/^([A-Za-z][\w:-]*)/)?.[1]?.toLowerCase() ?? "";
+
+    if (/(^|\s)w-\[/.test(classText)) {
+      warn(
+        warnings,
+        file,
+        line,
+        "fixed arbitrary width",
+        "Class contains unprefixed `w-[...]`; confirm it cannot overflow narrow mobile widths.",
+      );
+    }
+
+    if (/(^|\s)min-w-\[/.test(classText)) {
+      warn(
+        warnings,
+        file,
+        line,
+        "fixed arbitrary min-width",
+        "Class contains unprefixed `min-w-[...]`; prefer `min-w-0` or a responsive breakpoint unless required.",
+      );
+    }
+
+    if (
+      tagName === "section" &&
+      /(^|\s)overflow-hidden(\s|$)/.test(classText)
+    ) {
+      warn(
+        warnings,
+        file,
+        line,
+        "section overflow clipping",
+        "Section class contains `overflow-hidden`; verify it clips only decoration, not text, badges, CTAs or cards.",
+      );
+    }
+
+    const trackingPattern =
+      /(^|\s)(?:(sm|md|lg|xl|2xl):)?tracking-\[(0?\.\d+)em\]/g;
+    let trackingMatch;
+    while ((trackingMatch = trackingPattern.exec(classText)) !== null) {
+      const breakpoint = trackingMatch[2];
+      const value = Number.parseFloat(trackingMatch[3]);
+      if (value >= 0.2 && !breakpoint) {
+        warn(
+          warnings,
+          file,
+          line,
+          "wide mobile letter spacing",
+          `Unprefixed tracking-[${trackingMatch[3]}em] can clip narrow badges; move high tracking to sm:/md: or reduce it on mobile.`,
+        );
+      }
+    }
+
+    if (
+      CTA_FILE_HINT.test(file) &&
+      ["a", "button"].includes(tagName) &&
+      /(^|\s)inline-flex(\s|$)/.test(classText) &&
+      !hasMobileWidthGuard(classText)
+    ) {
+      warn(
+        warnings,
+        file,
+        line,
+        "inline-flex CTA width guard",
+        "Potential CTA uses `inline-flex` without `w-full` or `max-w-full`; verify it cannot clip on mobile.",
+      );
+    }
+  }
+}
+
+function analyzeLinePatterns(source, file, warnings) {
+  const lines = source.split("\n");
+  lines.forEach((lineText, index) => {
+    const line = index + 1;
+    if (/embedMode\s*=\s*["']iframe["']/.test(lineText)) {
+      warn(
+        warnings,
+        file,
+        line,
+        "iframe embed mode",
+        'Found `embedMode="iframe"`; project previews should avoid loading live iframes by default.',
+      );
+    }
+
+    if (/<iframe\b/i.test(lineText)) {
+      warn(
+        warnings,
+        file,
+        line,
+        "iframe element",
+        "Found `<iframe`; confirm it is intentional, lazy, and not loaded inside mobile project previews.",
+      );
+    }
+  });
+}
+
+const files = ROOTS.flatMap((root) => {
+  try {
+    return statSync(root).isDirectory() ? walk(root) : [];
+  } catch {
+    return [];
+  }
+});
+
+const warnings = [];
+
+for (const absoluteFile of files) {
+  const file = relative(process.cwd(), absoluteFile);
+  const source = readFileSync(absoluteFile, "utf8");
+  analyzeLinePatterns(source, file, warnings);
+  analyzeClassAttribute(source, file, warnings);
+}
+
+console.log(`Mobile pattern audit scanned ${files.length} source files.`);
+
+if (warnings.length === 0) {
+  console.log("No risky mobile layout patterns found.");
+  process.exit(0);
+}
+
+console.warn(
+  `Found ${warnings.length} mobile layout warning(s). Review manually:`,
+);
+for (const warning of warnings) {
+  console.warn(
+    `- ${warning.file}:${warning.line} [${warning.rule}] ${warning.detail}`,
+  );
+  const source = readFileSync(join(process.cwd(), warning.file), "utf8");
+  console.warn(`  ${lineAt(source, warning.line).slice(0, 180)}`);
+}
+
+console.warn(
+  "Audit completed with warnings only; this script does not fail CI by default.",
+);


### PR DESCRIPTION
### Motivation

- Prevent mobile layout regressions (horizontal overflow, clipped hero/badges/CTAs, heavy previews, accidental iframes) introduced by visual patches while keeping the repo lightweight. 
- Provide simple, repeatable manual and automated checks that reviewers can run before merging visual changes without adding browser automation or heavy deps.

### Description

- Added a human-facing checklist at `docs/mobile-regression-checklist.md` with required viewport widths, pages to test, manual checks, a DevTools overflow detection snippet, repo search commands and a recommended pre-deploy sequence. 
- Added a lightweight, dependency-free scanner `scripts/audit-mobile-patterns.mjs` that reads source files and warns about risky patterns such as `<iframe>`, `embedMode="iframe"`, unprefixed `w-[...]` / `min-w-[...]`, `overflow-hidden` on `section`, wide unprefixed `tracking-[...]`, and `inline-flex` CTA anchors/buttons without mobile width guards. The script only prints warnings and does not fail CI by default. 
- Wired the audit into `package.json` as the npm script `audit:mobile-patterns` and left existing `check:mobile-layout` intact. 
- Included repo grep checks in the docs and the DevTools console snippet for fast manual inspection.

### Testing

- Ran formatting: `prettier --write docs/mobile-regression-checklist.md scripts/audit-mobile-patterns.mjs package.json` (succeeded). 
- Built the site with `npm run build` to ensure no regressions in the static build (succeeded). 
- Ran the lightweight audit with `npm run audit:mobile-patterns`; it scanned source files and produced warning-only findings (14 warnings reported) for manual review, as expected (script is non-failing by design).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a029aceb1f08328a1eec12a574732a6)