### PR TITLE
Add 'capacidad' (demonstrated capability) to projects and surface it in cards/details

### DIFF
--- a/docs/portfolio-cro-notes.md
+++ b/docs/portfolio-cro-notes.md
@@ -1,0 +1,28 @@
+# Portfolio CRO notes — Capacidad demostrada
+
+Fecha: 2026-05-13
+
+## Propósito del campo `capacidad`
+
+El campo opcional `capacidad` explica, en una frase corta, qué habilidad o tipo de entregable prueba cada proyecto del portfolio. Su objetivo es que una persona que mira cards rápidamente entienda qué puede construir Marin.dev sin depender de métricas inventadas ni de explicaciones técnicas largas.
+
+## Reglas editoriales
+
+- Mantener una sola frase breve por proyecto.
+- Nombrar módulos concretos: agenda, WhatsApp, carta, dashboard, contenido editable, contacto o reservas.
+- No usar porcentajes, aumentos ni resultados cuantitativos si no están documentados.
+- Evitar repetir exactamente el `resumen`, el `highlight` o el `impacto`.
+- En cards, mostrarlo compacto con la etiqueta “Demuestra”.
+- En el detalle del proyecto, ampliarlo visualmente como “Qué demuestra este caso”.
+
+## Cobertura actual
+
+Todos los proyectos actuales tienen `capacidad` definida:
+
+- Smart Stock: dashboard operativo de inventario.
+- VetCare: demo vertical con turnos, urgencias y ficha de mascota.
+- Noir Barber Studio: landing premium con servicios, precios y reserva mobile.
+- Brasa 23: carta digital con ubicación, ambiente y reserva/pedido.
+- Cristal Sagrado: landing de servicios con contenido editable y CTA comercial.
+- Agencia Ariel: web corporativa real para servicios y contacto.
+- Servicio de Tarot: página liviana para confianza y WhatsApp.

--- a/src/components/FeaturedCases.astro
+++ b/src/components/FeaturedCases.astro
@@ -42,6 +42,7 @@ const { projects = [] } = Astro.props;
           businessType={p.data.businessType}
           resultLabel={p.data.resultLabel}
           highlight={p.data.highlight}
+          capacidad={p.data.capacidad}
           visualTone={p.data.visualTone}
           badges={p.data.badges}
           status={p.data.status}

