### PR TITLE
Agregar sección “No necesitás saber qué pedir” (NeedSelector) en la home

### DIFF
--- a/src/components/NeedSelector.astro
+++ b/src/components/NeedSelector.astro
@@ -1,0 +1,110 @@
+---
+import GlowCard from './GlowCard.astro';
+import IconBubble from './IconBubble.astro';
+import SectionHeader from './SectionHeader.astro';
+import VisualBadge from './VisualBadge.astro';
+import {
+  SELECTOR_AGENDA_WHATSAPP_MESSAGE,
+  SELECTOR_DEMO_WHATSAPP_MESSAGE,
+  SELECTOR_LANDING_WHATSAPP_MESSAGE,
+  SELECTOR_PANEL_WHATSAPP_MESSAGE,
+  waLink,
+} from '../lib/contact';
+
+const options = [
+  {
+    situation: 'Tengo solo Instagram o una idea',
+    recommended: 'Demo Comercial Express',
+    explanation:
+      'Sirve para mostrar una versión navegable del negocio antes de invertir en una web o sistema completo.',
+    cta: 'Pedir demo para mi rubro',
+    message: SELECTOR_DEMO_WHATSAPP_MESSAGE,
+    icon: 'rocket',
+    tone: 'cyan',
+  },
+  {
+    situation: 'Ya sé qué servicio quiero vender',
+    recommended: 'Landing de Conversión',
+    explanation:
+      'Sirve para presentar una oferta, explicar el servicio, responder dudas y llevar al cliente a WhatsApp.',
+    cta: 'Cotizar landing',
+    message: SELECTOR_LANDING_WHATSAPP_MESSAGE,
+    icon: 'target',
+    tone: 'emerald',
+  },
+  {
+    situation: 'Me llegan mensajes incompletos',
+    recommended: 'Web con WhatsApp / Agenda',
+    explanation:
+      'Sirve cuando necesitás que el cliente elija servicio, horario, rubro o datos antes de escribir.',
+    cta: 'Consultar flujo de turnos',
+    message: SELECTOR_AGENDA_WHATSAPP_MESSAGE,
+    icon: 'message',
+    tone: 'violet',
+  },
+  {
+    situation: 'Uso planillas o datos sueltos',
+    recommended: 'Sistema simple / Panel Admin',
+    explanation:
+      'Sirve para ver, editar o revisar datos básicos como productos, stock, leads, turnos o estados.',
+    cta: 'Consultar panel simple',
+    message: SELECTOR_PANEL_WHATSAPP_MESSAGE,
+    icon: 'database',
+    tone: 'amber',
+  },
+];
+---
+
+<section id="selector-necesidad" class="relative min-w-0 scroll-mt-24 overflow-hidden border-t border-line/70 py-14 md:py-20">
+  <div class="absolute -left-24 top-16 -z-10 hidden h-56 w-56 rounded-full bg-blue-electric/10 blur-3xl md:block" aria-hidden="true"></div>
+  <div class="absolute -right-28 bottom-10 -z-10 hidden h-52 w-52 rounded-full bg-cyan-electric/10 blur-3xl md:block" aria-hidden="true"></div>
+
+  <div class="flex min-w-0 flex-col gap-5 lg:flex-row lg:items-end lg:justify-between">
+    <SectionHeader
+      eyebrow="Elegí por situación"
+      title="No necesitás saber qué pedir"
+      description="Marcá el caso que más se parece a tu negocio y te llevo al tipo de solución que conviene revisar primero."
+      icon="help"
+    />
+    <a
+      href="/servicios"
+      class="premium-button inline-flex w-full max-w-full items-center justify-center rounded-2xl border border-line bg-surface-glass px-5 py-3 text-center text-sm font-semibold text-slate-50 hover:-translate-y-0.5 hover:border-line-strong hover:text-cyan-electric sm:w-fit"
+    >
+      Ver servicios completos
+    </a>
+  </div>
+
+  <div class="mt-8 grid min-w-0 gap-4 md:grid-cols-2 xl:gap-5">
+    {
+      options.map((option) => (
+        <GlowCard class="h-full p-5 sm:p-6">
+          <div class="flex min-w-0 items-start justify-between gap-4">
+            <IconBubble icon={option.icon} tone={option.tone} label={option.recommended} />
+            <VisualBadge label="Recomendado" tone={option.tone} compact />
+          </div>
+
+          <div class="mt-5 min-w-0">
+            <p class="mobile-safe-text text-sm font-semibold uppercase tracking-[0.12em] text-muted-soft">
+              {option.situation}
+            </p>
+            <h3 class="mobile-safe-text mt-2 break-words text-xl font-semibold tracking-tight text-slate-50">
+              {option.recommended}
+            </h3>
+            <p class="mobile-safe-text mt-3 text-sm leading-6 text-muted-soft">
+              {option.explanation}
+            </p>
+          </div>
+
+          <a
+            href={waLink(option.message)}
+            target="_blank"
+            rel="noopener noreferrer"
+            class="premium-button mt-5 inline-flex w-full max-w-full items-center justify-center rounded-2xl bg-gradient-to-r from-cyan-electric to-blue-electric px-5 py-3 text-center text-sm font-semibold text-ink shadow-[0_16px_40px_rgba(34,211,238,0.16)] hover:-translate-y-0.5 hover:shadow-[0_18px_44px_rgba(59,130,246,0.22)] sm:w-fit"
+          >
+            {option.cta}
+          </a>
+        </GlowCard>
+      ))
+    }
+  </div>
+</section>

