### PR TITLE
Rewrite service package copy and unify service data model

### DIFF
--- a/src/components/PricingPlans.astro
+++ b/src/components/PricingPlans.astro
@@ -5,119 +5,8 @@ import Icon from './Icon.astro';
 import IconBubble from './IconBubble.astro';
 import SectionHeader from './SectionHeader.astro';
 import VisualBadge from './VisualBadge.astro';
+import { servicePlans as plans } from '../data/services';
 import { SERVICE_WHATSAPP_MESSAGE, waLink } from '../lib/contact';
-
-const plans = [
-  {
-    name: 'Demo Comercial Express',
-    badge: 'Validar rápido',
-    price: 'USD 150–290',
-    time: '3–5 días hábiles',
-    forWho: 'Para leads, preventas, ideas nuevas o negocios que necesitan visualizar una propuesta antes de construir algo grande.',
-    solves: 'Convierte una idea o Instagram en una demo concreta, compartible y orientada a conversación comercial.',
-    deliverables: [
-      'Estructura de landing/demo de una página',
-      'Copy base orientado a consulta o reserva',
-      'CTA a WhatsApp con mensaje guiado',
-      'Mockup visual o bloques de producto/servicio',
-      'Deploy estático listo para compartir',
-    ],
-    comparison: 'Demo para mostrar valor',
-    cta: 'Quiero validar una demo',
-    icon: 'rocket',
-    tone: 'cyan',
-    chooser: 'Rápido',
-    positioning: 'Para pasar de idea o Instagram a una demo vendible sin armar un proyecto enorme.',
-    attributes: [
-      { label: '3–5 días', icon: 'speed' },
-      { label: 'One-page', icon: 'layout' },
-      { label: 'WhatsApp CTA', icon: 'message' },
-      { label: 'SEO base', icon: 'target' },
-    ],
-  },
-  {
-    name: 'Landing de Conversión',
-    badge: 'Recomendado',
-    price: 'USD 390–690',
-    time: '7–12 días hábiles',
-    forWho: 'Para campañas, profesionales, servicios y negocios locales que ya reciben tráfico o quieren empezar a vender mejor.',
-    solves: 'Ordena el mensaje, reduce dudas y guía al visitante hacia consultas, reservas o ventas con una estructura clara.',
-    deliverables: [
-      'Hero con promesa y CTA principal',
-      'Secciones de confianza, servicios, proceso y FAQs',
-      'Optimización básica para SEO y redes sociales',
-      'WhatsApp, formulario o link de reserva integrado',
-      'Medición básica y página rápida responsive',
-    ],
-    comparison: 'Captación de consultas',
-    cta: 'Consultar landing',
-    featured: true,
-    icon: 'target',
-    tone: 'emerald',
-    chooser: 'Conversión',
-    positioning: 'Para ordenar una oferta concreta y guiar visitas hacia consulta, reserva o venta.',
-    attributes: [
-      { label: 'CTA principal', icon: 'message' },
-      { label: 'Confianza', icon: 'shield' },
-      { label: 'OpenGraph', icon: 'external' },
-      { label: 'Performance', icon: 'zap' },
-    ],
-  },
-  {
-    name: 'Web con WhatsApp / Agenda',
-    badge: 'Reservas claras',
-    price: 'USD 590–990',
-    time: '10–15 días hábiles',
-    forWho: 'Para gimnasios, barberías, veterinarias, clínicas, restaurantes y servicios que necesitan ordenar consultas o turnos.',
-    solves: 'Evita mensajes incompletos y lleva a cada visitante al canal correcto con contexto, servicio elegido y próximo paso.',
-    deliverables: [
-      'Páginas o secciones por servicio/plan',
-      'CTAs por intención: consultar, reservar o pedir presupuesto',
-      'Mensajes de WhatsApp prearmados por flujo',
-      'Integración con agenda externa si ya existe',
-      'Guía simple para mantener links y contenidos',
-    ],
-    comparison: 'Consultas y reservas guiadas',
-    cta: 'Ordenar mis reservas',
-    icon: 'briefcase',
-    tone: 'violet',
-    chooser: 'Institucional',
-    positioning: 'Para mostrar servicios con más profundidad y llevar cada consulta al canal correcto.',
-    attributes: [
-      { label: 'Multipágina', icon: 'layout' },
-      { label: 'Confianza', icon: 'shield' },
-      { label: 'WhatsApp', icon: 'message' },
-      { label: 'Agenda', icon: 'flow' },
-    ],
-  },
-  {
-    name: 'Sistema simple / Panel Admin',
-    badge: 'Operación interna',
-    price: 'USD 790–1.490+',
-    time: '15–25 días hábiles',
-    forWho: 'Para negocios que ya necesitan gestionar contenido, stock, leads, reservas o información operativa sin depender de planillas sueltas.',
-    solves: 'Centraliza una operación acotada en un panel simple, pensado para usarlo de verdad sin prometer un backend corporativo complejo.',
-    deliverables: [
-      'Alcance funcional definido por hitos',
-      'Panel o flujo interno para datos clave',
-      'Estados simples para leads, reservas o stock',
-      'Roles/accesos básicos si el alcance lo permite',
-      'Documentación breve para operar el sistema',
-    ],
-    comparison: 'Gestión simple de datos',
-    cta: 'Consultar panel simple',
-    icon: 'database',
-    tone: 'amber',
-    chooser: 'Escalable',
-    positioning: 'Para ordenar datos, estados y tareas internas en una herramienta simple de usar.',
-    attributes: [
-      { label: 'Panel admin', icon: 'settings' },
-      { label: 'Formularios', icon: 'layout' },
-      { label: 'Integraciones', icon: 'flow' },
-      { label: 'Datos', icon: 'database' },
-    ],
-  },
-];
 
 const chooserItems = plans.map(({ name, chooser, comparison, tone }) => ({
   name,
@@ -130,7 +19,7 @@ const chooserItems = plans.map(({ name, chooser, comparison, tone }) => ({
   <SectionHeader
     eyebrow="Servicios"
     title="Elegí un punto de partida y lo adaptamos a tu negocio"
-    description="Trabajo con paquetes claros para avanzar rápido, pero cada propuesta se ajusta al objetivo real: consultas, reservas, ventas o gestión."
+    description="Cada paquete parte de un entregable concreto, con límites visibles y datos necesarios para cotizar sin adivinar el alcance."
     align="center"
   />
 
@@ -191,7 +80,7 @@ const chooserItems = plans.map(({ name, chooser, comparison, tone }) => ({
             <span>Incluye</span>
           </div>
           <ul class="mt-4 space-y-3 text-sm leading-6 text-muted-soft">
-            {plan.deliverables.map((deliverable) => (
+            {plan.includes.map((deliverable) => (
               <li class="flex min-w-0 gap-3">
                 <span
                   class="mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded-full border border-brand-success/25 bg-brand-success/10 text-brand-success"
@@ -207,13 +96,32 @@ const chooserItems = plans.map(({ name, chooser, comparison, tone }) => ({
 
         <div class="mt-5 rounded-2xl border border-cyan-electric/15 bg-cyan-electric/5 p-4">
           <p class="break-words text-xs font-semibold uppercase tracking-[0.1em] text-cyan-electric sm:tracking-[0.18em]">Ideal para</p>
-          <p class="mt-2 text-sm leading-6 text-muted-soft">{plan.forWho}</p>
+          <p class="mt-2 text-sm leading-6 text-muted-soft">{plan.bestFor}</p>
         </div>
 
         <div class="mt-5 rounded-2xl border border-line bg-surface-glass p-4">
           <p class="break-words text-xs font-semibold uppercase tracking-[0.1em] text-muted sm:tracking-[0.18em]">Resuelve</p>
           <p class="mt-2 text-sm leading-6 text-muted-soft">{plan.solves}</p>
           <p class="mt-3 text-xs font-medium text-slate-300">Tiempo estimado: {plan.time}</p>
+        </div>
+
+        <div class="mt-5 grid gap-3 text-sm leading-6 text-muted-soft">
+          <div class="rounded-2xl border border-line bg-ink/35 p-4">
+            <p class="text-xs font-semibold uppercase tracking-[0.14em] text-slate-300">Necesito de vos</p>
+            <p class="mt-2">{plan.clientInput.join(' · ')}</p>
+          </div>
+          <div class="rounded-2xl border border-line bg-ink/35 p-4">
+            <p class="text-xs font-semibold uppercase tracking-[0.14em] text-slate-300">No incluye por defecto</p>
+            <p class="mt-2">{plan.notIncluded.join(' · ')}</p>
+          </div>
+          <div class="rounded-2xl border border-brand-success/15 bg-brand-success/5 p-4">
+            <p class="text-xs font-semibold uppercase tracking-[0.14em] text-brand-success">Entrega final</p>
+            <p class="mt-2">{plan.finalDeliverable}</p>
+          </div>
+          <div class="rounded-2xl border border-amber-300/15 bg-amber-300/5 p-4">
+            <p class="text-xs font-semibold uppercase tracking-[0.14em] text-amber-200">Cuándo no conviene</p>
+            <p class="mt-2">{plan.wrongFit}</p>
+          </div>
         </div>
 
         <div class="mt-auto pt-6">

--- a/src/components/ProductizedServices.astro
+++ b/src/components/ProductizedServices.astro
@@ -19,7 +19,7 @@ const serviceBadges = [
     <SectionHeader
       eyebrow="Servicios"
       title="Paquetes con entregables definidos"
-      description="Cada servicio marca qué se entrega, qué queda fuera y qué necesito para empezar sin perder semanas."
+      description="Mismos paquetes de la página de servicios: entregable, límite de alcance, datos necesarios y CTA específico."
       icon="layout"
     />
     <div class="flex min-w-0 max-w-full flex-wrap gap-2 lg:max-w-md lg:justify-end">
@@ -36,20 +36,24 @@ const serviceBadges = [
         <h3 class="mt-5 break-words text-2xl font-semibold tracking-tight text-slate-50">{service.name}</h3>
         <p class="mt-3 text-sm leading-6 text-muted-soft">{service.description}</p>
         <ul class="mt-5 space-y-3 text-sm text-muted-soft">
-          {service.deliverables.map((item) => (
+          {service.includes.slice(0, 4).map((item) => (
             <li class="flex min-w-0 gap-3">
               <span class="mt-2 h-1.5 w-1.5 shrink-0 rounded-full bg-cyan-electric" aria-hidden="true"></span>
               <span class="min-w-0 break-words">{item}</span>
             </li>
           ))}
         </ul>
+        <div class="mt-5 space-y-3 rounded-2xl border border-line bg-ink/35 p-4 text-xs leading-5 text-muted-soft">
+          <p><span class="font-semibold text-slate-200">Necesito:</span> {service.clientInput.slice(0, 2).join(' · ')}</p>
+          <p><span class="font-semibold text-slate-200">No incluye:</span> {service.notIncluded.slice(0, 2).join(' · ')}</p>
+        </div>
         <a
           href={waLink(SERVICE_WHATSAPP_MESSAGE(service.name))}
           target="_blank"
           rel="noopener noreferrer"
           class="premium-button mt-6 inline-flex w-full max-w-full items-center justify-center rounded-2xl border border-line bg-surface-glass px-5 py-3 text-center text-sm font-semibold text-slate-50 hover:-translate-y-0.5 hover:border-line-strong hover:text-cyan-electric"
         >
-          Consultar este paquete
+          {service.cta}
         </a>
       </GlowCard>
     ))}

--- a/src/data/services.ts
+++ b/src/data/services.ts
@@ -1,51 +1,206 @@
-export const productizedServices = [
+export const servicePlans = [
   {
     name: "Demo Comercial Express",
-    tag: "Validar rápido",
+    tag: "Validar rubro",
+    badge: "Validar rápido",
+    price: "USD 150–290",
+    time: "3–5 días hábiles",
+    bestFor:
+      "Negocios que tienen Instagram, una idea o un rubro definido y necesitan una demo navegable antes de invertir en algo grande.",
     description:
-      "Una demo navegable para transformar una idea o Instagram en pantallas que se puedan evaluar.",
-    deliverables: [
-      "Mensaje principal y secciones necesarias",
-      "Secciones clave para explicar la propuesta",
+      "Una página/demo navegable con hero, servicios o módulos principales, CTA a WhatsApp, visual mobile y deploy publicado.",
+    positioning:
+      "Para pasar de Instagram, idea o rubro a una demo navegable que puedas mostrar por link.",
+    solves:
+      "Sirve cuando todavía falta ver cómo se presenta la oferta, qué pantallas hacen falta y qué mensaje abre WhatsApp.",
+    includes: [
+      "Una página/demo navegable",
+      "Hero con promesa y rubro",
+      "Servicios o módulos principales",
       "CTA a WhatsApp con mensaje prearmado",
-      "Vista responsive con deploy publicado",
+      "Visual mobile revisado",
+      "Deploy publicado",
+    ],
+    notIncluded: [
+      "Backend real",
+      "Pagos online",
+      "Panel admin completo",
+      "Carga masiva de productos",
+    ],
+    clientInput: [
+      "Instagram o web actual",
+      "Rubro y servicios principales",
+      "Logo/colores si existen",
+      "Referencias visuales opcionales",
+    ],
+    finalDeliverable:
+      "Link publicado con una demo one-page lista para revisar, enviar por WhatsApp o usar como base de cotización.",
+    wrongFit:
+      "No conviene si ya necesitás pagos, usuarios, panel completo o catálogo grande desde el primer día.",
+    comparison: "Demo navegable por rubro",
+    cta: "Pedir demo para mi rubro",
+    icon: "rocket",
+    tone: "cyan",
+    chooser: "Idea",
+    attributes: [
+      { label: "3–5 días", icon: "speed" },
+      { label: "One-page", icon: "layout" },
+      { label: "WhatsApp", icon: "message" },
+      { label: "Deploy", icon: "external" },
     ],
   },
   {
     name: "Landing de Conversión",
-    tag: "WhatsApp listo",
+    tag: "Oferta definida",
+    badge: "Recomendado",
+    price: "USD 390–690",
+    time: "7–12 días hábiles",
+    bestFor:
+      "Una oferta definida, campaña, link de bio, Google Business o servicio principal que necesita pedir cotizaciones con mejor contexto.",
     description:
-      "Una landing para mostrar servicios, prueba visual, objeciones y WhatsApp en los puntos clave.",
-    deliverables: [
-      "Hero con oferta, rubro y CTA visible",
-      "Bloques de confianza, servicios y objeciones",
-      "CTA principal y secundarios bien ubicados",
-      "SEO/share básico y carga rápida",
+      "Una landing con hero, oferta, prueba/confianza, FAQ, CTA a WhatsApp o formulario, metadata SEO/share y deploy.",
+    positioning:
+      "Para presentar una oferta concreta con precios, servicios, prueba y camino de cotización en una sola página.",
+    solves:
+      "Reduce dudas antes del mensaje: qué incluye el servicio, para quién es, qué datos mandar y cómo pedir cotización.",
+    includes: [
+      "Hero con oferta y CTA principal",
+      "Sección de servicios o propuesta",
+      "Bloques de prueba, confianza y objeciones",
+      "FAQ compacta",
+      "WhatsApp, formulario o link de reserva",
+      "Metadata SEO/share y deploy",
     ],
+    notIncluded: [
+      "E-commerce completo",
+      "Campañas pagas",
+      "Blog extenso",
+      "Integraciones avanzadas",
+    ],
+    clientInput: [
+      "Oferta o servicio principal",
+      "Precios o rangos si querés mostrarlos",
+      "Fotos/testimonios si existen",
+      "Datos necesarios para cotizar",
+    ],
+    finalDeliverable:
+      "Landing publicada con URL, preview para compartir y CTAs preparados para recibir pedidos de cotización.",
+    wrongFit:
+      "No conviene si todavía no sabés qué vendés; en ese caso es mejor empezar con una demo por rubro.",
+    comparison: "Oferta + cotización",
+    cta: "Cotizar landing",
     featured: true,
+    icon: "target",
+    tone: "emerald",
+    chooser: "Oferta",
+    attributes: [
+      { label: "CTA", icon: "message" },
+      { label: "FAQ", icon: "shield" },
+      { label: "OpenGraph", icon: "external" },
+      { label: "Performance", icon: "zap" },
+    ],
   },
   {
     name: "Web con WhatsApp / Agenda",
-    tag: "Agenda visible",
+    tag: "Turnos guiados",
+    badge: "Mensajes completos",
+    price: "USD 590–990",
+    time: "10–15 días hábiles",
+    bestFor:
+      "Barberías, clínicas, gimnasios, restaurantes o servicios que reciben mensajes incompletos sobre horarios, precios o disponibilidad.",
     description:
-      "Una web para mostrar servicios y guiar al visitante hacia WhatsApp, reserva o agenda.",
-    deliverables: [
+      "Una web con selección de servicio, agenda externa si aplica, WhatsApp prearmado y páginas de confianza para pedir turno con datos mínimos.",
+    positioning:
+      "Para que la persona elija servicio, vea datos clave y llegue a WhatsApp con el mensaje ya armado.",
+    solves:
+      "Ordena turnos y pedidos repetidos: servicio elegido, horario preferido, sucursal o datos que necesitás antes de responder.",
+    includes: [
       "Servicios o planes con CTA específico",
-      "Mensajes prearmados por intención",
-      "Flujo de reserva o consulta acotado",
-      "Páginas clave con servicios y contacto",
+      "WhatsApp prearmado por servicio",
+      "Link o embed de agenda externa si ya existe",
+      "Instrucciones de datos a enviar",
+      "Páginas/secciones de confianza",
+      "Guía para mantener links y textos",
+    ],
+    notIncluded: [
+      "Agenda propia compleja",
+      "Pagos reales",
+      "CRM avanzado",
+      "Automatizaciones grandes",
+    ],
+    clientInput: [
+      "Servicios, precios o rangos",
+      "Horarios y zonas de atención",
+      "Link de agenda actual si existe",
+      "Datos mínimos que debe mandar el cliente",
+    ],
+    finalDeliverable:
+      "Web publicada con botones por servicio y mensajes de WhatsApp listos para copiar datos útiles al chat.",
+    wrongFit:
+      "No conviene si necesitás un sistema de reservas propio con usuarios, pagos y reglas complejas.",
+    comparison: "Turnos y mensajes guiados",
+    cta: "Consultar flujo de turnos",
+    icon: "briefcase",
+    tone: "violet",
+    chooser: "Turnos",
+    attributes: [
+      { label: "Servicios", icon: "layout" },
+      { label: "Agenda", icon: "flow" },
+      { label: "WhatsApp", icon: "message" },
+      { label: "Datos", icon: "database" },
     ],
   },
   {
     name: "Sistema simple / Panel Admin",
-    tag: "Panel acotado",
+    tag: "Datos editables",
+    badge: "Panel acotado",
+    price: "USD 790–1.490+",
+    time: "15–25 días hábiles",
+    bestFor:
+      "Negocios que ya tienen un flujo manual y necesitan ver o editar datos básicos sin construir una plataforma enorme.",
     description:
-      "Una herramienta liviana para ver contenido, stock, leads, reservas o datos internos en módulos simples.",
-    deliverables: [
-      "Panel o flujo interno acotado",
-      "Datos y estados organizados",
-      "Acciones simples para el equipo",
-      "Guía de uso y entrega por hitos",
+      "Un panel acotado con tabla o dashboard, formularios, estados simples, filtros, deploy/repo y documentación breve.",
+    positioning:
+      "Para reemplazar una planilla o flujo manual por un panel pequeño con módulos y límites definidos.",
+    solves:
+      "Centraliza datos básicos como stock, leads, reservas o contenidos editables con formularios y estados simples.",
+    includes: [
+      "Tabla o dashboard inicial",
+      "CRUD básico cuando está en alcance",
+      "Estados simples y filtros",
+      "Formularios para cargar o editar datos",
+      "Deploy/repo del proyecto",
+      "Documentación breve de uso",
+    ],
+    notIncluded: [
+      "ERP",
+      "SaaS multiempresa",
+      "App móvil nativa",
+      "Permisos complejos salvo alcance específico",
+      "Automatizaciones grandes",
+    ],
+    clientInput: [
+      "Flujo manual actual",
+      "Campos que se deben guardar",
+      "Estados necesarios",
+      "Quién usa el panel y para qué",
+    ],
+    finalDeliverable:
+      "Panel publicado o entregado por repo/deploy, con módulos acordados y una guía breve para usarlo.",
+    wrongFit:
+      "No conviene si buscás un ERP completo, app nativa o producto SaaS con múltiples empresas desde el inicio.",
+    comparison: "Panel simple de datos",
+    cta: "Consultar panel simple",
+    icon: "database",
+    tone: "amber",
+    chooser: "Interno",
+    attributes: [
+      { label: "Panel", icon: "settings" },
+      { label: "CRUD", icon: "layout" },
+      { label: "Filtros", icon: "flow" },
+      { label: "Repo", icon: "external" },
     ],
   },
 ];
+
+export const productizedServices = servicePlans;

--- a/src/pages/servicios.astro
+++ b/src/pages/servicios.astro
@@ -6,14 +6,14 @@ import PricingPlans from '../components/PricingPlans.astro';
 import { SERVICE_WHATSAPP_MESSAGE } from '../lib/contact';
 
 const title = 'Servicios productizados – Marin.dev';
-const description = 'Demos, landings, webs con WhatsApp/agenda y sistemas simples para convertir visitas en consultas, reservas o ventas.';
+const description = 'Demos, landings, webs con WhatsApp/agenda y paneles simples para validar ofertas, recibir mejores mensajes o manejar datos básicos.';
 const url = 'https://daegon13.github.io/servicios';
 const image = '/og-default.png';
 
 const serviceHighlights = [
-  'Rangos claros antes de cotizar',
-  'Alcance definido por objetivo comercial',
-  'WhatsApp, agenda o panel cuando suma valor',
+  'Rangos de precio antes de cotizar',
+  'Alcance y límites visibles',
+  'Primer entregable definido',
 ];
 ---
 <BaseLayout {title} {description} {url} {image}>
@@ -22,10 +22,10 @@ const serviceHighlights = [
     <div class="relative mx-auto min-w-0 max-w-4xl text-center">
       <p class="break-words text-sm font-semibold uppercase tracking-[0.1em] text-cyan-electric sm:tracking-[0.24em]">Servicios Marin.dev</p>
       <h1 class="mt-4 break-words text-[clamp(2.25rem,10vw,3.5rem)] font-semibold leading-[1.04] tracking-tight text-slate-50 md:text-6xl">
-        Productos digitales simples para vender, reservar u operar mejor.
+        Productos digitales simples para validar una oferta, recibir mejores mensajes o manejar datos básicos.
       </h1>
       <p class="mx-auto mt-5 max-w-2xl text-base leading-7 text-muted-soft md:text-lg">
-        No arranco desde “necesitás una web”. Arranco desde el objetivo: validar una idea, captar consultas, ordenar reservas o crear una herramienta interna liviana.
+        No arranco desde “necesitás una web”. Arranco desde el problema real: falta contexto de precios, servicios dispersos, mensajes incompletos o datos internos en planillas.
       </p>
       <div class="mt-8 flex min-w-0 max-w-full flex-wrap justify-center gap-3">
         {serviceHighlights.map((item) => (
@@ -41,15 +41,15 @@ const serviceHighlights = [
     <div class="min-w-0">
       <p class="break-words text-sm font-semibold uppercase tracking-[0.1em] text-cyan-electric sm:tracking-[0.22em]">Cómo elegir</p>
       <h2 class="mt-3 break-words text-2xl font-semibold tracking-tight text-slate-50 md:text-4xl">
-        Elegí el punto de partida. Después ajustamos el alcance real.
+        Elegí según el problema que querés resolver primero.
       </h2>
     </div>
     <div class="min-w-0 space-y-4 text-sm leading-6 text-muted-soft md:text-base">
       <p>
-        Los planes no son moldes cerrados: son formas de ordenar la conversación para que sepas qué estás comprando, qué problema resuelve y qué entregables esperar.
+        Los planes sirven para ubicar el primer entregable: una demo, una landing, un flujo de turnos por WhatsApp o un panel acotado.
       </p>
       <p>
-        Si tu negocio todavía necesita validar una propuesta, conviene una demo. Si ya tenés tráfico o campañas, una landing. Si el cuello de botella son turnos o mensajes incompletos, WhatsApp/agenda. Si el problema está adentro del negocio, un panel simple.
+        Si solo tenés Instagram o idea → Demo Comercial Express. Si ya sabés qué vendés → Landing de Conversión. Si el problema son turnos o mensajes incompletos → Web con WhatsApp / Agenda. Si el problema es interno → Sistema simple / Panel Admin.
       </p>
     </div>
   </section>
@@ -63,7 +63,7 @@ const serviceHighlights = [
   <ContactCTA
     eyebrow="¿No sabés cuál elegir?"
     title="Mandame tu rubro, Instagram o web y te recomiendo el punto de partida."
-    description="Te respondo con una recomendación concreta: demo, landing, WhatsApp/agenda o panel simple, según el objetivo y el momento de tu negocio."
+    description="Te respondo con un punto de partida y qué datos necesito: rubro, servicios, precios/rangos, turnos o campos del panel."
     primaryLabel="Consultar mi caso por WhatsApp"
     primaryMessage={SERVICE_WHATSAPP_MESSAGE('Servicios Marin.dev')}
     secondaryLabel="Ver casos"


### PR DESCRIPTION
### Motivation
- Hacer el copy de servicios más concreto y comercial, atándolo a entregables y límites de alcance para reducir ambigüedad y evitar repeticiones genéricas como “fricción” o “experiencia clara”.
- Evitar dos vocabularios distintos para los mismos paquetes (tarjetas de home vs pricing) y convertir la sección de servicios en un punto de decisión claro para el visitante.

### Description
- Centralicé la definición de paquetes en `src/data/services.ts` como `servicePlans`, agregando campos concretos: `bestFor`, `includes`, `notIncluded`, `clientInput`, `finalDeliverable`, `wrongFit`, `price`, `time` y `cta` para cada paquete. (Demo Comercial Express, Landing de Conversión, Web con WhatsApp/Agenda, Sistema simple/Panel Admin).
- Alineé `src/components/PricingPlans.astro` para consumir `servicePlans` y añadí bloques visibles de alcance: “Incluye”, “Ideal para”, “Resuelve”, “Necesito de vos”, “No incluye por defecto”, “Entrega final” y “Cuándo no conviene”.
- Actualicé `src/components/ProductizedServices.astro` para usar la misma fuente canónica y mostrar un resumen compacto de `includes`, dos inputs requeridos y las exclusiones, además de CTA específica por paquete.
- Reescribí la página de servicios `src/pages/servicios.astro` (hero, highlights y sección “Cómo elegir”) para nombrar obstáculos concretos (falta de contexto de precios, servicios dispersos, mensajes incompletos, datos en planillas) y ofrecer la guía de decisión entre paquetes.
- Mantuve precios, enlaces de contacto y número de WhatsApp sin cambios; las CTAs siguen abriendo WhatsApp via `SERVICE_WHATSAPP_MESSAGE`.

### Testing
- Ejecuté `npm run build` y la compilación completa pasó correctamente (14 páginas estáticas generadas). ✅
- Intenté formatear con `npx prettier --write ...` — Prettier formateó `src/data/services.ts` correctamente, pero la configuración del repo no infiere parser para archivos `.astro` así que los archivos `.astro` no fueron formateados por Prettier en este paso (no bloqueante). ⚠️
- Verifiqué que los cambios no reintroducen las frases auditadas (se reemplazaron usos genéricos por entregables y límites concretos) y que las plantillas ahora usan la misma fuente de verdad para evitar dos versiones de la misma oferta. ✅

Archivos principales modificados:
- `src/data/services.ts`
- `src/components/PricingPlans.astro`
- `src/components/ProductizedServices.astro`
- `src/pages/servicios.astro`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a039ccb6a44832881b2b5e06646b53a)