### PR TITLE
Add “Te respondo con” informational block to contact flow

### DIFF
--- a/src/pages/contacto.astro
+++ b/src/pages/contacto.astro
@@ -49,6 +49,20 @@ const budgetRanges = [
   "Más de USD 1000",
 ];
 
+const responseItems = [
+  "Qué conviene construir primero: demo, landing, agenda o panel.",
+  "Qué incluiría la primera versión.",
+  "Rango estimado y posibles hitos.",
+  "Qué necesito de vos para empezar.",
+];
+
+const responseBadges = [
+  "Alcance inicial",
+  "Rango estimado",
+  "Primer hito",
+  "Datos necesarios",
+];
+
 const contactCards = [
   {
     label: "WhatsApp directo",
@@ -193,6 +207,31 @@ const contactCards = [
           <div class="mt-4">
             <label for="mensaje" class="block text-sm font-medium text-slate-100">Mensaje libre</label>
             <textarea id="mensaje" name="mensaje" rows="5" class="mt-2 w-full rounded-2xl border border-line bg-surface/75 px-4 py-3 text-slate-50 outline-none transition placeholder:text-muted focus:border-cyan-electric/60 focus:ring-2 focus:ring-cyan-electric/20" placeholder="Contame qué vendés, qué querés conseguir o qué referencia querés imitar."></textarea>
+          </div>
+
+          <div class="mt-6 rounded-[1.5rem] border border-line bg-white/[0.04] p-4 sm:p-5">
+            <div class="flex min-w-0 flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+              <div class="min-w-0">
+                <p class="text-xs font-semibold uppercase tracking-[0.16em] text-cyan-electric">Después del mensaje</p>
+                <h3 class="mt-2 break-words text-lg font-semibold tracking-tight text-slate-50">Te respondo con algo útil, no con un presupuesto al aire</h3>
+              </div>
+              <div class="flex min-w-0 flex-wrap gap-2 sm:max-w-xs sm:justify-end">
+                {responseBadges.map((badge) => (
+                  <span class="rounded-full border border-cyan-electric/20 bg-cyan-electric/10 px-2.5 py-1 text-[0.68rem] font-semibold text-cyan-100">
+                    {badge}
+                  </span>
+                ))}
+              </div>
+            </div>
+
+            <ul class="mt-4 grid gap-2 text-sm leading-6 text-muted-soft sm:grid-cols-2">
+              {responseItems.map((item) => (
+                <li class="flex min-w-0 gap-2">
+                  <span class="mt-2 size-1.5 shrink-0 rounded-full bg-cyan-electric shadow-[0_0_0.75rem_rgba(34,211,238,0.55)]" aria-hidden="true"></span>
+                  <span>{item}</span>
+                </li>
+              ))}
+            </ul>
           </div>
 
           <div class="mt-6 rounded-2xl border border-cyan-electric/20 bg-cyan-electric/10 p-4 text-sm leading-6 text-cyan-50">


### PR DESCRIPTION
### Motivation
- Reduce uncertainty after the user sends the WhatsApp message by clearly explaining what Diego/Marin.dev will reply with, so the contact flow converts better without changing functionality.

### Description
- Added two small data arrays `responseItems` and `responseBadges` and an informational card inside the contact form that presents the title “Te respondo con algo útil, no con un presupuesto al aire”, compact badges, and four concise bullets. The new UI is informational only and does not alter form or WhatsApp behavior. (`src/pages/contacto.astro`)

### Testing
- Ran `npm run build` and the static site built successfully. 
- Ran the mobile layout check with `npm run check:mobile-layout` and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04a970f7ec83288e833046f6f488f6)