### PR TITLE
Rewrite project portfolio copy and ProjectCard benefit logic

### DIFF
--- a/src/components/FeaturedCases.astro
+++ b/src/components/FeaturedCases.astro
@@ -11,8 +11,8 @@ const { projects = [] } = Astro.props;
     <div class="min-w-0 space-y-5">
       <SectionHeader
         eyebrow="Portfolio"
-        title="Casos con WhatsApp, agenda, catálogo o panel"
-        description="Demos y webs donde el entregable se ve rápido: reserva, carta, formulario, panel o WhatsApp con contexto."
+        title="Casos por rubro con entregables visibles"
+        description="Algunos casos muestran rubros distintos: una veterinaria con turnos, una barbería con reservas, un restaurante con carta y un panel de stock."
         icon="folder"
       />
 

--- a/src/components/ProjectCard.astro
+++ b/src/components/ProjectCard.astro
@@ -72,7 +72,16 @@ const visualSystem = getProjectVisual({
 const visualStyles = visualSystem.styles;
 const commercialType = category || tipo || sector || visualSystem.category.label || 'Caso comercial';
 const businessLabel = businessType || sector || commercialType;
-const benefit = resultLabel || highlight || impacto || resultado;
+const normalizeCopy = (value = '') => String(value).trim().replace(/\s+/g, ' ');
+const highlightCopy = normalizeCopy(highlight);
+const benefitOptions = [
+  { label: 'Qué permite', value: resultLabel },
+  { label: 'Qué demuestra', value: impacto },
+  { label: 'Resultado', value: resultado },
+].map((item) => ({ ...item, normalized: normalizeCopy(item.value) }));
+const selectedBenefit = benefitOptions.find((item) => item.normalized && item.normalized !== highlightCopy);
+const benefit = selectedBenefit?.value || '';
+const benefitLabel = selectedBenefit?.label || 'Qué permite';
 const visual = projectVisualAsset({ slug, thumbnail, cover, image });
 const hasImage = visual.hasImage;
 const isStarProject = Number(priority) >= 120;
@@ -166,7 +175,7 @@ const copyFocus = highlight || solucion || problema;
     {copyFocus && (
       <div class="mobile-safe-text mt-5 min-w-0 rounded-2xl border border-line bg-ink/35 p-4 text-sm leading-6 text-muted-soft">
         {highlight ? (
-          <p><span class="font-semibold text-slate-50">Clave:</span> {highlight}</p>
+          <p><span class="font-semibold text-slate-50">Construido:</span> {highlight}</p>
         ) : (
           <>
             {problema && (
@@ -188,7 +197,7 @@ const copyFocus = highlight || solucion || problema;
 
     {benefit && (
       <p class="mobile-safe-text mt-5 min-w-0 break-words rounded-2xl border border-brand-success/20 bg-brand-success/10 p-3 text-sm leading-6 text-emerald-100">
-        <span class="font-semibold">Resultado / beneficio:</span> {benefit}
+        <span class="font-semibold">{benefitLabel}:</span> {benefit}
       </p>
     )}
 

--- a/src/content/proyectos/Agencia_ariel.mdx
+++ b/src/content/proyectos/Agencia_ariel.mdx
@@ -2,7 +2,7 @@
 title: "Agencia Ariel – Soluciones Logísticas Integrales"
 tipo: "Web corporativa"
 sector: "Depósito / Transporte"
-idealPara: "Empresas logísticas que necesitan transmitir confianza y ordenar consultas comerciales."
+idealPara: "Empresas logísticas que necesitan explicar servicios, cobertura y canales de contacto fuera de redes."
 category: "Corporativo"
 businessType: "Logística / transporte"
 visualTone: "neutral"
@@ -11,7 +11,8 @@ badges:
   - Firebase
   - Contacto
   - Mobile
-highlight: "Ordena la propuesta de una empresa tradicional en una web confiable y consultable."
+highlight: "Web corporativa para explicar servicios logísticos, cobertura y canales de contacto."
+resultLabel: "Convierte una empresa tradicional en una presencia consultable y seria fuera de redes."
 rol: "Desarrollador Frontend"
 stack:
   - HTML5
@@ -23,24 +24,24 @@ features:
   - Consulta conectada a Firebase
   - Contenido editable
   - Presentación de servicios
-  - Experiencia clara en celulares
+  - Secciones consultables desde celulares
 fecha: "2025-09"
 status: "real"
 featured: true
 priority: 20
 ctaLabel: "Ver caso corporativo"
 resumen: >
-  Web corporativa para una empresa logística que necesitaba explicar servicios, generar confianza y centralizar consultas.
+  Web corporativa para una empresa logística que necesitaba explicar servicios, cobertura y canales de contacto.
 problema: >
-  La empresa necesitaba una presencia digital más clara para presentar sus servicios logísticos y facilitar la comunicación con potenciales clientes.
+  La empresa necesitaba una presencia consultable fuera de redes para presentar servicios logísticos y recibir pedidos de información.
 solucion: >
-  Se desarrolló un sitio corporativo con servicios claros, formulario de contacto y una zona editable para mantener información actualizada.
+  Se desarrolló un sitio corporativo con servicios logísticos, formulario de contacto y zona editable para mantener información actualizada.
 impacto: >
-  El caso demuestra cómo una empresa tradicional puede convertir su información comercial en una web clara, confiable y lista para recibir consultas.
+  Demuestra trabajo corporativo real: servicios, confianza, contacto y estructura institucional.
 El_sitio_incluye:
   - Página principal con presentación de servicios, misión y valores.
   - Sección de contacto para registrar consultas de forma ordenada.
-  - Experiencia clara en celulares para clientes que consultan desde el teléfono.
+  - Secciones consultables desde celulares para clientes que consultan desde el teléfono.
   - Contenido editable para mantener servicios actualizados.
 El_desarrollo_priorizo: >
   que la web sea fácil de usar, cargue rápido y pueda crecer con nuevas secciones cuando haga falta.

--- a/src/content/proyectos/brasa-23.mdx
+++ b/src/content/proyectos/brasa-23.mdx
@@ -11,7 +11,8 @@ badges:
   - Reserva
   - Pedido
   - Ubicación
-highlight: "Centraliza carta, ambiente y contacto para no perder intención de compra."
+highlight: "Carta digital, ambiente del restaurante, ubicación y reserva/pedido en un solo link."
+resultLabel: "El cliente no tiene que buscar menú, horario y contacto entre posts o PDFs."
 rol: "Diseño UI y desarrollo Frontend"
 stack:
   - HTML
@@ -29,13 +30,13 @@ featured: true
 priority: 60
 ctaLabel: "Ver demo restaurante"
 resumen: >
-  Demo gastronómica para presentar carta, ambiente y propuesta del restaurante con un flujo simple hacia reserva o pedido.
+  Demo gastronómica para presentar carta, ambiente, ubicación y reserva/pedido desde un mismo enlace.
 problema: >
-  En gastronomía, los clientes necesitan encontrar rápido carta, ubicación, horarios y contacto; si esa información está dispersa, se pierde intención de compra.
+  En gastronomía, el cliente suele buscar menú, horario y contacto entre posts, PDFs o mensajes antes de decidir.
 solucion: >
-  Se armó una demo de restaurante con estructura directa, foco visual en producto y CTAs pensados para reserva, pedido o consulta.
+  Se armó una demo de restaurante con carta digital, ubicación, ambiente visual y caminos separados para reserva o pedido.
 impacto: >
-  Ejemplo claro para gastronomía: una web liviana puede funcionar como carta digital, pieza comercial y enlace principal para redes.
+  Demuestra una demo gastronómica útil para Instagram, Google Business y WhatsApp.
 demoUrl: "https://daegon13.github.io/Brasa-23/"
 cover: "/og-default.png"
 thumbnail: "/galeria/brasa-23.jpg"
@@ -43,7 +44,7 @@ thumbnail: "/galeria/brasa-23.jpg"
 
 ### Enfoque del caso
 
-Brasa 23 es una demo pensada para que un restaurante pueda explicar su propuesta en segundos y llevar al usuario hacia una acción concreta: ver carta, reservar o iniciar una consulta.
+Brasa 23 es una demo pensada para que un restaurante pueda mostrar carta, ambiente, ubicación y reserva/pedido desde un solo enlace.
 
 ### Oportunidad comercial
 

--- a/src/content/proyectos/cristal-sagrado.mdx
+++ b/src/content/proyectos/cristal-sagrado.mdx
@@ -2,7 +2,7 @@
 title: "Cristal Sagrado – Web con contenido editable"
 tipo: "Web con contenido editable"
 sector: "Servicios / Bienestar"
-idealPara: "Servicios personales que necesitan una web editable y un canal directo de consultas."
+idealPara: "Servicios personales que necesitan actualizar su oferta sin depender de cambios de código."
 category: "Bienestar"
 businessType: "Servicios personales"
 visualTone: "rose"
@@ -11,7 +11,7 @@ badges:
   - Servicios
   - Consultas
   - Marca cuidada
-highlight: "Una web editable para sostener una marca de servicios sin depender de cambios manuales."
+highlight: "Landing de servicios con panel/admin liviano para actualizar la oferta."
 image: "https://cristal-sagrado.com/favicon_io/cristal_sagrado.png"
 rol: "Desarrollador Frontend"
 stack:
@@ -22,17 +22,18 @@ features:
   - Web editable
   - Contenido editable
   - Servicios destacados
-  - botón a consultas
+  - Botón a consultas
 fecha: "2025-09"
 status: "real"
 featured: true
 priority: 30
 ctaLabel: "Ver web editable"
-resumen: "Web optimizada con zona editable de administración ligero para gestionar servicios y orientar al contacto."
-problema: "El cliente necesitaba una web clara, rápida y fácil de actualizar sin tocar código."
-solucion: "Web rápida con una zona privada para actualizar servicios y contenido clave."
-resultado: "+38% consultas en 21 días"
-impacto: "Caso real con marca definida, estética cuidada y una estructura pensada para transformar visitas en consultas sin depender de cambios manuales en código."
+resumen: "Landing de servicios con administración liviana para actualizar la oferta y mantener el contacto visible."
+problema: "El cliente necesitaba actualizar servicios y contenido sin pedir cambios de código cada vez."
+solucion: "Landing rápida con zona privada para modificar servicios, textos principales y contenido clave."
+resultLabel: "Permite modificar servicios sin tocar código cada vez."
+resultado: "Mejor presentación de servicios y contacto más directo por WhatsApp."
+impacto: "Demuestra una web de marca con contenido editable y CTA comercial."
 repoUrl: "https://github.com/Daegon13/cristal-sagrado-site"
 demoUrl: "https://cristal-sagrado.com"
 cover: "https://cristal-sagrado.com/favicon_io/cristal_sagrado.png"

--- a/src/content/proyectos/noir-barber-studio.mdx
+++ b/src/content/proyectos/noir-barber-studio.mdx
@@ -2,7 +2,7 @@
 title: "Noir Barber Studio – Demo para barbería"
 tipo: "Demo comercial"
 sector: "Barbería / Estética masculina"
-idealPara: "Barberías y estudios de estética que quieren una presencia premium con reservas y contacto directo."
+idealPara: "Barberías y estudios de estética que necesitan mostrar estilo, servicios, precios y reserva desde Instagram."
 category: "Barbería"
 businessType: "Barbería / estética masculina"
 visualTone: "violet"
@@ -11,7 +11,8 @@ badges:
   - Servicios
   - Estética premium
   - Mobile-first
-highlight: "Convierte contenido de redes en una experiencia premium orientada a reservas."
+highlight: "Identidad oscura premium, menú de servicios, precios y CTA de reserva."
+resultLabel: "Funciona como link principal desde Instagram para ver estilo, servicios y reservar."
 rol: "Diseño UI y desarrollo Frontend"
 stack:
   - Astro
@@ -19,8 +20,8 @@ stack:
   - Vercel
   - Diseño responsive
 features:
-  - Reservas por WhatsApp
-  - Servicios destacados
+  - Reserva desde el celular
+  - Servicios y precios
   - Estética premium
   - Mobile-first
 fecha: "2026-01"
@@ -29,13 +30,13 @@ featured: true
 priority: 80
 ctaLabel: "Ver demo barbería"
 resumen: >
-  Demo visual para barbería con estética oscura, servicios claros y foco en llevar al visitante a reservar o consultar desde el celular.
+  Demo visual para barbería con estética oscura, menú de servicios, precios y reserva desde el celular.
 problema: >
-  Una barbería puede tener buen contenido en redes, pero perder consultas si no tiene una experiencia clara para mostrar servicios, estilo y reserva.
+  Una barbería puede tener buen contenido en redes, pero el cliente necesita ver estilo, servicios y precios antes de pedir hora.
 solucion: >
-  Se creó una landing demo con identidad fuerte, estructura simple, servicios visibles y llamados a la acción orientados a reserva o WhatsApp.
+  Se creó una landing demo con identidad fuerte, servicios visibles, precios de referencia y CTA de reserva pensado para mobile.
 impacto: >
-  Demo útil para negocios locales: transforma una marca visual en una página compartible, con servicios claros y reservas sin fricción.
+  Demuestra landing visual para barbería con estética fuerte y recorrido mobile.
 demoUrl: "https://barber-demo-puce.vercel.app/"
 cover: "/og-default.png"
 thumbnail: "/galeria/noir-barber-studio.jpg"

--- a/src/content/proyectos/servicio-de-tarot.mdx
+++ b/src/content/proyectos/servicio-de-tarot.mdx
@@ -2,7 +2,7 @@
 title: "Servicio de Tarot – Web informativa"
 tipo: "Web para recibir consultas"
 sector: "Servicios / Bienestar"
-idealPara: "Profesionales independientes que venden por confianza y necesitan llevar consultas a WhatsApp."
+idealPara: "Profesionales independientes que necesitan explicar su servicio antes de abrir una conversación."
 category: "Bienestar"
 businessType: "Profesional independiente"
 visualTone: "rose"
@@ -11,7 +11,7 @@ badges:
   - Confianza
   - Mobile-first
   - SEO básico
-highlight: "Una presencia simple y directa para llevar visitantes hacia conversación por WhatsApp."
+highlight: "Página liviana con presentación del servicio, confianza inicial y CTA directo a WhatsApp."
 rol: "Desarrollador Frontend"
 stack:
   - html
@@ -26,11 +26,12 @@ status: "demo"
 featured: false
 priority: 10
 ctaLabel: "Ver web"
-resumen: "Web ligera y directa con foco en reservas por WhatsApp y confianza del cliente."
-problema: "Se necesitaba una web clara, rápida y fácil de navegar para ofrecer lecturas y contacto directo."
-solucion: "Página liviana, fácil de navegar desde el celular y con botones claros hacia WhatsApp."
-resultado: "Más consultas y reservas por WhatsApp directo"
-impacto: "Muestra cómo un servicio personal puede ordenar su propuesta y llevar al visitante hacia una conversación concreta por WhatsApp."
+resumen: "Web ligera para presentar el servicio, responder dudas básicas y abrir contacto desde el celular."
+problema: "El servicio necesitaba explicar qué ofrece, cómo se consulta y qué esperar antes de que la persona escriba."
+solucion: "Página liviana con presentación del servicio, señales de confianza, preguntas básicas y botón de contacto visible."
+resultLabel: "El visitante entiende qué se ofrece antes de iniciar la consulta."
+resultado: "Contacto más directo desde una página simple y fácil de compartir."
+impacto: "Demuestra cómo un servicio personal puede usar una web simple como filtro de confianza."
 repoUrl: "https://github.com/Daegon13/Servicio-de-Tarot"
 demoUrl: "https://daegon13.github.io/Servicio-de-Tarot/"
 cover: "https://daegon13.github.io/Servicio-de-Tarot/images/cover.png"

--- a/src/content/proyectos/smart-stock.mdx
+++ b/src/content/proyectos/smart-stock.mdx
@@ -11,8 +11,8 @@ badges:
   - Stock
   - Compras
   - Datos POS
-highlight: "Demuestra capacidad para construir herramientas operativas navegables, no solo landings."
-resultLabel: "Showcase funcional en modo solo lectura para validar producto y flujo operativo."
+highlight: "Dashboard demo con productos, stock, compras, estados e indicadores."
+resultLabel: "Permite mostrar flujo de inventario sin exponer datos reales ni prometer un SaaS terminado."
 rol: "Desarrollador Frontend"
 stack:
   - React
@@ -21,9 +21,9 @@ stack:
   - Prisma / PostgreSQL
   - Dashboard UI
 features:
-  - Dashboard operativo
+  - Dashboard demo
   - Control de stock
-  - Compras y órdenes
+  - Compras y estados
   - Importación POS
 fecha: "2026-01"
 status: "demo"
@@ -31,13 +31,13 @@ featured: true
 priority: 140
 ctaLabel: "Abrir showcase funcional"
 resumen: >
-  Showcase funcional de inventario para comercios: permite navegar dashboard, productos, stock, compras y señales operativas con datos ficticios en modo solo lectura.
+  Demo funcional de inventario para comercios: productos, stock, compras, estados e indicadores con datos ficticios en modo solo lectura.
 problema: >
   Muchos comercios gestionan stock, ventas POS y reposición con planillas dispersas, poca trazabilidad y decisiones manuales sobre productos críticos.
 solucion: >
-  Se construyó un sistema navegable con dashboard, catálogo, movimientos, compras, importación POS y arquitectura preparada para auth, roles y multi-tenant.
+  Se construyó una demo navegable con dashboard, catálogo, movimientos, compras, importación POS y base preparada para auth, roles y multi-tenant.
 impacto: >
-  Proyecto estrella del portfolio: demuestra capacidad para construir producto operativo real. Para ser completamente comercial faltan los módulos finales de autenticación, roles y hardening multi-tenant.
+  Demuestra capacidad para construir herramienta interna, no solo landing comercial. Es una demo funcional en modo portfolio, no un SaaS productivo completo.
 demoUrl: "https://smart-stock-showcase.vercel.app/"
 repoUrl: "https://github.com/Daegon13/smart-stock"
 cover: "/og-default.png"
@@ -50,7 +50,7 @@ Smart Stock ya funciona como showcase público navegable y en modo solo lectura.
 
 ### Enfoque del caso
 
-Smart Stock muestra una línea fuerte del portfolio: sistemas simples y paneles que ayudan a ordenar operaciones internas. Es un ejemplo útil para comercios, depósitos o equipos que necesitan reemplazar procesos manuales por una interfaz clara, auditable y preparada para crecer.
+Smart Stock muestra una línea fuerte del portfolio: sistemas simples y paneles para inventario. Es un ejemplo útil para comercios, depósitos o equipos que necesitan reemplazar planillas por una interfaz auditable y preparada para crecer.
 
 ### Módulos demostrables
 

--- a/src/content/proyectos/vetcare.mdx
+++ b/src/content/proyectos/vetcare.mdx
@@ -2,7 +2,7 @@
 title: "VetCare – Demo veterinaria con agenda y urgencias"
 tipo: "Demo comercial / sistema simple"
 sector: "Veterinarias"
-idealPara: "Clínicas veterinarias que quieren ordenar consultas, urgencias y turnos desde una experiencia web clara."
+idealPara: "Clínicas veterinarias que quieren separar turnos, urgencias y datos de mascota antes de abrir el chat."
 category: "Veterinaria"
 businessType: "Clínica veterinaria"
 visualTone: "emerald"
@@ -11,8 +11,8 @@ badges:
   - Urgencias
   - WhatsApp
   - Portal mascota
-highlight: "Ordena turnos, urgencias y consultas en una experiencia mobile clara."
-resultLabel: "Demo lista para vender una experiencia más completa que una web institucional."
+highlight: "Agenda de turnos, urgencias, ficha de mascota y contacto por WhatsApp."
+resultLabel: "Una veterinaria puede mostrar atención común y urgencias sin mezclar todo en un mismo chat."
 rol: "Diseño UI y desarrollo Frontend"
 stack:
   - Astro
@@ -30,13 +30,13 @@ featured: true
 priority: 100
 ctaLabel: "Ver demo veterinaria"
 resumen: >
-  Demo para veterinarias que convierte una web institucional en un flujo claro para turnos, urgencias y consultas por WhatsApp.
+  Demo para veterinarias con agenda, urgencias, ficha de mascota y contacto por WhatsApp en un recorrido mobile.
 problema: >
-  Muchas veterinarias reciben consultas dispersas por redes, llamadas y mensajes sin una estructura clara para urgencias, reservas o información de servicios.
+  Muchas veterinarias reciben turnos, urgencias y preguntas generales por redes, llamadas y mensajes, sin separar prioridades ni datos básicos de la mascota.
 solucion: >
-  Se diseñó una demo con jerarquía comercial, llamadas a la acción visibles, módulos de agenda, urgencias y un flujo pensado para llevar al visitante al canal correcto.
+  Se diseñó una demo con módulos de agenda, urgencias, ficha de mascota y WhatsApp para que cada tipo de atención tenga su entrada.
 impacto: >
-  Demo lista para mostrar una experiencia más completa que una web informativa: servicios claros, prioridades ordenadas y contacto fácil desde mobile.
+  Demuestra una demo vertical con agenda, triaje y portal básico, no solo una web institucional.
 demoUrl: "https://vetcare-uy.vercel.app/"
 cover: "/og-default.png"
 thumbnail: "/galeria/vetcare.jpg"

--- a/src/pages/proyectos/index.astro
+++ b/src/pages/proyectos/index.astro
@@ -21,14 +21,14 @@ const proyectos = (await getCollection('proyectos')).sort(byCommercialPriority);
 ---
 <BaseLayout
   title="Casos, demos y herramientas | Marin.dev"
-  description="Portfolio comercial de Marin.dev: demos, webs y herramientas simples pensadas para recibir consultas, reservas o ventas."
+  description="Portfolio comercial de Marin.dev: demos, webs y herramientas simples con agenda, WhatsApp, carta digital, panel, catálogo o web corporativa."
 >
   <Container class="py-14 sm:py-20">
     <div class="grid min-w-0 gap-8 lg:grid-cols-[minmax(0,1fr)_minmax(0,22rem)] lg:items-end">
       <SectionHeader
         eyebrow="Portfolio"
-        title="Proyectos y demos pensados para vender mejor"
-        description="No son solo sitios lindos: cada pieza está diseñada para ordenar el mensaje, reducir fricción y llevar al usuario hacia una consulta o acción concreta."
+        title="Casos, demos y sistemas por rubro"
+        description="Cada caso muestra un tipo de decisión: agenda, WhatsApp, carta digital, panel, catálogo o web corporativa."
       />
       <div class="min-w-0 rounded-3xl border border-line bg-surface-glass p-5 text-sm leading-6 text-muted-soft shadow-premium backdrop-blur">
         <p class="font-semibold text-slate-50">Criterio de orden</p>
@@ -72,7 +72,7 @@ const proyectos = (await getCollection('proyectos')).sort(byCommercialPriority);
     <div class="mt-10 flex min-w-0 flex-col gap-4 rounded-3xl border border-line bg-surface-glass p-5 shadow-premium backdrop-blur sm:flex-row sm:items-center sm:justify-between">
       <div class="min-w-0">
         <p class="break-words font-semibold text-slate-50">¿Querés algo parecido para tu negocio?</p>
-        <p class="mt-1 text-sm leading-6 text-muted-soft">Compartime tu Instagram, web o idea y te digo cómo convertirla en una demo accionable.</p>
+        <p class="mt-1 text-sm leading-6 text-muted-soft">Compartime tu Instagram, web o idea y te digo qué módulos conviene mostrar primero.</p>
       </div>
       <a href={waLink(DEMO_WHATSAPP_MESSAGE)} target="_blank" rel="noreferrer" class="premium-button inline-flex w-full max-w-full items-center justify-center gap-2 rounded-2xl bg-brand-gradient px-5 py-3 text-center text-sm font-semibold text-white shadow-glow sm:w-fit">
         Pedir una demo <span aria-hidden="true">↗</span>


### PR DESCRIPTION
### Motivation

- Reduce la repetición de frases abstractas detectada en el audit y atar el copy de los proyectos a entregables concretos por rubro. 
- Evitar que los campos de los MDX (`highlight`, `resultLabel`, `impacto`, `resultado`) repitan la misma idea en las cards, para que cada uno cumpla un rol semántico distinto. 
- Hacer que la introducción del portfolio y el strip de casos comuniquen entregables visibles (agenda, WhatsApp, carta, panel) en lugar de frases genéricas como “reducir fricción”.

### Description

- Se reescribieron los frontmatter/fields de los proyectos para separar semánticas: `highlight` (qué se construyó), `resultLabel` (beneficio visible), `impacto` (qué demuestra) y `resultado` (solo resultados honestos); archivos afectados: `vetcare.mdx`, `noir-barber-studio.mdx`, `servicio-de-tarot.mdx`, `Agencia_ariel.mdx`, `brasa-23.mdx`, `cristal-sagrado.mdx`, `smart-stock.mdx`. 
- Se actualizó `src/components/ProjectCard.astro` para impedir que `highlight` sea usado como fallback del bloque de beneficio; ahora normaliza y elige `resultLabel`, luego `impacto`, luego `resultado` siempre que no repitan el `highlight`, y muestra etiquetas compactas (`Construido:` y `Qué permite` / `Qué demuestra` / `Resultado`). 
- Se afinó la copia del overview y featured cases: `src/components/FeaturedCases.astro` ahora usa título/description más concretos y `src/pages/proyectos/index.astro` actualiza title/description y CTA a una frase que pide módulos concretos a mostrar. 
- No se introdujeron métricas nuevas ni se eliminaron proyectos o URLs; cuando un resultado numérico no estaba claramente soportado se reemplazó por texto cualitativo (p.ej. `cristal-sagrado` ahora refleja impacto cualitativo y agrega `resultLabel`/`resultado` acordes). 

### Testing

- Ejecuté `npm run build` y el build completó correctamente (generó las rutas de `/proyectos/[slug]` y la site build sin errores). 
- No se ejecutaron otras pruebas automatizadas; la verificación importante fue la compilación estática (`npm run build`) que pasó exitosamente.

Files changed: `src/components/ProjectCard.astro`, `src/components/FeaturedCases.astro`, `src/pages/proyectos/index.astro`, `src/content/proyectos/vetcare.mdx`, `src/content/proyectos/noir-barber-studio.mdx`, `src/content/proyectos/servicio-de-tarot.mdx`, `src/content/proyectos/Agencia_ariel.mdx`, `src/content/proyectos/brasa-23.mdx`, `src/content/proyectos/cristal-sagrado.mdx`, `src/content/proyectos/smart-stock.mdx`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0351d246d88328abb7afbee7a18c01)