--- a/src/components/ProjectCard.astro
+++ b/src/components/ProjectCard.astro
@@ -22,6 +22,7 @@ const {
   businessType = '',
   resultLabel = '',
   highlight = '',
+  capacidad = '',
   visualTone = '',
   badges = [],
   status = '',
@@ -75,6 +76,7 @@ const businessLabel = businessType || sector || commercialType;
 const normalizeCopy = (value = '') => String(value).trim().replace(/\s+/g, ' ');
 const highlightCopy = normalizeCopy(highlight);
 const benefitOptions = [
+  { label: 'Demuestra', value: capacidad },
   { label: 'Qué permite', value: resultLabel },
   { label: 'Qué demuestra', value: impacto },
   { label: 'Resultado', value: resultado },

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -21,6 +21,7 @@ const proyectos = defineCollection({
     businessType: z.string().optional(),
     resultLabel: z.string().optional(),
     highlight: z.string().optional(),
+    capacidad: z.string().optional(),
     visualTone: z
       .enum(["cyan", "violet", "emerald", "amber", "rose", "neutral"])
       .optional(),

--- a/src/content/proyectos/Agencia_ariel.mdx
+++ b/src/content/proyectos/Agencia_ariel.mdx
@@ -12,6 +12,7 @@ badges:
   - Contacto
   - Mobile
 highlight: "Web corporativa para explicar servicios logísticos, cobertura y canales de contacto."
+capacidad: "Web corporativa real para explicar servicios y centralizar contacto."
 resultLabel: "Convierte una empresa tradicional en una presencia consultable y seria fuera de redes."
 rol: "Desarrollador Frontend"
 stack:

--- a/src/content/proyectos/brasa-23.mdx
+++ b/src/content/proyectos/brasa-23.mdx
@@ -12,6 +12,7 @@ badges:
   - Pedido
   - Ubicación
 highlight: "Carta digital, ambiente del restaurante, ubicación y reserva/pedido en un solo link."
+capacidad: "Carta digital con ubicación, ambiente y reserva/pedido."
 resultLabel: "El cliente no tiene que buscar menú, horario y contacto entre posts o PDFs."
 rol: "Diseño UI y desarrollo Frontend"
 stack:

--- a/src/content/proyectos/cristal-sagrado.mdx
+++ b/src/content/proyectos/cristal-sagrado.mdx
@@ -12,6 +12,7 @@ badges:
   - Consultas
   - Marca cuidada
 highlight: "Landing de servicios con panel/admin liviano para actualizar la oferta."
+capacidad: "Landing de servicios con contenido editable y CTA comercial."
 image: "https://cristal-sagrado.com/favicon_io/cristal_sagrado.png"
 rol: "Desarrollador Frontend"
 stack:

--- a/src/content/proyectos/noir-barber-studio.mdx
+++ b/src/content/proyectos/noir-barber-studio.mdx
@@ -12,6 +12,7 @@ badges:
   - Estética premium
   - Mobile-first
 highlight: "Identidad oscura premium, menú de servicios, precios y CTA de reserva."
+capacidad: "Landing visual premium con servicios, precios y reserva mobile."
 resultLabel: "Funciona como link principal desde Instagram para ver estilo, servicios y reservar."
 rol: "Diseño UI y desarrollo Frontend"
 stack:

--- a/src/content/proyectos/servicio-de-tarot.mdx
+++ b/src/content/proyectos/servicio-de-tarot.mdx
@@ -12,6 +12,7 @@ badges:
   - Mobile-first
   - SEO básico
 highlight: "Página liviana con presentación del servicio, confianza inicial y CTA directo a WhatsApp."
+capacidad: "Página liviana para servicio personal con confianza y WhatsApp."
 rol: "Desarrollador Frontend"
 stack:
   - html

--- a/src/content/proyectos/smart-stock.mdx
+++ b/src/content/proyectos/smart-stock.mdx
@@ -12,6 +12,7 @@ badges:
   - Compras
   - Datos POS
 highlight: "Dashboard demo con productos, stock, compras, estados e indicadores."
+capacidad: "Dashboard operativo con productos, stock, compras y estados."
 resultLabel: "Permite mostrar flujo de inventario sin exponer datos reales ni prometer un SaaS terminado."
 rol: "Desarrollador Frontend"
 stack:

--- a/src/content/proyectos/vetcare.mdx
+++ b/src/content/proyectos/vetcare.mdx
@@ -12,6 +12,7 @@ badges:
   - WhatsApp
   - Portal mascota
 highlight: "Agenda de turnos, urgencias, ficha de mascota y contacto por WhatsApp."
+capacidad: "Demo vertical con turnos, urgencias y ficha básica de mascota."
 resultLabel: "Una veterinaria puede mostrar atención común y urgencias sin mezclar todo en un mismo chat."
 rol: "Diseño UI y desarrollo Frontend"
 stack:

--- a/src/pages/proyectos/[slug].astro
+++ b/src/pages/proyectos/[slug].astro
@@ -35,6 +35,7 @@ const {
   idealPara,
   features = [],
   impacto,
+  capacidad,
   status,
 } = proyecto.data;
 
@@ -102,6 +103,13 @@ const whatsappText = PROJECT_WHATSAPP_MESSAGE(title);
 
         <ProjectLinkPreview title={title} url={demoUrl} cover={image || cover} thumbnail={thumbnail} slug={proyecto.slug} eager />
       </header>
+
+      {capacidad && (
+        <section class="mt-10 min-w-0 rounded-3xl border border-cyan-electric/25 bg-cyan-electric/10 p-6 shadow-premium backdrop-blur">
+          <p class="break-words text-sm font-semibold uppercase tracking-[0.1em] text-cyan-electric sm:tracking-[0.2em]">Qué demuestra este caso</p>
+          <p class="mt-3 text-base leading-7 text-cyan-50/90">{capacidad}</p>
+        </section>
+      )}
 
       <section class="mt-12 grid min-w-0 gap-5 lg:grid-cols-3">
         {idealPara && (

--- a/src/pages/proyectos/index.astro
+++ b/src/pages/proyectos/index.astro
@@ -55,6 +55,7 @@ const proyectos = (await getCollection('proyectos')).sort(byCommercialPriority);
           businessType={p.data.businessType}
           resultLabel={p.data.resultLabel}
           highlight={p.data.highlight}
+          capacidad={p.data.capacidad}
           visualTone={p.data.visualTone}
           badges={p.data.badges}
           status={p.data.status}


### PR DESCRIPTION
### Motivation
- Ayudar a visitantes a entender rápidamente qué capacidad concreta demuestra cada proyecto sin añadir métricas inventadas ni alargar las cards. 
- Mantener la presentación compacta en mobile y ofrecer algo más visible en la página de detalle del caso.

### Description
- Añadido campo opcional `capacidad` al schema de la colección de proyectos en `src/content/config.ts` y pobladas las frontmatter de los proyectos actuales con frases cortas en español (`src/content/proyectos/*.mdx`).
- Actualizado `src/components/ProjectCard.astro` para aceptar la prop `capacidad` y priorizarla en el bloque compacto mostrado en la card con la etiqueta `Demuestra` sin agregar párrafos largos en mobile.
- Pasado `capacidad` desde `src/components/FeaturedCases.astro` y `src/pages/proyectos/index.astro` para que los casos destacados también muestren la señal compacta.
- Insertada una sección destacada `Qué demuestra este caso` en la plantilla de detalle `src/pages/proyectos/[slug].astro` que muestra `capacidad` con mayor prominencia cuando existe.
- Añadido documento `docs/portfolio-cro-notes.md` que explica el propósito editorial y las reglas para escribir `capacidad`.

### Testing
- Ejecutado `npm run build` y la compilación finalizó correctamente with static pages generated (build passed).
- Ejecutado `npm run check:mobile-layout` y la comprobación de contrato móvil pasó (`Mobile layout contract passed`).
- Ejecutado `npm run audit:mobile-patterns` que devolvió solo advertencias para revisión manual (warnings only), no fallos.
- Verificado que no se añadieron métricas inventadas y que la altura de las cards móviles no aumentó por nuevas secciones compactas.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03f6f39b648328bcca59c87764d260)