### PR TITLE
Centralize contextual WhatsApp lead intents

### DIFF
--- a/docs/whatsapp-intents.md
+++ b/docs/whatsapp-intents.md
@@ -1,0 +1,12 @@
+# WhatsApp intents
+
+Los CTA principales abren WhatsApp con mensajes precompletados desde `src/lib/contact.ts`. La intención es que Diego reciba contexto mínimo sin obligar al lead a completar un briefing largo.
+
+| CTA source                                             | Message pattern                                                                                        | Expected lead context                                                                    |
+| ------------------------------------------------------ | ------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------- |
+| Hero, navegación, footer, CTA final y contacto directo | `Hola Diego, quiero saber qué conviene construir primero. Mi rubro es: ___ y mi Instagram/web es: ___` | Rubro del negocio y link actual para orientar si conviene demo, landing, agenda o panel. |
+| NeedSelector cards                                     | `Hola Diego, quiero consultar por [service]. Mi negocio es: ___ y hoy necesito resolver: ___`          | Servicio recomendado por situación y problema inicial que quiere resolver.               |
+| VerticalDemos cards                                    | `Hola Diego, quiero una demo para [vertical]. Mi Instagram/web es: ___`                                | Rubro específico de la demo y referencia actual del negocio.                             |
+| Service cards / pricing plans                          | `Hola Diego, quiero consultar por [service]. Mi negocio es: ___ y hoy necesito resolver: ___`          | Paquete de interés, tipo de negocio y necesidad operativa/comercial.                     |
+| Project cards and case-study CTA                       | `Hola Diego, vi el caso [project] y quiero algo parecido para mi negocio. Mi rubro es: ___`            | Caso visto como referencia y rubro donde quiere aplicar una solución similar.            |
+| Contact form                                           | Mensaje armado con rubro, Instagram/web, objetivo, interés y datos opcionales.                         | Datos estructurados del formulario sin convertir el WhatsApp en un briefing largo.       |

--- a/src/components/NeedSelector.astro
+++ b/src/components/NeedSelector.astro
@@ -3,13 +3,7 @@ import GlowCard from './GlowCard.astro';
 import IconBubble from './IconBubble.astro';
 import SectionHeader from './SectionHeader.astro';
 import VisualBadge from './VisualBadge.astro';