--- a/src/lib/contact.ts
+++ b/src/lib/contact.ts
@@ -21,6 +21,18 @@ export const DEMO_WHATSAPP_MESSAGE =
 export const AUDIT_WHATSAPP_MESSAGE =
   "Hola Diego, te paso mi Instagram, web o idea para que me recomiendes qué construir primero.\n\nRubro: ___\nLink actual: ___\nQuiero lograr: ___\nCreo que necesito: demo / landing / agenda / panel.";
 
+export const SELECTOR_DEMO_WHATSAPP_MESSAGE =
+  "Hola Diego, creo que necesito una demo para mi rubro. Mi negocio es: ___ y mi Instagram/web es: ___";
+
+export const SELECTOR_LANDING_WHATSAPP_MESSAGE =
+  "Hola Diego, quiero cotizar una landing. Mi negocio es: ___ y el servicio/oferta principal es: ___";
+
+export const SELECTOR_AGENDA_WHATSAPP_MESSAGE =
+  "Hola Diego, quiero revisar un flujo de WhatsApp/agenda. Hoy me escriben por: ___ y necesito que el cliente mande: ___";
+
+export const SELECTOR_PANEL_WHATSAPP_MESSAGE =
+  "Hola Diego, quiero consultar por un panel simple. Hoy manejo datos en: ___ y necesito ver/editar: ___";
+
 export function SERVICE_WHATSAPP_MESSAGE(planName: string) {
   return `Hola Diego, quiero consultar por ${planName}.\n\nMi negocio es: ___\nNecesito resolver: ___\nHoy tengo: Instagram / WhatsApp / web actual.`;
 }

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -9,6 +9,7 @@ import ProductizedServices from '../components/ProductizedServices.astro';
 import SocialProofStrip from '../components/SocialProofStrip.astro';
 import VerticalDemos from '../components/VerticalDemos.astro';
 import OutcomeGrid from '../components/OutcomeGrid.astro';
+import NeedSelector from '../components/NeedSelector.astro';
 import ConversionFlow from '../components/ConversionFlow.astro';
 import { getCollection } from 'astro:content';
 import { DEMO_WHATSAPP_MESSAGE } from '../lib/contact';
@@ -34,6 +35,7 @@ const homeCases = destacados.length > 0 ? destacados : proyectos.slice(0, HOME_C
   <SocialProofStrip />
 
   <OutcomeGrid />
+  <NeedSelector />
   <ConversionFlow />
 
   <FeaturedCases projects={homeCases} />


### PR DESCRIPTION
### Motivation
- Mejorar la conversión ayudando a visitantes que no saben qué servicio pedir a identificarse por situación y recibir una recomendación clara. 
- Reducir fricción en el primer contacto proporcionando CTAs a WhatsApp con mensajes pre-armados según la situación del negocio. 

### Description
- Se agregó el componente `src/components/NeedSelector.astro` que muestra cuatro cards compactas (Idea/Instagram → Demo, Oferta definida → Landing, Mensajes incompletos → Web con WhatsApp/Agenda, Planillas → Panel simple) usando los componentes visuales existentes (`GlowCard`, `IconBubble`, `VisualBadge`, `SectionHeader`).
- Se añadieron mensajes predefinidos específicos para cada selector en `src/lib/contact.ts` (`SELECTOR_DEMO_WHATSAPP_MESSAGE`, `SELECTOR_LANDING_WHATSAPP_MESSAGE`, `SELECTOR_AGENDA_WHATSAPP_MESSAGE`, `SELECTOR_PANEL_WHATSAPP_MESSAGE`) y se reutiliza el helper `waLink` para generar los enlaces a WhatsApp sin cambiar el número ni datos de contacto existentes.
- Se insertó el selector en la home (`src/pages/index.astro`) justo después de `OutcomeGrid` y antes de `ConversionFlow`, y se incluyó un enlace secundario `Ver servicios completos` a `/servicios` sin alterar rutas ni precios.

### Testing
- Ejecutado `npm run build` y la compilación está exitosa (`14 page(s) built`, build completa). ✅
- Ejecutado el chequeo de layout móvil `npm run check:mobile-layout` y pasó el contrato de layout móvil (8 checks) sin overflow detectado. ✅
- Ejecutado `npx prettier --check src/lib/contact.ts` que pasó para el archivo modificado de JS/TS; Prettier no infiere parser para archivos `.astro` en la configuración actual (advertencia no bloqueante). ℹ️
- Ejecutado `npm run lint` falló por ausencia de `eslint.config.*` en la configuración del repo; esto es una limitación del entorno actual y no se cambiaron reglas de lint en este PR. ⚠️

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03ea6f8f448328890aff651a9b2387)