### PR TITLE
Lower‑commitment global CTA: “Mandar Instagram y rubro” + WhatsApp message update

### DIFF
--- a/src/components/BrowserMockup.astro
+++ b/src/components/BrowserMockup.astro
@@ -81,7 +81,7 @@ const sideCards = [
 
         <div class="min-w-0 rounded-2xl border border-emerald-300/20 bg-emerald-400/10 p-4">
           <p class="break-words text-xs font-semibold uppercase tracking-[0.1em] text-emerald-100 sm:tracking-[0.18em]">Nueva consulta</p>
-          <p class="mt-2 text-sm leading-6 text-muted-soft">“Quiero una demo. Rubro: estética. Servicio: depilación.”</p>
+          <p class="mt-2 text-sm leading-6 text-muted-soft">“Mi rubro es estética y mi Instagram/web es: ___.”</p>
         </div>
       </div>
 

--- a/src/components/ContactCTA.astro
+++ b/src/components/ContactCTA.astro
@@ -3,7 +3,7 @@ import Icon from './Icon.astro';
 import SectionHeader from './SectionHeader.astro';
 import VisualBadge from './VisualBadge.astro';
 import {
-  AUDIT_WHATSAPP_MESSAGE,
+  DEFAULT_WHATSAPP_MESSAGE,
   EMAIL,
   INSTAGRAM_HANDLE,
   INSTAGRAM_URL,
@@ -14,8 +14,8 @@ const {
   eyebrow = 'Brief por WhatsApp',
   title = 'Pasame tu idea y vemos qué conviene construir primero',
   description = 'Mandame tu Instagram, web actual o una explicación corta. Te respondo con una dirección posible: demo, landing, agenda o panel simple.',
-  primaryLabel = 'Enviar brief por WhatsApp',
-  primaryMessage = AUDIT_WHATSAPP_MESSAGE,
+  primaryLabel = 'Mandar Instagram y rubro',
+  primaryMessage = DEFAULT_WHATSAPP_MESSAGE,
   secondaryLabel = 'Ver proyectos',
   secondaryHref = '/proyectos',
 } = Astro.props;
@@ -30,7 +30,7 @@ const contactMethods = [
   {
     label: 'WhatsApp',
     description: 'Para mandar rubro, link y objetivo.',
-    cta: 'Enviar brief',
+    cta: 'Mandar datos',
     href: waLink(primaryMessage),
     icon: 'message',
     external: true,
@@ -78,7 +78,11 @@ const contactMethods = [
           {trustBadges.map((badge) => <VisualBadge label={badge.label} icon={badge.icon} tone={badge.tone} />)}
         </div>
 
-        <div class="mt-8 flex min-w-0 max-w-full flex-col gap-3 sm:flex-row">
+        <p class="mt-5 max-w-xl text-sm leading-6 text-muted-soft">
+          No necesitás tener el alcance definido. Con tu rubro y link actual alcanza para orientarte.
+        </p>
+
+        <div class="mt-6 flex min-w-0 max-w-full flex-col gap-3 sm:flex-row">
           <a
             href={waLink(primaryMessage)}
             target="_blank"

--- a/src/components/HeroV2.astro
+++ b/src/components/HeroV2.astro
@@ -2,7 +2,7 @@
 import BrowserMockup from './BrowserMockup.astro';
 import IconBubble from './IconBubble.astro';
 import VisualBadge from './VisualBadge.astro';
-import { waLink, DEMO_WHATSAPP_MESSAGE } from '../lib/contact';
+import { waLink, DEFAULT_WHATSAPP_MESSAGE } from '../lib/contact';
 
 const mobileHeroBadges = [
   { label: 'WhatsApp preparado', icon: 'message', tone: 'emerald' },
@@ -65,12 +65,12 @@ const mobileFlow = [
 
       <div class="mt-7 flex min-w-0 max-w-full flex-col gap-3 sm:mt-8 sm:flex-row">
         <a
-          href={waLink(DEMO_WHATSAPP_MESSAGE)}
+          href={waLink(DEFAULT_WHATSAPP_MESSAGE)}
           target="_blank"
           rel="noopener noreferrer"
           class="premium-button inline-flex min-h-12 w-full max-w-full items-center justify-center whitespace-normal rounded-2xl bg-brand-gradient px-5 py-3 text-center text-sm font-semibold leading-5 text-white shadow-glow hover:-translate-y-0.5 hover:shadow-premium-hover sm:w-auto sm:px-6"
         >
-          Quiero una demo para mi negocio
+          Mandar Instagram y rubro
         </a>
         <a
           href="#casos"
@@ -79,6 +79,9 @@ const mobileFlow = [
           Ver proyectos
         </a>
       </div>
+      <p class="mt-3 max-w-xl text-sm leading-6 text-muted-soft">
+        No necesitás tener el alcance definido. Con tu rubro y link actual alcanza para orientarte.
+      </p>
 
       <div class="mt-5 grid w-full max-w-full grid-cols-1 gap-2.5 sm:hidden" aria-label="Señales de confianza">
         {trustBadges.map((badge) => (

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -54,7 +54,8 @@ const current = Astro.url.pathname;
         target="_blank"
         rel="noopener noreferrer"
       >
-        Pedir demo
+        <span class="lg:hidden">Mandar rubro</span>
+        <span class="hidden lg:inline">Mandar Instagram y rubro</span>
       </a>
     </div>
 
@@ -120,7 +121,7 @@ const current = Astro.url.pathname;
           target="_blank"
           rel="noopener noreferrer"
         >
-          Pedir demo por WhatsApp
+          Mandar Instagram y rubro
         </a>
       </li>
     </ul>

--- a/src/lib/contact.ts
+++ b/src/lib/contact.ts
@@ -13,13 +13,12 @@ export const WHATSAPP_NUMBER_E164 = "59897316092"; // UY (+598) + 97316092
 export const WHATSAPP_BASE_URL = `https://wa.me/${WHATSAPP_NUMBER_E164}`;
 
 export const DEFAULT_WHATSAPP_MESSAGE =
-  "Hola Diego, quiero mejorar mi web o Instagram. Mi negocio es: ___ y hoy necesito: demo / landing / agenda / panel.";
+  "Hola Diego, quiero saber qué conviene construir primero. Mi rubro es: ___ y mi Instagram/web es: ___.\n\nHoy necesito: más consultas / turnos / pedidos / mostrar una idea / manejar datos.";
 
 export const DEMO_WHATSAPP_MESSAGE =
   "Hola Diego, quiero una demo para mi negocio. Mi rubro es: ___ y hoy atiendo/vendo por: Instagram / WhatsApp / web actual.";
 
-export const AUDIT_WHATSAPP_MESSAGE =
-  "Hola Diego, te paso mi Instagram, web o idea para que me recomiendes qué construir primero.\n\nRubro: ___\nLink actual: ___\nQuiero lograr: ___\nCreo que necesito: demo / landing / agenda / panel.";
+export const AUDIT_WHATSAPP_MESSAGE = DEFAULT_WHATSAPP_MESSAGE;
 
 export const SELECTOR_DEMO_WHATSAPP_MESSAGE =
   "Hola Diego, creo que necesito una demo para mi rubro. Mi negocio es: ___ y mi Instagram/web es: ___";

--- a/src/pages/contacto.astro
+++ b/src/pages/contacto.astro
@@ -8,7 +8,7 @@ import BaseLayout from "../layouts/BaseLayout.astro";
 import Container from "../components/Container.astro";
 import GlowCard from "../components/GlowCard.astro";
 import {
-  AUDIT_WHATSAPP_MESSAGE,
+  DEFAULT_WHATSAPP_MESSAGE,
   EMAIL,
   GITHUB_URL,
   INSTAGRAM_HANDLE,
@@ -52,8 +52,8 @@ const budgetRanges = [
 const contactCards = [
   {
     label: "WhatsApp directo",
-    value: "Enviar brief guiado",
-    href: waLink(AUDIT_WHATSAPP_MESSAGE),
+    value: "Mandar Instagram y rubro",
+    href: waLink(DEFAULT_WHATSAPP_MESSAGE),
   },
   {
     label: "Instagram",
@@ -201,7 +201,7 @@ const contactCards = [
 
           <div class="mt-6 flex flex-col gap-3 sm:flex-row sm:items-center">
             <button type="submit" class="inline-flex w-full items-center justify-center rounded-2xl bg-brand-gradient px-6 py-3 text-sm font-semibold text-white shadow-glow transition hover:-translate-y-0.5 hover:shadow-premium-hover sm:w-auto">
-              Enviar brief por WhatsApp
+              Mandar Instagram y rubro
             </button>
             <a class="inline-flex w-full items-center justify-center rounded-2xl border border-line bg-white/[0.04] px-6 py-3 text-sm font-semibold text-slate-100 transition hover:border-cyan-electric/40 hover:bg-white/[0.07] sm:w-auto" href={WHATSAPP_BASE_URL} target="_blank" rel="noopener noreferrer">
               Abrir WhatsApp directo
@@ -238,13 +238,13 @@ const contactCards = [
       const mensaje = String(data.get('mensaje') || '').trim();
 
       const lines = [
-        `Hola Diego, te mando datos de mi proyecto para que me recomiendes qué construir primero.`,
+        `Hola Diego, quiero saber qué conviene construir primero.`,
         '',
         nombre ? `Nombre: ${nombre}` : null,
         email ? `Email: ${email}` : null,
-        `Rubro: ${rubro || '[rubro]'}`,
-        `Link actual: ${referencia || '[Instagram, web o referencia]'}`,
-        `Qué quiero lograr: ${objetivo || '[más consultas / reservas / ventas / sistema interno / otro]'}`,
+        `Mi rubro es: ${rubro || '[rubro]'}`,
+        `Mi Instagram/web es: ${referencia || '[Instagram, web o referencia]'}`,
+        `Hoy necesito: ${objetivo || '[más consultas / turnos / pedidos / mostrar una idea / manejar datos]'}`,
         `Servicio que creo necesitar: ${interes || '[demo / landing / agenda / panel / no sé todavía]'}`,
         presupuesto && presupuesto !== 'Todavía no lo sé' ? `Presupuesto: ${presupuesto}` : null,
       ].filter((line) => line !== null);

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -12,7 +12,7 @@ import OutcomeGrid from '../components/OutcomeGrid.astro';
 import NeedSelector from '../components/NeedSelector.astro';
 import ConversionFlow from '../components/ConversionFlow.astro';
 import { getCollection } from 'astro:content';
-import { DEMO_WHATSAPP_MESSAGE } from '../lib/contact';
+import { DEFAULT_WHATSAPP_MESSAGE } from '../lib/contact';
 
 let proyectos = await getCollection('proyectos');
 proyectos = proyectos.sort((a, b) => {
@@ -47,8 +47,8 @@ const homeCases = destacados.length > 0 ? destacados : proyectos.slice(0, HOME_C
     eyebrow="Listo para empezar"
     title="Mandame tu Instagram o web y te digo qué conviene construir primero."
     description="Puede ser una demo, landing, agenda o panel: elegimos el primer entregable según tus servicios, precios, horarios y datos para cotizar."
-    primaryLabel="Quiero una demo para mi negocio"
-    primaryMessage={DEMO_WHATSAPP_MESSAGE}
+    primaryLabel="Mandar Instagram y rubro"
+    primaryMessage={DEFAULT_WHATSAPP_MESSAGE}
     secondaryLabel="Ver demos por rubro"
     secondaryHref="#casos"
   />

--- a/src/pages/servicios.astro
+++ b/src/pages/servicios.astro
@@ -3,7 +3,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 import ContactCTA from '../components/ContactCTA.astro';
 import FAQs from '../components/FAQs.astro';
 import PricingPlans from '../components/PricingPlans.astro';
-import { SERVICE_WHATSAPP_MESSAGE } from '../lib/contact';
+import { DEFAULT_WHATSAPP_MESSAGE } from '../lib/contact';
 
 const title = 'Servicios productizados – Marin.dev';
 const description = 'Demos, landings, webs con WhatsApp/agenda y paneles simples para validar ofertas, recibir mejores mensajes o manejar datos básicos.';
@@ -64,8 +64,8 @@ const serviceHighlights = [
     eyebrow="¿No sabés cuál elegir?"
     title="Mandame tu rubro, Instagram o web y te recomiendo el punto de partida."
     description="Te respondo con un punto de partida y qué datos necesito: rubro, servicios, precios/rangos, turnos o campos del panel."
-    primaryLabel="Mandar datos del proyecto"
-    primaryMessage={SERVICE_WHATSAPP_MESSAGE('Servicios Marin.dev')}
+    primaryLabel="Mandar Instagram y rubro"
+    primaryMessage={DEFAULT_WHATSAPP_MESSAGE}
     secondaryLabel="Ver casos"
     secondaryHref="/proyectos"
   />


### PR DESCRIPTION
### Motivation
- Reduce friction for cold visitors by replacing broad/global CTAs that ask for a specific deliverable with a lower‑commitment action that requests `Instagram` and `rubro` so visitors can get an orientation without choosing a solution upfront. 
- Keep existing service‑specific CTAs (e.g. `Pedir demo para mi rubro`, `Cotizar landing`, `Consultar panel simple`) unchanged so warm leads can still select a concrete next step.

### Description
- Replaced broad CTA labels with the lower‑commitment copy `Mandar Instagram y rubro` across hero, final home CTA, services fallback CTA, contact entry points, and nav CTAs, using `DEFAULT_WHATSAPP_MESSAGE` as the prefilled message; files changed: `src/components/HeroV2.astro`, `src/pages/index.astro`, `src/pages/servicios.astro`, `src/components/Nav.astro`, `src/components/ContactCTA.astro`, `src/pages/contacto.astro`, `src/components/BrowserMockup.astro`, and `src/lib/contact.ts`.
- Updated the default WhatsApp prefilled text in `src/lib/contact.ts` to: `Hola Diego, quiero saber qué conviene construir primero. Mi rubro es: ___ y mi Instagram/web es: ___.\n\nHoy necesito: más consultas / turnos / pedidos / mostrar una idea / manejar datos.` and made `AUDIT_WHATSAPP_MESSAGE` point to that same default for consistency.
- Added short microcopy near the CTAs: `No necesitás tener el alcance definido. Con tu rubro y link actual alcanza para orientarte.` to reassure cold visitors; also updated a mockup sample line to match the new phrasing in `BrowserMockup.astro`.
- Left all service chooser messages and specific action messages intact (files such as `src/data/services.ts` and `src/components/NeedSelector.astro` still provide targeted CTAs and messages).

### Testing
- `npm run build` completed successfully and produced the static output with all pages built (14 pages built). ✅
- `npm run check:mobile-layout` passed the mobile layout contract checks. ✅
- `npm run audit:mobile-patterns` ran successfully and reported existing non‑failing warnings to review manually. ✅ (warnings only)
- `npm run lint` failed due to repository ESLint configuration expectations (`eslint` v9 expects an `eslint.config.*` file), so lint did not pass in this environment. ⚠️
- `npx prettier --write` reported parser issues for `.astro` files in this environment (no Astro parser available), so formatting of `.astro` files was not completed by Prettier here. ⚠️
- Attempt to run `npx --yes playwright --version` failed due to npm registry access restrictions in this environment, so no browser automation checks could be executed. ⚠️

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03efc6a4108328a94a0e1da3ae5338)