-import {
-  SELECTOR_AGENDA_WHATSAPP_MESSAGE,
-  SELECTOR_DEMO_WHATSAPP_MESSAGE,
-  SELECTOR_LANDING_WHATSAPP_MESSAGE,
-  SELECTOR_PANEL_WHATSAPP_MESSAGE,
-  waLink,
-} from '../lib/contact';
+import { getServiceLeadMessage, waLink } from '../lib/contact';
 
 const options = [
   {
@@ -17,8 +11,8 @@ const options = [
     recommended: 'Demo Comercial Express',
     explanation:
       'Sirve para mostrar una versión navegable del negocio antes de invertir en una web o sistema completo.',
-    cta: 'Pedir demo para mi rubro',
-    message: SELECTOR_DEMO_WHATSAPP_MESSAGE,
+    cta: 'Consultar este paquete',
+    message: getServiceLeadMessage('Demo Comercial Express'),
     icon: 'rocket',
     tone: 'cyan',
   },
@@ -27,8 +21,8 @@ const options = [
     recommended: 'Landing de Conversión',
     explanation:
       'Sirve para presentar una oferta, explicar el servicio, responder dudas y llevar al cliente a WhatsApp.',
-    cta: 'Cotizar landing',
-    message: SELECTOR_LANDING_WHATSAPP_MESSAGE,
+    cta: 'Consultar este paquete',
+    message: getServiceLeadMessage('Landing de Conversión'),
     icon: 'target',
     tone: 'emerald',
   },
@@ -37,8 +31,8 @@ const options = [
     recommended: 'Web con WhatsApp / Agenda',
     explanation:
       'Sirve cuando necesitás que el cliente elija servicio, horario, rubro o datos antes de escribir.',
-    cta: 'Consultar flujo de turnos',
-    message: SELECTOR_AGENDA_WHATSAPP_MESSAGE,
+    cta: 'Consultar este paquete',
+    message: getServiceLeadMessage('Web con WhatsApp / Agenda'),
     icon: 'message',
     tone: 'violet',
   },
@@ -47,8 +41,8 @@ const options = [
     recommended: 'Sistema simple / Panel Admin',
     explanation:
       'Sirve para ver, editar o revisar datos básicos como productos, stock, leads, turnos o estados.',
-    cta: 'Consultar panel simple',
-    message: SELECTOR_PANEL_WHATSAPP_MESSAGE,
+    cta: 'Consultar este paquete',
+    message: getServiceLeadMessage('Sistema simple / Panel Admin'),
     icon: 'database',
     tone: 'amber',
   },

--- a/src/components/PricingPlans.astro
+++ b/src/components/PricingPlans.astro
@@ -6,7 +6,7 @@ import IconBubble from './IconBubble.astro';
 import SectionHeader from './SectionHeader.astro';
 import VisualBadge from './VisualBadge.astro';
 import { servicePlans as plans } from '../data/services';
-import { SERVICE_WHATSAPP_MESSAGE, waLink } from '../lib/contact';
+import { getServiceLeadMessage, waLink } from '../lib/contact';
 
 const chooserItems = plans.map(({ name, chooser, comparison, tone }) => ({
   name,
@@ -148,7 +148,7 @@ const chooserItems = plans.map(({ name, chooser, comparison, tone }) => ({
         <div class="mt-auto pt-6">
           <p class="mb-3 text-xs font-medium text-muted-soft">Enfoque: {plan.comparison}</p>
           <a
-            href={waLink(SERVICE_WHATSAPP_MESSAGE(plan.name))}
+            href={waLink(getServiceLeadMessage(plan.name))}
             target="_blank"
             rel="noopener noreferrer"
             class={`inline-flex w-full max-w-full items-center justify-center gap-2 rounded-2xl px-5 py-3 text-center text-sm font-semibold transition hover:-translate-y-0.5 ${
@@ -158,7 +158,7 @@ const chooserItems = plans.map(({ name, chooser, comparison, tone }) => ({
             }`}
             aria-label={`Consultar el plan ${plan.name} por WhatsApp`}
           >
-            <span>{plan.cta}</span>
+            <span>Consultar este paquete</span>
             <Icon name="arrow" size="sm" />
           </a>
         </div>

--- a/src/components/ProductizedServices.astro
+++ b/src/components/ProductizedServices.astro
@@ -4,7 +4,7 @@ import GlowCard from './GlowCard.astro';
 import SectionHeader from './SectionHeader.astro';
 import VisualBadge from './VisualBadge.astro';
 import { productizedServices } from '../data/services';
-import { waLink, SERVICE_WHATSAPP_MESSAGE } from '../lib/contact';
+import { waLink, getServiceLeadMessage } from '../lib/contact';
 
 const serviceBadges = [
   { label: '3–5 días', icon: 'speed', tone: 'cyan' },
@@ -68,12 +68,12 @@ const serviceBadges = [
           </div>
         </div>
         <a
-          href={waLink(SERVICE_WHATSAPP_MESSAGE(service.name))}
+          href={waLink(getServiceLeadMessage(service.name))}
           target="_blank"
           rel="noopener noreferrer"
           class="premium-button mt-6 inline-flex w-full max-w-full items-center justify-center rounded-2xl border border-line bg-surface-glass px-5 py-3 text-center text-sm font-semibold text-slate-50 hover:-translate-y-0.5 hover:border-line-strong hover:text-cyan-electric"
         >
-          {service.cta}
+          Consultar este paquete
         </a>
       </GlowCard>
     ))}

--- a/src/components/ProjectCard.astro
+++ b/src/components/ProjectCard.astro
@@ -2,6 +2,7 @@
 import Badge from './Badge.astro';
 import { projectVisualAsset } from '../lib/projectGallery';
 import { getProjectVisual } from '../lib/projectVisuals';
+import { getProjectLeadMessage, waLink } from '../lib/contact';
 
 const FEATURE_LIMIT = 4;
 const STACK_LIMIT = 5;
@@ -216,6 +217,9 @@ const copyFocus = highlight || solucion || problema;
       <a href={resolvedCaseUrl} class="premium-button inline-flex w-full max-w-full items-center justify-center gap-2 rounded-2xl bg-brand-gradient px-4 py-2.5 text-center text-sm font-semibold text-white shadow-none sm:w-auto md:shadow-glow">
         {ctaLabel}
         <span aria-hidden="true" class="transition duration-300 group-hover:translate-x-1">→</span>
+      </a>
+      <a href={waLink(getProjectLeadMessage(title))} target="_blank" rel="noreferrer" class="inline-flex w-full max-w-full items-center justify-center gap-1.5 rounded-2xl border border-line bg-surface-glass px-4 py-2.5 text-center text-sm font-semibold text-cyan-electric transition hover:border-line-strong hover:bg-surface-800/70 sm:w-auto">
+        Quiero algo parecido <span aria-hidden="true">↗</span>
       </a>
       {demoUrl && (
         <a href={demoUrl} target="_blank" rel="noreferrer" class="inline-flex w-full max-w-full items-center justify-center gap-1.5 rounded-2xl border border-line bg-surface-glass px-4 py-2.5 text-center text-sm font-semibold text-cyan-electric transition hover:border-line-strong hover:bg-surface-800/70 sm:w-auto">

--- a/src/components/VerticalDemos.astro
+++ b/src/components/VerticalDemos.astro
@@ -4,7 +4,7 @@ import Icon from './Icon.astro';
 import IconBubble from './IconBubble.astro';
 import SectionHeader from './SectionHeader.astro';
 import { verticalDemos } from '../data/verticals';
-import { VERTICAL_WHATSAPP_MESSAGE, waLink } from '../lib/contact';
+import { getVerticalLeadMessage, waLink } from '../lib/contact';
 ---
 <section class="min-w-0 py-14 md:py-20">
   <SectionHeader
@@ -36,7 +36,7 @@ import { VERTICAL_WHATSAPP_MESSAGE, waLink } from '../lib/contact';
         </div>
 
         <a
-          href={waLink(VERTICAL_WHATSAPP_MESSAGE(demo.name))}
+          href={waLink(getVerticalLeadMessage(demo.name))}
           target="_blank"
           rel="noopener noreferrer"
           class="premium-button mt-6 inline-flex w-full max-w-full items-center justify-center gap-2 rounded-2xl border border-line bg-surface-glass px-4 py-2 text-center text-sm font-semibold text-slate-50 hover:-translate-y-0.5 hover:border-cyan-electric/35 hover:text-cyan-electric sm:w-fit"

--- a/src/lib/contact.ts
+++ b/src/lib/contact.ts
@@ -12,39 +12,59 @@ export const INSTAGRAM_URL = "https://www.instagram.com/marin_dev_/";
 export const WHATSAPP_NUMBER_E164 = "59897316092"; // UY (+598) + 97316092
 export const WHATSAPP_BASE_URL = `https://wa.me/${WHATSAPP_NUMBER_E164}`;
 
-export const DEFAULT_WHATSAPP_MESSAGE =
-  "Hola Diego, quiero saber qué conviene construir primero. Mi rubro es: ___ y mi Instagram/web es: ___.\n\nHoy necesito: más consultas / turnos / pedidos / mostrar una idea / manejar datos.";
+const cleanContext = (value: string) => value.trim().replace(/\s+/g, " ");
 
-export const DEMO_WHATSAPP_MESSAGE =
-  "Hola Diego, quiero una demo para mi negocio. Mi rubro es: ___ y hoy atiendo/vendo por: Instagram / WhatsApp / web actual.";
+export function makeWhatsAppUrl(message = getGlobalLeadMessage()) {
+  const text = cleanContext(message);
+  return `${WHATSAPP_BASE_URL}?text=${encodeURIComponent(text)}`;
+}
 
-export const AUDIT_WHATSAPP_MESSAGE = DEFAULT_WHATSAPP_MESSAGE;
+export function getGlobalLeadMessage() {
+  return "Hola Diego, quiero saber qué conviene construir primero. Mi rubro es: ___ y mi Instagram/web es: ___";
+}
 
-export const SELECTOR_DEMO_WHATSAPP_MESSAGE =
-  "Hola Diego, creo que necesito una demo para mi rubro. Mi negocio es: ___ y mi Instagram/web es: ___";
+export function getServiceLeadMessage(serviceName: string) {
+  const service = cleanContext(serviceName || "este paquete");
+  return `Hola Diego, quiero consultar por ${service}. Mi negocio es: ___ y hoy necesito resolver: ___`;
+}
 
-export const SELECTOR_LANDING_WHATSAPP_MESSAGE =
-  "Hola Diego, quiero cotizar una landing. Mi negocio es: ___ y el servicio/oferta principal es: ___";
+export function getVerticalLeadMessage(verticalName: string) {
+  const vertical = cleanContext(verticalName || "mi rubro");
+  return `Hola Diego, quiero una demo para ${vertical}. Mi Instagram/web es: ___`;
+}
 
-export const SELECTOR_AGENDA_WHATSAPP_MESSAGE =
-  "Hola Diego, quiero revisar un flujo de WhatsApp/agenda. Hoy me escriben por: ___ y necesito que el cliente mande: ___";
+export function getProjectLeadMessage(projectName: string) {
+  const project = cleanContext(projectName || "un caso del portfolio");
+  return `Hola Diego, vi el caso ${project} y quiero algo parecido para mi negocio. Mi rubro es: ___`;
+}
 
-export const SELECTOR_PANEL_WHATSAPP_MESSAGE =
-  "Hola Diego, quiero consultar por un panel simple. Hoy manejo datos en: ___ y necesito ver/editar: ___";
+export const DEFAULT_WHATSAPP_MESSAGE = getGlobalLeadMessage();
+export const DEMO_WHATSAPP_MESSAGE = getGlobalLeadMessage();
+export const AUDIT_WHATSAPP_MESSAGE = getGlobalLeadMessage();
+
+export const SELECTOR_DEMO_WHATSAPP_MESSAGE = getServiceLeadMessage(
+  "Demo Comercial Express",
+);
+export const SELECTOR_LANDING_WHATSAPP_MESSAGE = getServiceLeadMessage(
+  "Landing de Conversión",
+);
+export const SELECTOR_AGENDA_WHATSAPP_MESSAGE = getServiceLeadMessage(
+  "Web con WhatsApp / Agenda",
+);
+export const SELECTOR_PANEL_WHATSAPP_MESSAGE = getServiceLeadMessage(
+  "Sistema simple / Panel Admin",
+);
 
 export function SERVICE_WHATSAPP_MESSAGE(planName: string) {
-  return `Hola Diego, quiero consultar por ${planName}.\n\nMi negocio es: ___\nNecesito resolver: ___\nHoy tengo: Instagram / WhatsApp / web actual.`;
+  return getServiceLeadMessage(planName);
 }
 
 export function PROJECT_WHATSAPP_MESSAGE(projectName: string) {
-  return `Hola Diego, vi el caso de ${projectName}. Quiero algo parecido para mi negocio.\n\nMi rubro es: ___.`;
+  return getProjectLeadMessage(projectName);
 }
 
 export function VERTICAL_WHATSAPP_MESSAGE(rubro: string) {
-  return `Hola Diego, quiero una demo para ${rubro}.\n\nHoy atiendo/vendo por: Instagram / WhatsApp / web actual.`;
+  return getVerticalLeadMessage(rubro);
 }
 
-export function waLink(text?: string) {
-  const msg = (text ?? DEFAULT_WHATSAPP_MESSAGE).trim();
-  return `${WHATSAPP_BASE_URL}?text=${encodeURIComponent(msg)}`;
-}
+export const waLink = makeWhatsAppUrl;

--- a/src/pages/contacto.astro
+++ b/src/pages/contacto.astro
@@ -15,7 +15,7 @@ import {
   INSTAGRAM_URL,
   LINKEDIN_URL,
   WHATSAPP_BASE_URL,
-  WHATSAPP_NUMBER_E164,
+  makeWhatsAppUrl,
   waLink,
 } from "../lib/contact";
 
@@ -203,8 +203,8 @@ const contactCards = [
             <button type="submit" class="inline-flex w-full items-center justify-center rounded-2xl bg-brand-gradient px-6 py-3 text-sm font-semibold text-white shadow-glow transition hover:-translate-y-0.5 hover:shadow-premium-hover sm:w-auto">
               Mandar Instagram y rubro
             </button>
-            <a class="inline-flex w-full items-center justify-center rounded-2xl border border-line bg-white/[0.04] px-6 py-3 text-sm font-semibold text-slate-100 transition hover:border-cyan-electric/40 hover:bg-white/[0.07] sm:w-auto" href={WHATSAPP_BASE_URL} target="_blank" rel="noopener noreferrer">
-              Abrir WhatsApp directo
+            <a class="inline-flex w-full items-center justify-center rounded-2xl border border-line bg-white/[0.04] px-6 py-3 text-sm font-semibold text-slate-100 transition hover:border-cyan-electric/40 hover:bg-white/[0.07] sm:w-auto" href={makeWhatsAppUrl(DEFAULT_WHATSAPP_MESSAGE)} target="_blank" rel="noopener noreferrer">
+              Mandar Instagram y rubro
             </a>
           </div>
 
@@ -221,7 +221,7 @@ const contactCards = [
     </section>
   </Container>
 
-  <script define:vars={{ WHATSAPP_NUMBER_E164 }}>
+  <script define:vars={{ WHATSAPP_BASE_URL }}>
     const form = document.getElementById('contacto');
 
     form?.addEventListener('submit', (e) => {
@@ -239,24 +239,20 @@ const contactCards = [
 
       const lines = [
         `Hola Diego, quiero saber qué conviene construir primero.`,
-        '',
+        `Mi rubro es: ${rubro || '___'} y mi Instagram/web es: ${referencia || '___'}`,
+        objetivo ? `Objetivo: ${objetivo}` : null,
+        interes ? `Me interesa: ${interes}` : null,
         nombre ? `Nombre: ${nombre}` : null,
         email ? `Email: ${email}` : null,
-        `Mi rubro es: ${rubro || '[rubro]'}`,
-        `Mi Instagram/web es: ${referencia || '[Instagram, web o referencia]'}`,
-        `Hoy necesito: ${objetivo || '[más consultas / turnos / pedidos / mostrar una idea / manejar datos]'}`,
-        `Servicio que creo necesitar: ${interes || '[demo / landing / agenda / panel / no sé todavía]'}`,
         presupuesto && presupuesto !== 'Todavía no lo sé' ? `Presupuesto: ${presupuesto}` : null,
       ].filter((line) => line !== null);
 
       if (mensaje) {
-        lines.push('', `Mensaje libre: ${mensaje}`);
+        lines.push(`Nota: ${mensaje}`);
       }
 
-      lines.push('', 'Quedo atento a tu dirección: demo, landing, agenda o panel simple.');
-
       const text = lines.join(String.fromCharCode(10));
-      const href = `https://wa.me/${WHATSAPP_NUMBER_E164}?text=${encodeURIComponent(text)}`;
+      const href = `${WHATSAPP_BASE_URL}?text=${encodeURIComponent(text)}`;
       window.open(href, '_blank', 'noopener,noreferrer');
     });
   </script>

--- a/src/pages/proyectos/[slug].astro
+++ b/src/pages/proyectos/[slug].astro
@@ -4,7 +4,7 @@ import Badge from '../../components/Badge.astro';
 import Container from '../../components/Container.astro';
 import GlowCard from '../../components/GlowCard.astro';
 import ProjectLinkPreview from '../../components/ProjectLinkPreview.astro';
-import { PROJECT_WHATSAPP_MESSAGE, waLink } from '../../lib/contact';
+import { getProjectLeadMessage, waLink } from '../../lib/contact';
 import { getCollection } from 'astro:content';
 
 export async function getStaticPaths() {
@@ -52,7 +52,7 @@ const statusTone = {
   demo: 'cyan',
   concepto: 'violet',
 };
-const whatsappText = PROJECT_WHATSAPP_MESSAGE(title);
+const whatsappText = getProjectLeadMessage(title);
 ---
 <BaseLayout title={`${title} | Caso Marin.dev`} description={resumen} image={previewImage} url={`/proyectos/${proyecto.slug}`}>
   <Container class="py-12 sm:py-16">
@@ -177,7 +177,7 @@ const whatsappText = PROJECT_WHATSAPP_MESSAGE(title);
           <h2 class="mt-3 break-words text-2xl font-semibold text-slate-50">¿Querés algo parecido para tu negocio?</h2>
           <p class="mx-auto mt-3 max-w-2xl text-sm leading-6 text-muted-soft">Mandame tu rubro, tu Instagram o web actual y qué querés conseguir. Te digo si conviene demo, landing, agenda o panel simple.</p>
           <a href={waLink(whatsappText)} target="_blank" rel="noopener noreferrer" class="mt-6 inline-flex w-full max-w-full items-center justify-center rounded-xl bg-slate-50 px-5 py-3 text-center text-sm font-semibold text-ink transition hover:-translate-y-0.5 hover:bg-white sm:w-auto">
-            Pedir demo parecida
+            Quiero algo parecido
           </a>
         </div>
       </section>

--- a/src/pages/proyectos/index.astro
+++ b/src/pages/proyectos/index.astro
@@ -76,7 +76,7 @@ const proyectos = (await getCollection('proyectos')).sort(byCommercialPriority);
         <p class="mt-1 text-sm leading-6 text-muted-soft">Compartime tu Instagram, web o idea y te digo qué módulos conviene mostrar primero.</p>
       </div>
       <a href={waLink(DEMO_WHATSAPP_MESSAGE)} target="_blank" rel="noreferrer" class="premium-button inline-flex w-full max-w-full items-center justify-center gap-2 rounded-2xl bg-brand-gradient px-5 py-3 text-center text-sm font-semibold text-white shadow-glow sm:w-fit">
-        Pedir demo parecida <span aria-hidden="true">↗</span>
+        Quiero algo parecido <span aria-hidden="true">↗</span>
       </a>
     </div>
   </Container>


### PR DESCRIPTION
### Motivation

- Improve lead quality by centralizing and standardizing prefilled WhatsApp messages so each CTA sends concise context-appropriate information. 
- Keep the existing WhatsApp number and avoid visual/layout changes while making CTAs more actionable and mobile-safe.
- Reduce duplication of message logic across components by moving intent generation into a single helper module.

### Description

- Centralized WhatsApp helpers in `src/lib/contact.ts` including `makeWhatsAppUrl`, `getGlobalLeadMessage`, `getServiceLeadMessage`, `getVerticalLeadMessage`, `getProjectLeadMessage` and exported `waLink` alias, while keeping `WHATSAPP_NUMBER_E164` unchanged. 
- Rewired components to use the centralized helpers and updated CTA labels: `NeedSelector`, `VerticalDemos`, `ProductizedServices`, `PricingPlans`, `ProjectCard`, project detail page and contact page now produce context-specific messages and short mobile-safe labels (e.g. "Consultar este paquete", "Quiero algo parecido", "Mandar Instagram y rubro").
- Shortened and restructured the contact form message generation to produce a readable, URL-encoded WhatsApp brief using the centralized base URL helper. 
- Added documentation `docs/whatsapp-intents.md` that maps CTA sources to message patterns and expected lead context.

### Testing

- Ran `npm run build` and the static site build completed successfully (14 pages built). 
- Ran `git diff --check` with no issues reported. 
- Ran `npx prettier --write` for formatting; Prettier formatted supported files but could not infer a parser for `.astro` files because the repo lacks an Astro parser plugin (warning only, not blocking). 
- Verified that WhatsApp links remain `https://wa.me/<same-number>` and are generated via the new helpers so the phone number was not changed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a049d943f008328bd62bb6f0c370bb3)