### PR TITLE
Homepage copy: make messaging concrete (hero, outcomes, flow, CTAs)

### DIFF
--- a/src/components/BrowserMockup.astro
+++ b/src/components/BrowserMockup.astro
@@ -5,14 +5,14 @@ import VisualBadge from './VisualBadge.astro';
 const { trustBadges = [] } = Astro.props;
 
 const modules = [
-  { title: 'WhatsApp CTA', detail: 'Consulta guiada', icon: 'message', tone: 'emerald' },
-  { title: 'Agenda', detail: 'Reservas claras', icon: 'layout', tone: 'cyan' },
-  { title: 'Panel admin', detail: 'Contenido editable', icon: 'settings', tone: 'violet' },
-  { title: 'SEO base', detail: 'Estructura clara', icon: 'target', tone: 'amber' },
+  { title: 'WhatsApp CTA', detail: 'Mensaje prearmado', icon: 'message', tone: 'emerald' },
+  { title: 'Agenda', detail: 'Turnos visibles', icon: 'layout', tone: 'cyan' },
+  { title: 'Panel editable', detail: 'Módulos simples', icon: 'settings', tone: 'violet' },
+  { title: 'SEO base', detail: 'Datos ordenados', icon: 'target', tone: 'amber' },
 ];
 
 const sideCards = [
-  { label: '+ consultas', value: 'CTA claro', icon: 'message', tone: 'emerald', className: '-left-6 top-20' },
+  { label: 'WhatsApp', value: 'con contexto', icon: 'message', tone: 'emerald', className: '-left-6 top-20' },
   { label: 'repo + deploy', value: 'publicado', icon: 'code', tone: 'violet', className: '-right-4 top-10' },
   { label: 'propuesta en 24h', value: 'alcance inicial', icon: 'speed', tone: 'cyan', className: 'right-6 bottom-8' },
 ];
@@ -45,14 +45,14 @@ const sideCards = [
 
     <div class="relative min-w-0 p-4 sm:p-6">
       <div class="absolute right-6 top-6 hidden rounded-full border border-cyan-electric/25 bg-cyan-electric/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.16em] text-cyan-100 sm:block">
-        Flujo de conversión
+        Recorrido publicado
       </div>
 
       <section class="min-w-0 rounded-3xl border border-line bg-ink/45 p-5 sm:p-6">
         <div class="max-w-sm min-w-0">
           <p class="break-words text-xs font-semibold uppercase tracking-[0.1em] text-cyan-electric sm:tracking-[0.22em]">Web comercial</p>
-          <h3 class="mt-3 break-words text-2xl font-semibold tracking-tight text-slate-50 sm:text-3xl">De visita a consulta</h3>
-          <p class="mt-3 text-sm leading-6 text-muted-soft">Mensaje claro, prueba visual y próximo paso simple.</p>
+          <h3 class="mt-3 break-words text-2xl font-semibold tracking-tight text-slate-50 sm:text-3xl">De visita a WhatsApp</h3>
+          <p class="mt-3 text-sm leading-6 text-muted-soft">Servicios visibles, agenda y mensaje listo para enviar.</p>
         </div>
 
         <div class="mt-6 grid min-w-0 grid-cols-2 gap-3 lg:grid-cols-4">
@@ -81,7 +81,7 @@ const sideCards = [
 
         <div class="min-w-0 rounded-2xl border border-emerald-300/20 bg-emerald-400/10 p-4">
           <p class="break-words text-xs font-semibold uppercase tracking-[0.1em] text-emerald-100 sm:tracking-[0.18em]">Nueva consulta</p>
-          <p class="mt-2 text-sm leading-6 text-muted-soft">“Quiero una demo. Rubro: estética. Objetivo: más reservas.”</p>
+          <p class="mt-2 text-sm leading-6 text-muted-soft">“Quiero una demo. Rubro: estética. Servicio: depilación.”</p>
         </div>
       </div>
 

--- a/src/components/ContactCTA.astro
+++ b/src/components/ContactCTA.astro
@@ -12,7 +12,7 @@ import {
 
 const {
   eyebrow = 'Próximo paso',
-  title = 'Pasame tu idea y vemos cómo convertirla en una web que venda mejor',
+  title = 'Pasame tu idea y vemos qué conviene construir primero',
   description = 'Mandame tu Instagram, web actual o una explicación corta. Te digo qué camino conviene: landing, demo, web o sistema simple.',
   primaryLabel = 'Enviar mensaje por WhatsApp',
   primaryMessage = AUDIT_WHATSAPP_MESSAGE,
@@ -21,7 +21,7 @@ const {
 } = Astro.props;
 
 const trustBadges = [
-  { label: 'Propuesta clara', icon: 'target', tone: 'cyan' },
+  { label: 'Alcance sugerido', icon: 'target', tone: 'cyan' },
   { label: 'Repo + deploy', icon: 'code', tone: 'violet' },
   { label: 'Pagos por hitos', icon: 'check', tone: 'emerald' },
 ];
@@ -151,7 +151,7 @@ const contactMethods = [
             </div>
             <div class="rounded-2xl border border-line bg-surface-glass p-3">
               <p class="text-[0.68rem] font-semibold uppercase tracking-[0.16em] text-muted">Salida</p>
-              <p class="mt-1 text-sm font-semibold text-slate-50">Camino y demo clara</p>
+              <p class="mt-1 text-sm font-semibold text-slate-50">Primer entregable</p>
             </div>
           </div>
         </div>

--- a/src/components/ConversionFlow.astro
+++ b/src/components/ConversionFlow.astro
@@ -7,12 +7,12 @@ import { conversionFlow } from '../data/conversionFlow';
   <div class="grid min-w-0 gap-8 lg:grid-cols-[minmax(0,0.9fr)_minmax(0,1.1fr)] lg:items-start">
     <div class="min-w-0">
       <SectionHeader
-        eyebrow="Criterio CRO simple"
-        title="Cómo una visita se convierte en consulta."
-        description="Cada bloque baja fricción, responde dudas y acerca al visitante a una acción concreta."
+        eyebrow="Recorrido del cliente"
+        title="Del primer clic a un mensaje con datos."
+        description="La página debe responder precio orientativo, disponibilidad, servicios y canal antes de abrir el chat."
       />
       <div class="mt-6 rounded-3xl border border-cyan-electric/20 bg-cyan-electric/10 p-5 text-sm leading-6 text-cyan-50">
-        <strong class="text-slate-50">Resultado:</strong> una web lista para compartir por WhatsApp y usar como link principal.
+        <strong class="text-slate-50">Resultado:</strong> un link publicado para bio, anuncios o Google Business con WhatsApp listo.
       </div>
     </div>
 

--- a/src/components/FAQs.astro
+++ b/src/components/FAQs.astro
@@ -12,7 +12,7 @@ const toneClasses = {
 };
 
 const trustBadges = [
-  { label: 'Cronograma claro', icon: 'speed', tone: 'cyan' },
+  { label: 'Cronograma por hitos', icon: 'speed', tone: 'cyan' },
   { label: 'Pagos por hitos', icon: 'briefcase', tone: 'emerald' },
   { label: 'Repo + deploy', icon: 'code', tone: 'violet' },
 ];

--- a/src/components/FeaturedCases.astro
+++ b/src/components/FeaturedCases.astro
@@ -11,8 +11,8 @@ const { projects = [] } = Astro.props;
     <div class="min-w-0 space-y-5">
       <SectionHeader
         eyebrow="Portfolio"
-        title="Proyectos y demos pensados para vender mejor"
-        description="Casos diseñados para ordenar el mensaje, reducir fricción y llevar al usuario hacia una acción concreta."
+        title="Casos con WhatsApp, agenda, catálogo o panel"
+        description="Demos y webs donde el entregable se ve rápido: reserva, carta, formulario, panel o WhatsApp con contexto."
         icon="folder"
       />
 
@@ -63,7 +63,7 @@ const { projects = [] } = Astro.props;
 
   <div class="mt-10 flex min-w-0 flex-col gap-4 rounded-3xl border border-line bg-surface-glass p-5 shadow-none backdrop-blur-none sm:flex-row md:shadow-premium md:backdrop-blur sm:items-center sm:justify-between">
     <p class="min-w-0 break-words text-sm leading-6 text-muted-soft">
-      <span class="font-semibold text-slate-50">¿Querés algo parecido?</span> Mandame tu Instagram o web y vemos una demo posible.
+      <span class="font-semibold text-slate-50">¿Querés algo parecido?</span> Mandame tu Instagram o web y vemos si conviene una landing, agenda, catálogo o panel.
     </p>
     <a href={waLink(DEMO_WHATSAPP_MESSAGE)} target="_blank" rel="noreferrer" class="premium-button inline-flex w-full max-w-full items-center justify-center gap-2 rounded-2xl bg-brand-gradient px-5 py-3 text-center text-sm font-semibold text-white shadow-none sm:w-fit md:shadow-glow">
       Pedir una demo <span aria-hidden="true">↗</span>

--- a/src/components/HeroV2.astro
+++ b/src/components/HeroV2.astro
@@ -5,17 +5,17 @@ import VisualBadge from './VisualBadge.astro';
 import { waLink, DEMO_WHATSAPP_MESSAGE } from '../lib/contact';
 
 const mobileHeroBadges = [
-  { label: 'WhatsApp guiado', icon: 'message', tone: 'emerald' },
-  { label: 'Agenda', icon: 'layout', tone: 'cyan' },
-  { label: 'Panel admin', icon: 'settings', tone: 'violet' },
-  { label: 'SEO', icon: 'speed', tone: 'amber' },
+  { label: 'WhatsApp preparado', icon: 'message', tone: 'emerald' },
+  { label: 'Agenda / reservas', icon: 'layout', tone: 'cyan' },
+  { label: 'Panel editable', icon: 'settings', tone: 'violet' },
+  { label: 'SEO base', icon: 'speed', tone: 'amber' },
 ];
 
 const desktopHeroBadges = [
-  { label: 'WhatsApp guiado', icon: 'message', tone: 'emerald' },
+  { label: 'WhatsApp preparado', icon: 'message', tone: 'emerald' },
   { label: 'Agenda / reservas', icon: 'layout', tone: 'cyan' },
-  { label: 'Panel admin', icon: 'settings', tone: 'violet' },
-  { label: 'SEO + performance', icon: 'speed', tone: 'amber' },
+  { label: 'Panel editable', icon: 'settings', tone: 'violet' },
+  { label: 'Deploy publicado', icon: 'speed', tone: 'amber' },
 ];
 
 const trustBadges = [
@@ -27,7 +27,7 @@ const trustBadges = [
 const mobileFlow = [
   { label: 'Consulta por WhatsApp', icon: 'message', tone: 'emerald' },
   { label: 'Servicio elegido', icon: 'layout', tone: 'cyan' },
-  { label: 'Demo lista para compartir', icon: 'check', tone: 'violet' },
+  { label: 'Link publicado', icon: 'check', tone: 'violet' },
 ];
 ---
 <section class="relative py-12 sm:py-16 lg:overflow-x-clip lg:py-24" aria-labelledby="hero-title">
@@ -38,7 +38,7 @@ const mobileFlow = [
   <div class="grid min-w-0 items-center gap-8 lg:grid-cols-[minmax(0,0.92fr)_minmax(0,1.08fr)] lg:gap-14">
     <div class="relative z-10 min-w-0 max-w-full">
       <div class="inline-flex min-w-0 max-w-full items-center gap-2 rounded-full border border-cyan-electric/25 bg-cyan-electric/10 px-3 py-2 shadow-[0_0_22px_rgba(34,211,238,0.10)] sm:gap-3 sm:px-4 lg:shadow-[0_0_32px_rgba(34,211,238,0.12)] lg:backdrop-blur">
-        <IconBubble icon="rocket" tone="cyan" size="sm" label="Conversión, tecnología y velocidad" />
+        <IconBubble icon="rocket" tone="cyan" size="sm" label="Demos, tecnología y deploy" />
         <span class="min-w-0 text-xs font-semibold uppercase leading-5 tracking-[0.08em] text-cyan-100 sm:tracking-[0.16em] lg:tracking-[0.2em]">
           <span class="sm:hidden">Marin.dev · demos web</span>
           <span class="hidden sm:inline">Marin.dev · demos, webs y sistemas comerciales</span>
@@ -46,10 +46,10 @@ const mobileFlow = [
       </div>
 
       <h1 id="hero-title" class="mt-5 max-w-full break-words text-[clamp(2.25rem,10vw,3.5rem)] font-semibold leading-[1.04] tracking-tight text-slate-50 sm:mt-6 sm:max-w-4xl sm:text-5xl lg:text-6xl lg:leading-[1.02]">
-        Webs y demos comerciales que convierten visitas en consultas.
+        Webs y demos comerciales para convertir visitas en consultas útiles.
       </h1>
       <p class="mt-4 max-w-2xl break-words text-base leading-7 text-muted-soft sm:mt-6 sm:text-lg sm:leading-8">
-        Landings, demos y sistemas simples con WhatsApp, agenda y estructura clara para generar consultas.
+        Armo landings, demos navegables y paneles livianos con servicios visibles, WhatsApp preparado, SEO base y deploy publicado.
       </p>
 
       <div class="mt-5 grid min-w-0 max-w-full grid-cols-1 gap-2.5 min-[360px]:grid-cols-2 sm:hidden" aria-label="Funciones que puede incluir una demo o web comercial">

--- a/src/components/OutcomeGrid.astro
+++ b/src/components/OutcomeGrid.astro
@@ -11,8 +11,8 @@ import { outcomes } from '../data/outcomes';
 
   <SectionHeader
     eyebrow="Qué resuelvo"
-    title="Tu web no debería solo verse bien: debería ayudarte a vender"
-    description="Ordeno el mensaje, reduzco la fricción y diseño caminos claros para que la visita termine en consulta, reserva o venta."
+    title="Problemas concretos que una buena web puede resolver"
+    description="Cuando todo vive en Instagram, historias destacadas o mensajes sueltos, el cliente termina preguntando lo mismo por chat. La web tiene que mostrar servicios, precios orientativos, pasos y contacto antes de que te escriban."
     icon="target"
   />
 
@@ -32,6 +32,6 @@ import { outcomes } from '../data/outcomes';
   </div>
 
   <p class="mt-6 rounded-3xl border border-line bg-surface-glass px-4 py-4 text-sm leading-6 text-muted-soft backdrop-blur sm:px-5">
-    Cada bloque tiene una función: aclarar, generar confianza o acercar a la consulta.
+    Cada bloque responde una duda puntual: qué ofrecés, cuánto puede costar, cómo reservar o qué datos mandar para cotizar.
   </p>
 </section>

--- a/src/components/ProcessSteps.astro
+++ b/src/components/ProcessSteps.astro
@@ -6,8 +6,8 @@ import { processSteps } from '../data/process';
 <section class="min-w-0 py-14 md:py-20">
   <SectionHeader
     eyebrow="Proceso"
-    title="De Instagram o idea suelta a una web lista para compartir."
-    description="Un proceso corto, con avances revisables y foco en consultas, reservas o ventas."
+    title="De Instagram o idea suelta a un link publicado."
+    description="Un proceso corto, con avances revisables y foco en el primer entregable: demo, landing, agenda o panel."
     align="center"
   />
   <div class="mt-10 grid min-w-0 gap-5 md:grid-cols-2 lg:grid-cols-4">

--- a/src/components/ProductizedServices.astro
+++ b/src/components/ProductizedServices.astro
@@ -18,8 +18,8 @@ const serviceBadges = [
   <div class="flex min-w-0 flex-col gap-5 lg:flex-row lg:items-end lg:justify-between">
     <SectionHeader
       eyebrow="Servicios"
-      title="Soluciones empaquetadas para avanzar rápido"
-      description="Paquetes claros para definir alcance, prioridad comercial y próximos pasos sin perder semanas."
+      title="Paquetes con entregables definidos"
+      description="Cada servicio marca qué se entrega, qué queda fuera y qué necesito para empezar sin perder semanas."
       icon="layout"
     />
     <div class="flex min-w-0 max-w-full flex-wrap gap-2 lg:max-w-md lg:justify-end">

--- a/src/components/VerticalDemos.astro
+++ b/src/components/VerticalDemos.astro
@@ -9,8 +9,8 @@ import { waLink } from '../lib/contact';
 <section class="min-w-0 py-14 md:py-20">
   <SectionHeader
     eyebrow="Demos por rubro"
-    title="Una demo concreta vende mejor que una explicación abstracta."
-    description="Cada rubro necesita ver su oferta, reservas y WhatsApp ordenados como los usaría un cliente real."
+    title="Una demo por rubro muestra más que una explicación abstracta."
+    description="Cada rubro necesita ver servicios, precios orientativos, reservas o WhatsApp como los usaría un cliente real."
     icon="layout"
   />
   <div class="mt-8 grid min-w-0 gap-5 md:grid-cols-2">
@@ -36,7 +36,7 @@ import { waLink } from '../lib/contact';
         </div>
 
         <a
-          href={waLink(`Hola Diego, quiero una demo para este rubro: ${demo.name}.\n\nObjetivo: [más consultas / reservas / ventas]\nHoy tengo: [Instagram / web / nada]\nLink de referencia: [Instagram o web]`)}
+          href={waLink(`Hola Diego, quiero una demo para este rubro: ${demo.name}.\n\nObjetivo: [turnos / pedidos / cotizaciones]\nHoy tengo: [Instagram / web / nada]\nLink de referencia: [Instagram o web]`)}
           target="_blank"
           rel="noopener noreferrer"
           class="premium-button mt-6 inline-flex w-full max-w-full items-center justify-center gap-2 rounded-2xl border border-line bg-surface-glass px-4 py-2 text-center text-sm font-semibold text-slate-50 hover:-translate-y-0.5 hover:border-cyan-electric/35 hover:text-cyan-electric sm:w-fit"

--- a/src/data/conversionFlow.ts
+++ b/src/data/conversionFlow.ts
@@ -1,29 +1,29 @@
 export const conversionFlow = [
   {
     step: "01",
-    title: "Aterriza desde Instagram, Google o WhatsApp",
+    title: "Llegan desde Instagram, Google o un anuncio",
     description:
-      "La primera pantalla explica qué hacés, para quién es y cuál es el próximo paso.",
-    signal: "Promesa + CTA",
+      "La primera pantalla confirma el rubro, la oferta y el canal principal sin hacerlos buscar en historias destacadas.",
+    signal: "Origen del tráfico",
   },
   {
     step: "02",
-    title: "Entiende servicios, confianza y diferencial",
+    title: "Ven servicios, precio orientativo u horarios",
     description:
-      "Servicios, pruebas y preguntas se ordenan para bajar dudas antes del mensaje.",
-    signal: "Confianza + claridad",
+      "El contenido responde las dudas básicas antes del chat: qué incluye, cuándo atiende y qué módulo conviene mirar.",
+    signal: "Datos para decidir",
   },
   {
     step: "03",
-    title: "Elige una acción guiada",
-    description: "WhatsApp, reserva o pedido salen con un mensaje preparado.",
+    title: "Eligen qué quieren consultar, reservar o cotizar",
+    description: "El CTA conecta con WhatsApp, agenda o pedido según el tipo de negocio.",
     signal: "WhatsApp / agenda",
   },
   {
     step: "04",
-    title: "La demo valida qué construir después",
+    title: "Te llega un WhatsApp con más contexto",
     description:
-      "Una versión navegable permite validar mensaje, secciones y siguiente alcance.",
-    signal: "Demo → siguiente hito",
+      "El mensaje puede incluir rubro, servicio y objetivo para evitar el típico ‘hola, info’.",
+    signal: "Mensaje prearmado",
   },
 ];

--- a/src/data/faqs.ts
+++ b/src/data/faqs.ts
@@ -1,7 +1,7 @@
 export const faqs = [
   {
     q: "¿Necesito tener todo definido antes de pedir una demo?",
-    a: "No. Con tu Instagram, una web actual o una idea alcanza para ordenar la oferta, detectar fricción y proponer una primera versión clara.",
+    a: "No. Con tu Instagram, una web actual o una idea alcanza para revisar servicios, precios orientativos, horarios y proponer una primera versión navegable.",
     icon: "message",
     tone: "cyan",
   },
@@ -13,7 +13,7 @@ export const faqs = [
   },
   {
     q: "¿Cómo se manejan los pagos?",
-    a: "Trabajo con alcance claro y pagos por hitos acordados según el proyecto. La idea es que cada avance tenga una entrega revisable y no haya sorpresas al final.",
+    a: "Trabajo con alcance, entregables y pagos por hitos acordados según el proyecto. La idea es que cada avance tenga una entrega revisable y no haya sorpresas al final.",
     icon: "briefcase",
     tone: "emerald",
   },

--- a/src/data/outcomes.ts
+++ b/src/data/outcomes.ts
@@ -1,31 +1,33 @@
 export const outcomes = [
   {
-    title: "Más consultas",
+    title: "Preguntas repetidas por DM",
     description:
-      "CTAs claros y WhatsApp guiado para pedir los datos correctos.",
-    badge: "WhatsApp CTA",
+      "Servicios, precios orientativos y preguntas frecuentes visibles para no responder lo mismo todo el día.",
+    badge: "Servicios + FAQ",
     icon: "message",
     tone: "cyan",
   },
   {
-    title: "Más confianza",
+    title: "Mensajes incompletos",
     description:
-      "Estructura, prueba visual y señales de confianza para decidir más rápido.",
-    badge: "Confianza",
+      "WhatsApp puede abrir con rubro, servicio y objetivo ya escritos para recibir consultas con contexto.",
+    badge: "Mensaje prearmado",
     icon: "shield",
     tone: "violet",
   },
   {
-    title: "Más velocidad",
-    description: "Carga rápida, SEO base y navegación fluida en mobile.",
-    badge: "Performance",
+    title: "Reservas dispersas",
+    description:
+      "Turnos, horarios o agenda externa en el mismo flujo, sin mandar al cliente a buscar links.",
+    badge: "Agenda / turnos",
     icon: "zap",
     tone: "amber",
   },
   {
-    title: "Menos fricción",
-    description: "Flujos simples, repo, deploy y próximos pasos definidos.",
-    badge: "Repo + deploy",
+    title: "Oferta difícil de mostrar",
+    description:
+      "Una demo navegable permite enseñar la idea, el rubro y el recorrido antes de construir algo más grande.",
+    badge: "Demo publicada",
     icon: "flow",
     tone: "emerald",
   },

--- a/src/data/process.ts
+++ b/src/data/process.ts
@@ -7,8 +7,8 @@ export const processSteps = [
   },
   {
     step: "02",
-    title: "Detecto fricción y oportunidad",
-    description: "Marco dudas, frenos y contenido clave para mostrar primero.",
+    title: "Detecto dudas y oportunidades",
+    description: "Marco precios, servicios, horarios o datos que conviene mostrar primero.",
   },
   {
     step: "03",
@@ -18,8 +18,8 @@ export const processSteps = [
   },
   {
     step: "04",
-    title: "Construimos, deployamos y vendés",
+    title: "Construimos, deployamos y medimos",
     description:
-      "Publicamos, dejamos accesos claros y un flujo listo para compartir.",
+      "Publicamos, dejamos accesos definidos y una URL para enviar por WhatsApp.",
   },
 ];

--- a/src/data/services.ts
+++ b/src/data/services.ts
@@ -3,21 +3,21 @@ export const productizedServices = [
     name: "Demo Comercial Express",
     tag: "Validar rápido",
     description:
-      "Una demo cuidada para transformar una idea o Instagram en una propuesta web lista para mostrar.",
+      "Una demo navegable para transformar una idea o Instagram en pantallas que se puedan evaluar.",
     deliverables: [
-      "Mensaje principal y estructura comercial",
+      "Mensaje principal y secciones necesarias",
       "Secciones clave para explicar la propuesta",
-      "CTA a WhatsApp con mensaje guiado",
-      "Vista responsive lista para compartir",
+      "CTA a WhatsApp con mensaje prearmado",
+      "Vista responsive con deploy publicado",
     ],
   },
   {
     name: "Landing de Conversión",
-    tag: "Más consultas",
+    tag: "WhatsApp listo",
     description:
-      "Una landing clara para llevar visitas hacia consultas, reservas o ventas.",
+      "Una landing para mostrar servicios, prueba visual, objeciones y WhatsApp en los puntos clave.",
     deliverables: [
-      "Hero orientado a resultado",
+      "Hero con oferta, rubro y CTA visible",
       "Bloques de confianza, servicios y objeciones",
       "CTA principal y secundarios bien ubicados",
       "SEO/share básico y carga rápida",
@@ -26,21 +26,21 @@ export const productizedServices = [
   },
   {
     name: "Web con WhatsApp / Agenda",
-    tag: "Reservas claras",
+    tag: "Agenda visible",
     description:
       "Una web para mostrar servicios y guiar al visitante hacia WhatsApp, reserva o agenda.",
     deliverables: [
       "Servicios o planes con CTA específico",
       "Mensajes prearmados por intención",
-      "Flujo simple de reserva o consulta",
-      "Páginas clave para generar confianza",
+      "Flujo de reserva o consulta acotado",
+      "Páginas clave con servicios y contacto",
     ],
   },
   {
     name: "Sistema simple / Panel Admin",
-    tag: "Operar mejor",
+    tag: "Panel acotado",
     description:
-      "Una herramienta liviana para ordenar contenido, stock, leads, reservas o datos internos.",
+      "Una herramienta liviana para ver contenido, stock, leads, reservas o datos internos en módulos simples.",
     deliverables: [
       "Panel o flujo interno acotado",
       "Datos y estados organizados",

--- a/src/data/site.ts
+++ b/src/data/site.ts
@@ -6,14 +6,14 @@ export const capabilityStrip = [
     tone: "violet",
   },
   {
-    title: "WhatsApp guiado",
-    description: "Mensajes preparados para consultar.",
+    title: "WhatsApp preparado",
+    description: "Texto inicial con contexto.",
     icon: "message",
     tone: "emerald",
   },
   {
     title: "Agenda / reservas",
-    description: "Turnos y pedidos sin fricción.",
+    description: "Turnos y pedidos en un link.",
     icon: "layout",
     tone: "cyan",
   },
@@ -25,14 +25,14 @@ export const capabilityStrip = [
   },
   {
     title: "Entrega por hitos",
-    description: "Avances claros y revisables.",
+    description: "Alcance y entregables revisables.",
     icon: "speed",
     tone: "cyan",
   },
 ];
 
 export const heroSignals = [
-  { label: "Web publicada", value: "lista para compartir" },
+  { label: "Web publicada", value: "deploy activo" },
   { label: "WhatsApp listo", value: "consulta al momento" },
-  { label: "Paso a paso", value: "alcance claro" },
+  { label: "Paso a paso", value: "alcance definido" },
 ];

--- a/src/data/verticals.ts
+++ b/src/data/verticals.ts
@@ -51,7 +51,7 @@ export const verticalDemos = [
   {
     name: "Estudios profesionales",
     problem:
-      "La confianza depende de recomendaciones y no de un proceso claro.",
+      "La confianza depende de recomendaciones y los pasos de atención no están visibles.",
     solution: "servicios, experiencia, pasos de atención y agenda inicial.",
     features: ["Confianza", "Proceso", "Agenda", "Experiencia"],
     icon: "shield",

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -27,8 +27,8 @@ const homeCases = destacados.length > 0 ? destacados : proyectos.slice(0, HOME_C
 
 ---
 <BaseLayout
-  title="Marin.dev | Demos web y herramientas simples para vender mejor"
-  description="Demos y webs claras para negocios que quieren recibir consultas, reservas o ventas."
+  title="Marin.dev | Webs, demos y sistemas simples"
+  description="Demos y webs para negocios que quieren recibir consultas, reservas o ventas con WhatsApp preparado, SEO base y deploy publicado."
 >
   <HeroV2 />
   <SocialProofStrip />
@@ -43,8 +43,8 @@ const homeCases = destacados.length > 0 ? destacados : proyectos.slice(0, HOME_C
   <FAQs />
   <ContactCTA
     eyebrow="Listo para empezar"
-    title="Mandame tu Instagram o web y armamos una demo con objetivo comercial."
-    description="Convertimos mensajes sueltos en una experiencia clara para recibir consultas, reservas o ventas."
+    title="Mandame tu Instagram o web y te digo qué conviene construir primero."
+    description="Puede ser una demo, landing, agenda o panel: elegimos el primer entregable según tus servicios, precios, horarios y datos para cotizar."
     primaryLabel="Quiero una demo para mi negocio"
     primaryMessage={DEMO_WHATSAPP_MESSAGE}
     secondaryLabel="Ver casos primero"


### PR DESCRIPTION
### Motivation
- Reduce repeated abstract conversion language on the homepage and tie benefits to concrete deliverables following the copy audit (e.g. WhatsApp messages, agenda, deploy URL, prices). 
- Replace generic phrases like “fricción”, “vender mejor” and “experiencia clara” with specific buyer situations and outputs so visitors understand what they get and what to send. 
- Keep the existing visual system and routes unchanged while improving persuasion and first-contact quality via copy only. 

### Description
- Updated the hero copy and badges to concrete deliverables: headline and description now emphasize landings, demos, WhatsApp preparado, SEO base and deploy publicado, and hero badges were renamed accordingly (`src/components/HeroV2.astro`, `src/data/site.ts`).
- Rewrote the Outcome grid into four business situations (Preguntas repetidas por DM, Mensajes incompletos, Reservas dispersas, Oferta difícil de mostrar) and replaced the outcomes data file (`src/data/outcomes.ts`) used by `src/components/OutcomeGrid.astro`.
- Replaced abstract CRO flow with a named customer path (source → visible services/prices/hours → choose CTA → WhatsApp with context) by changing `src/data/conversionFlow.ts` and `src/components/ConversionFlow.astro`.
- Tightened related homepage microcopy and CTAs (Featured cases, Vertical demos, Process steps, Productized services, Browser mockup, Contact CTA, FAQs and supporting data) to reference specific deliverables and first-step outputs without altering layout, links, contact data, routes, or project content (`src/components/FeaturedCases.astro`, `src/components/VerticalDemos.astro`, `src/components/ProcessSteps.astro`, `src/components/ProductizedServices.astro`, `src/components/BrowserMockup.astro`, `src/components/ContactCTA.astro`, `src/components/FAQs.astro`, plus respective data files).

### Testing
- Ran `npm run build` (Astro build) and the static build completed successfully with all pages generated; result: build passed.
- Ran `git diff --check` to validate whitespace/merge markers and it returned clean results (no check errors).
- Ran a grep-based audit for the audit-forbidden/reduced phrases (checks for occurrences of terms like “fricción”, “vender mejor”, repeated “consultas, reservas o ventas”, etc.) against the homepage-related files and confirmed the homepage copy no longer contains the banned abstractions except one allowed meta occurrence in page description.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a033dd5133083288704e398c6f45e3a)