### PR TITLE
Add lightweight privacy-conscious CRO event tracking

### DIFF
--- a/docs/cro-events.md
+++ b/docs/cro-events.md
@@ -1,0 +1,63 @@
+# CRO event tracking
+
+This site uses a lightweight, privacy-conscious event helper in `src/lib/analytics.ts`.
+It does not load analytics providers or external scripts by itself, does not add dependencies,
+and only sends non-sensitive CTA metadata.
+
+## Runtime behavior
+
+`track(eventName, payload?)` is safe by default:
+
+1. No-ops during SSR (`window` is unavailable).
+2. Sends to `window.gtag('event', eventName, payload)` if a Google `gtag` object already exists.
+3. Sends to `window.plausible(eventName, { props: payload })` if Plausible already exists.
+4. Logs to `console.debug` only in local development when no provider exists.
+5. Catches errors so tracking never blocks navigation or breaks the UI.
+
+A tiny delegated listener is initialized from `BaseLayout.astro` and reads declarative attributes:
+
+- `data-analytics-event="event_name"` for click events.
+- `data-analytics-submit-event="event_name"` for submit events.
+- `data-analytics-source`, `data-analytics-service-slug`, `data-analytics-vertical-slug`,
+  `data-analytics-project-slug`, and `data-analytics-cta-label` for allowed payload fields.
+
+No form values, names, emails, phone numbers, URLs entered by users, or free-text messages are collected.
+
+## Events
+
+| Event name | Where it fires | Payload fields |
+| --- | --- | --- |
+| `hero_primary_cta` | Primary WhatsApp CTA in `HeroV2` | `source`, `cta_label` |
+| `hero_secondary_cta` | Secondary project CTA in `HeroV2` | `source`, `cta_label` |
+| `need_selector_cta` | WhatsApp CTA for a recommendation in `NeedSelector` | `source`, `service_slug`, `cta_label` |
+| `service_cta` | Service/package CTAs in `ProductizedServices` and `PricingPlans` | `source`, `service_slug`, `cta_label` |
+| `vertical_demo_cta` | WhatsApp CTA for a demo by rubro in `VerticalDemos` | `source`, `vertical_slug`, `cta_label` |
+| `project_demo_click` | External demo links in `ProjectCard` and project detail hero | `source`, `project_slug`, `cta_label` |
+| `project_whatsapp_click` | "Quiero algo parecido" WhatsApp CTA in `ProjectCard` and project detail final CTA | `source`, `project_slug`, `cta_label` |
+| `contact_whatsapp_submit` | Contact form submit, direct contact WhatsApp links, and reusable `ContactCTA` WhatsApp entry points | `source`, `cta_label` |
+| `nav_cta_click` | Desktop and mobile WhatsApp CTA in `Nav` | `source`, `cta_label` |
+
+## Wiring a provider later
+
+The helper automatically detects a provider if one is intentionally added later.
+Keep provider setup separate from CTA instrumentation.
+
+### Plausible example
+
+If Plausible is added in the future, load the official script in the layout and expose `window.plausible` as usual.
+The current helper will call:
+
+```js
+window.plausible(eventName, { props: payload });
+```
+
+### gtag example
+
+If an existing approved setup exposes `window.gtag`, the helper will call:
+
+```js
+window.gtag('event', eventName, payload);
+```
+
+Do not include personal data in payloads. Keep payloads to stable labels/slugs such as source, service slug,
+vertical slug, project slug, and CTA label.

--- a/src/components/ContactCTA.astro
+++ b/src/components/ContactCTA.astro
@@ -87,6 +87,9 @@ const contactMethods = [
             href={waLink(primaryMessage)}
             target="_blank"
             rel="noopener noreferrer"
+            data-analytics-event="contact_whatsapp_submit"
+            data-analytics-source="contact_cta"
+            data-analytics-cta-label={primaryLabel}
             class="premium-button inline-flex min-h-12 w-full max-w-full items-center justify-center gap-2 whitespace-normal rounded-2xl bg-brand-gradient px-5 py-3 text-center text-sm font-semibold leading-5 text-white shadow-glow hover:-translate-y-0.5 hover:shadow-premium-hover sm:w-auto sm:min-w-64 sm:px-6"
           >
             <Icon name="message" size="sm" />
@@ -110,6 +113,9 @@ const contactMethods = [
               target={method.external ? '_blank' : undefined}
               rel={method.external ? 'noopener noreferrer' : undefined}
               class="group min-w-0 rounded-2xl border border-line bg-surface-glass p-4 text-left transition duration-300 hover:-translate-y-0.5 hover:border-line-strong hover:bg-surface-850/80"
+              data-analytics-event={method.label === 'WhatsApp' ? 'contact_whatsapp_submit' : undefined}
+              data-analytics-source="contact_cta_method"
+              data-analytics-cta-label={method.cta}
             >
               <span class={`inline-flex size-10 items-center justify-center rounded-xl bg-gradient-to-br ${method.tone} text-cyan-100 ring-1 ring-white/10`}>
                 <Icon name={method.icon} size="sm" />

--- a/src/components/HeroV2.astro
+++ b/src/components/HeroV2.astro
@@ -68,12 +68,18 @@ const mobileFlow = [
           href={waLink(DEFAULT_WHATSAPP_MESSAGE)}
           target="_blank"
           rel="noopener noreferrer"
+          data-analytics-event="hero_primary_cta"
+          data-analytics-source="home_hero"
+          data-analytics-cta-label="Mandar Instagram y rubro"
           class="premium-button inline-flex min-h-12 w-full max-w-full items-center justify-center whitespace-normal rounded-2xl bg-brand-gradient px-5 py-3 text-center text-sm font-semibold leading-5 text-white shadow-glow hover:-translate-y-0.5 hover:shadow-premium-hover sm:w-auto sm:px-6"
         >
           Mandar Instagram y rubro
         </a>
         <a
           href="#casos"
+          data-analytics-event="hero_secondary_cta"
+          data-analytics-source="home_hero"
+          data-analytics-cta-label="Ver proyectos"
           class="premium-button inline-flex min-h-12 w-full max-w-full items-center justify-center whitespace-normal rounded-2xl border border-line bg-surface-glass px-5 py-3 text-center text-sm font-semibold leading-5 text-slate-50 backdrop-blur hover:-translate-y-0.5 hover:border-line-strong hover:text-cyan-electric sm:w-auto sm:px-6"
         >
           Ver proyectos

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -53,6 +53,9 @@ const current = Astro.url.pathname;
         class="inline-flex items-center justify-center rounded-full bg-brand-gradient px-4 py-2 text-sm font-semibold text-slate-950 shadow-glow transition hover:-translate-y-0.5 hover:shadow-premium-hover"
         target="_blank"
         rel="noopener noreferrer"
+        data-analytics-event="nav_cta_click"
+        data-analytics-source="nav_desktop"
+        data-analytics-cta-label="Mandar Instagram y rubro"
       >
         <span class="lg:hidden">Mandar rubro</span>
         <span class="hidden lg:inline">Mandar Instagram y rubro</span>
@@ -120,6 +123,9 @@ const current = Astro.url.pathname;
           class="block rounded-2xl bg-brand-gradient px-4 py-3 text-center text-sm font-semibold text-slate-950 shadow-glow"
           target="_blank"
           rel="noopener noreferrer"
+          data-analytics-event="nav_cta_click"
+          data-analytics-source="nav_mobile"
+          data-analytics-cta-label="Mandar Instagram y rubro"
         >
           Mandar Instagram y rubro
         </a>

--- a/src/components/NeedSelector.astro
+++ b/src/components/NeedSelector.astro
@@ -4,6 +4,7 @@ import IconBubble from './IconBubble.astro';
 import SectionHeader from './SectionHeader.astro';
 import VisualBadge from './VisualBadge.astro';
 import { getServiceLeadMessage, waLink } from '../lib/contact';
+import { toAnalyticsSlug } from '../lib/analytics';
 
 const options = [
   {
@@ -93,6 +94,10 @@ const options = [
             href={waLink(option.message)}
             target="_blank"
             rel="noopener noreferrer"
+            data-analytics-event="need_selector_cta"
+            data-analytics-source="need_selector"
+            data-analytics-service-slug={toAnalyticsSlug(option.recommended)}
+            data-analytics-cta-label={option.cta}
             class="premium-button mt-5 inline-flex w-full max-w-full items-center justify-center rounded-2xl bg-gradient-to-r from-cyan-electric to-blue-electric px-5 py-3 text-center text-sm font-semibold text-ink shadow-[0_16px_40px_rgba(34,211,238,0.16)] hover:-translate-y-0.5 hover:shadow-[0_18px_44px_rgba(59,130,246,0.22)] sm:w-fit"
           >
             {option.cta}

--- a/src/components/PricingPlans.astro
+++ b/src/components/PricingPlans.astro
@@ -7,6 +7,7 @@ import SectionHeader from './SectionHeader.astro';
 import VisualBadge from './VisualBadge.astro';
 import { servicePlans as plans } from '../data/services';
 import { getServiceLeadMessage, waLink } from '../lib/contact';
+import { toAnalyticsSlug } from '../lib/analytics';
 
 const chooserItems = plans.map(({ name, chooser, comparison, tone }) => ({
   name,
@@ -157,6 +158,10 @@ const chooserItems = plans.map(({ name, chooser, comparison, tone }) => ({
                 : 'border border-line bg-surface-glass text-slate-50 hover:border-line-strong hover:text-cyan-electric'
             }`}
             aria-label={`Consultar el plan ${plan.name} por WhatsApp`}
+            data-analytics-event="service_cta"
+            data-analytics-source="pricing_plans"
+            data-analytics-service-slug={toAnalyticsSlug(plan.name)}
+            data-analytics-cta-label="Consultar este paquete"
           >
             <span>Consultar este paquete</span>
             <Icon name="arrow" size="sm" />

--- a/src/components/ProductizedServices.astro
+++ b/src/components/ProductizedServices.astro
@@ -5,6 +5,7 @@ import SectionHeader from './SectionHeader.astro';
 import VisualBadge from './VisualBadge.astro';
 import { productizedServices } from '../data/services';
 import { waLink, getServiceLeadMessage } from '../lib/contact';
+import { toAnalyticsSlug } from '../lib/analytics';
 
 const serviceBadges = [
   { label: '3–5 días', icon: 'speed', tone: 'cyan' },
@@ -71,6 +72,10 @@ const serviceBadges = [
           href={waLink(getServiceLeadMessage(service.name))}
           target="_blank"
           rel="noopener noreferrer"
+          data-analytics-event="service_cta"
+          data-analytics-source="productized_services"
+          data-analytics-service-slug={toAnalyticsSlug(service.name)}
+          data-analytics-cta-label="Consultar este paquete"
           class="premium-button mt-6 inline-flex w-full max-w-full items-center justify-center rounded-2xl border border-line bg-surface-glass px-5 py-3 text-center text-sm font-semibold text-slate-50 hover:-translate-y-0.5 hover:border-line-strong hover:text-cyan-electric"
         >
           Consultar este paquete

--- a/src/components/ProjectCard.astro
+++ b/src/components/ProjectCard.astro
@@ -3,6 +3,7 @@ import Badge from './Badge.astro';
 import { projectVisualAsset } from '../lib/projectGallery';
 import { getProjectVisual } from '../lib/projectVisuals';
 import { getProjectLeadMessage, waLink } from '../lib/contact';
+import { toAnalyticsSlug } from '../lib/analytics';
 
 const FEATURE_LIMIT = 4;
 const STACK_LIMIT = 5;
@@ -89,6 +90,7 @@ const visual = projectVisualAsset({ slug, thumbnail, cover, image });
 const hasImage = visual.hasImage;
 const isStarProject = Number(priority) >= 120;
 const resolvedCaseUrl = caseUrl || `/proyectos/${slug}`;
+const analyticsProjectSlug = toAnalyticsSlug(slug || title);
 const normalizedSignals = [commercialType, sector, resumen, problema, solucion, ...features, ...stack]
   .filter(Boolean)
   .map((item) => String(item).toLowerCase());
@@ -218,11 +220,11 @@ const copyFocus = highlight || solucion || problema;
         {ctaLabel}
         <span aria-hidden="true" class="transition duration-300 group-hover:translate-x-1">→</span>
       </a>
-      <a href={waLink(getProjectLeadMessage(title))} target="_blank" rel="noreferrer" class="inline-flex w-full max-w-full items-center justify-center gap-1.5 rounded-2xl border border-line bg-surface-glass px-4 py-2.5 text-center text-sm font-semibold text-cyan-electric transition hover:border-line-strong hover:bg-surface-800/70 sm:w-auto">
+      <a href={waLink(getProjectLeadMessage(title))} target="_blank" rel="noreferrer" data-analytics-event="project_whatsapp_click" data-analytics-source="project_card" data-analytics-project-slug={analyticsProjectSlug} data-analytics-cta-label="Quiero algo parecido" class="inline-flex w-full max-w-full items-center justify-center gap-1.5 rounded-2xl border border-line bg-surface-glass px-4 py-2.5 text-center text-sm font-semibold text-cyan-electric transition hover:border-line-strong hover:bg-surface-800/70 sm:w-auto">
         Quiero algo parecido <span aria-hidden="true">↗</span>
       </a>
       {demoUrl && (
-        <a href={demoUrl} target="_blank" rel="noreferrer" class="inline-flex w-full max-w-full items-center justify-center gap-1.5 rounded-2xl border border-line bg-surface-glass px-4 py-2.5 text-center text-sm font-semibold text-cyan-electric transition hover:border-line-strong hover:bg-surface-800/70 sm:w-auto">
+        <a href={demoUrl} target="_blank" rel="noreferrer" data-analytics-event="project_demo_click" data-analytics-source="project_card" data-analytics-project-slug={analyticsProjectSlug} data-analytics-cta-label="Ver demo" class="inline-flex w-full max-w-full items-center justify-center gap-1.5 rounded-2xl border border-line bg-surface-glass px-4 py-2.5 text-center text-sm font-semibold text-cyan-electric transition hover:border-line-strong hover:bg-surface-800/70 sm:w-auto">
           Ver demo <span aria-hidden="true">↗</span>
         </a>
       )}

--- a/src/components/VerticalDemos.astro
+++ b/src/components/VerticalDemos.astro
@@ -5,6 +5,7 @@ import IconBubble from './IconBubble.astro';
 import SectionHeader from './SectionHeader.astro';
 import { verticalDemos } from '../data/verticals';
 import { getVerticalLeadMessage, waLink } from '../lib/contact';
+import { toAnalyticsSlug } from '../lib/analytics';
 ---
 <section class="min-w-0 py-14 md:py-20">
   <SectionHeader
@@ -39,6 +40,10 @@ import { getVerticalLeadMessage, waLink } from '../lib/contact';
           href={waLink(getVerticalLeadMessage(demo.name))}
           target="_blank"
           rel="noopener noreferrer"
+          data-analytics-event="vertical_demo_cta"
+          data-analytics-source="vertical_demos"
+          data-analytics-vertical-slug={toAnalyticsSlug(demo.name)}
+          data-analytics-cta-label="Pedir demo para este rubro"
           class="premium-button mt-6 inline-flex w-full max-w-full items-center justify-center gap-2 rounded-2xl border border-line bg-surface-glass px-4 py-2 text-center text-sm font-semibold text-slate-50 hover:-translate-y-0.5 hover:border-cyan-electric/35 hover:text-cyan-electric sm:w-fit"
         >
           Pedir demo para este rubro <Icon name="arrow" size="sm" />

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -150,5 +150,10 @@ const faqJsonLd = {
       <slot />
     </main>
     <Footer />
+    <script>
+      import { bindAnalyticsEvents } from "../lib/analytics";
+
+      bindAnalyticsEvents();
+    </script>
   </body>
 </html>

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,0 +1,109 @@
+export type AnalyticsPayload = Record<string, string | number | boolean | undefined | null>;
+
+type Gtag = (command: 'event', eventName: string, payload?: Record<string, string | number | boolean>) => void;
+type Plausible = (eventName: string, options?: { props?: Record<string, string | number | boolean> }) => void;
+
+declare global {
+  interface Window {
+    gtag?: Gtag;
+    plausible?: Plausible;
+    marinTrack?: typeof track;
+  }
+}
+
+const ALLOWED_PAYLOAD_FIELDS = new Set([
+  'source',
+  'service_slug',
+  'vertical_slug',
+  'project_slug',
+  'cta_label',
+]);
+
+const normalizeDatasetKey = (key: string) => key.replace(/[A-Z]/g, (match) => `_${match.toLowerCase()}`);
+
+export const toAnalyticsSlug = (value: string) =>
+  value
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+
+const sanitizePayload = (payload: AnalyticsPayload = {}) =>
+  Object.entries(payload).reduce<Record<string, string | number | boolean>>((safePayload, [key, value]) => {
+    if (!ALLOWED_PAYLOAD_FIELDS.has(key) || value === undefined || value === null || value === '') {
+      return safePayload;
+    }
+
+    safePayload[key] = typeof value === 'string' ? value.slice(0, 120) : value;
+    return safePayload;
+  }, {});
+
+const payloadFromElement = (element: HTMLElement) =>
+  Object.entries(element.dataset).reduce<AnalyticsPayload>((payload, [key, value]) => {
+    if (!key.startsWith('analytics') || key === 'analyticsEvent' || key === 'analyticsSubmitEvent') {
+      return payload;
+    }
+
+    const normalizedKey = normalizeDatasetKey(key.replace(/^analytics/, ''));
+    payload[normalizedKey] = value;
+    return payload;
+  }, {});
+
+export function track(eventName: string, payload?: AnalyticsPayload) {
+  if (typeof window === 'undefined' || !eventName) return;
+
+  try {
+    const safePayload = sanitizePayload(payload);
+
+    if (typeof window.gtag === 'function') {
+      window.gtag('event', eventName, safePayload);
+      return;
+    }
+
+    if (typeof window.plausible === 'function') {
+      window.plausible(eventName, { props: safePayload });
+      return;
+    }
+
+    if (import.meta.env.DEV) {
+      console.debug('[analytics]', eventName, safePayload);
+    }
+  } catch {
+    // Analytics must never block navigation or break the UI.
+  }
+}
+
+export function bindAnalyticsEvents() {
+  if (typeof window === 'undefined') return;
+
+  window.marinTrack = track;
+  window.addEventListener('marin:track', (event) => {
+    const detail = event instanceof CustomEvent ? event.detail : null;
+    if (!detail || typeof detail.eventName !== 'string') return;
+    track(detail.eventName, detail.payload);
+  });
+
+  document.addEventListener(
+    'click',
+    (event) => {
+      const target = event.target instanceof Element ? event.target.closest<HTMLElement>('[data-analytics-event]') : null;
+      if (!target) return;
+
+      track(target.dataset.analyticsEvent || '', payloadFromElement(target));
+    },
+    { capture: true },
+  );
+
+  document.addEventListener(
+    'submit',
+    (event) => {
+      const target = event.target instanceof HTMLElement && event.target.matches('[data-analytics-submit-event]') ? event.target : null;
+      if (!target) return;
+
+      track(target.dataset.analyticsSubmitEvent || '', payloadFromElement(target));
+    },
+    { capture: true },
+  );
+}

--- a/src/pages/contacto.astro
+++ b/src/pages/contacto.astro
@@ -130,7 +130,7 @@ const contactCards = [
             <p class="text-sm font-semibold text-slate-50">Canales directos</p>
             <div class="mt-4 space-y-3">
               {contactCards.map((card) => (
-                <a class="group/contact flex min-w-0 items-center justify-between gap-4 rounded-2xl border border-line bg-white/[0.04] px-4 py-3 text-sm transition hover:-translate-y-0.5 hover:border-cyan-electric/40 hover:bg-cyan-electric/10" href={card.href} target={card.href.startsWith("http") ? "_blank" : undefined} rel={card.href.startsWith("http") ? "noopener noreferrer" : undefined}>
+                <a class="group/contact flex min-w-0 items-center justify-between gap-4 rounded-2xl border border-line bg-white/[0.04] px-4 py-3 text-sm transition hover:-translate-y-0.5 hover:border-cyan-electric/40 hover:bg-cyan-electric/10" href={card.href} target={card.href.startsWith("http") ? "_blank" : undefined} rel={card.href.startsWith("http") ? "noopener noreferrer" : undefined} data-analytics-event={card.label === "WhatsApp directo" ? "contact_whatsapp_submit" : undefined} data-analytics-source="contact_page_channel" data-analytics-cta-label={card.value}>
                   <span class="min-w-0">
                     <span class="block break-words font-medium text-slate-100">{card.label}</span>
                     <span class="mt-0.5 block text-muted-soft">{card.value}</span>
@@ -142,7 +142,7 @@ const contactCards = [
           </GlowCard>
         </aside>
 
-        <form id="contacto" class="min-w-0 rounded-[2rem] border border-line bg-ink/70 p-5 shadow-premium backdrop-blur md:p-7" aria-describedby="contacto-ayuda">
+        <form id="contacto" class="min-w-0 rounded-[2rem] border border-line bg-ink/70 p-5 shadow-premium backdrop-blur md:p-7" aria-describedby="contacto-ayuda" data-analytics-submit-event="contact_whatsapp_submit" data-analytics-source="contact_page_form" data-analytics-cta-label="Mandar Instagram y rubro">
           <div class="flex min-w-0 flex-col gap-3 border-b border-line pb-5 sm:flex-row sm:items-start sm:justify-between">
             <div class="min-w-0">
               <p class="break-words text-sm font-semibold uppercase tracking-[0.1em] text-cyan-electric sm:tracking-[0.18em]">Armá el mensaje</p>
@@ -242,7 +242,7 @@ const contactCards = [
             <button type="submit" class="inline-flex w-full items-center justify-center rounded-2xl bg-brand-gradient px-6 py-3 text-sm font-semibold text-white shadow-glow transition hover:-translate-y-0.5 hover:shadow-premium-hover sm:w-auto">
               Mandar Instagram y rubro
             </button>
-            <a class="inline-flex w-full items-center justify-center rounded-2xl border border-line bg-white/[0.04] px-6 py-3 text-sm font-semibold text-slate-100 transition hover:border-cyan-electric/40 hover:bg-white/[0.07] sm:w-auto" href={makeWhatsAppUrl(DEFAULT_WHATSAPP_MESSAGE)} target="_blank" rel="noopener noreferrer">
+            <a class="inline-flex w-full items-center justify-center rounded-2xl border border-line bg-white/[0.04] px-6 py-3 text-sm font-semibold text-slate-100 transition hover:border-cyan-electric/40 hover:bg-white/[0.07] sm:w-auto" href={makeWhatsAppUrl(DEFAULT_WHATSAPP_MESSAGE)} target="_blank" rel="noopener noreferrer" data-analytics-event="contact_whatsapp_submit" data-analytics-source="contact_page_fallback_link" data-analytics-cta-label="Mandar Instagram y rubro">
               Mandar Instagram y rubro
             </a>
           </div>

--- a/src/pages/proyectos/[slug].astro
+++ b/src/pages/proyectos/[slug].astro
@@ -5,6 +5,7 @@ import Container from '../../components/Container.astro';
 import GlowCard from '../../components/GlowCard.astro';
 import ProjectLinkPreview from '../../components/ProjectLinkPreview.astro';
 import { getProjectLeadMessage, waLink } from '../../lib/contact';
+import { toAnalyticsSlug } from '../../lib/analytics';
 import { getCollection } from 'astro:content';
 
 export async function getStaticPaths() {
@@ -53,6 +54,7 @@ const statusTone = {
   concepto: 'violet',
 };
 const whatsappText = getProjectLeadMessage(title);
+const analyticsProjectSlug = toAnalyticsSlug(proyecto.slug || title);
 ---
 <BaseLayout title={`${title} | Caso Marin.dev`} description={resumen} image={previewImage} url={`/proyectos/${proyecto.slug}`}>
   <Container class="py-12 sm:py-16">
@@ -89,7 +91,7 @@ const whatsappText = getProjectLeadMessage(title);
 
           <div class="mt-8 flex min-w-0 flex-col gap-3 sm:flex-row sm:flex-wrap">
             {demoUrl && (
-              <a href={demoUrl} target="_blank" rel="noopener noreferrer" class="inline-flex w-full max-w-full items-center justify-center rounded-xl bg-brand-gradient px-5 py-3 text-center text-sm font-semibold text-white shadow-glow transition hover:-translate-y-0.5 sm:w-auto">
+              <a href={demoUrl} target="_blank" rel="noopener noreferrer" data-analytics-event="project_demo_click" data-analytics-source="project_detail_hero" data-analytics-project-slug={analyticsProjectSlug} data-analytics-cta-label="Ver demo" class="inline-flex w-full max-w-full items-center justify-center rounded-xl bg-brand-gradient px-5 py-3 text-center text-sm font-semibold text-white shadow-glow transition hover:-translate-y-0.5 sm:w-auto">
                 Ver demo
               </a>
             )}
@@ -176,7 +178,7 @@ const whatsappText = getProjectLeadMessage(title);
           <p class="break-words text-sm font-semibold uppercase tracking-[0.1em] text-cyan-100 sm:tracking-[0.2em]">Último paso</p>
           <h2 class="mt-3 break-words text-2xl font-semibold text-slate-50">¿Querés algo parecido para tu negocio?</h2>
           <p class="mx-auto mt-3 max-w-2xl text-sm leading-6 text-muted-soft">Mandame tu rubro, tu Instagram o web actual y qué querés conseguir. Te digo si conviene demo, landing, agenda o panel simple.</p>
-          <a href={waLink(whatsappText)} target="_blank" rel="noopener noreferrer" class="mt-6 inline-flex w-full max-w-full items-center justify-center rounded-xl bg-slate-50 px-5 py-3 text-center text-sm font-semibold text-ink transition hover:-translate-y-0.5 hover:bg-white sm:w-auto">
+          <a href={waLink(whatsappText)} target="_blank" rel="noopener noreferrer" data-analytics-event="project_whatsapp_click" data-analytics-source="project_detail_final_cta" data-analytics-project-slug={analyticsProjectSlug} data-analytics-cta-label="Quiero algo parecido" class="mt-6 inline-flex w-full max-w-full items-center justify-center rounded-xl bg-slate-50 px-5 py-3 text-center text-sm font-semibold text-ink transition hover:-translate-y-0.5 hover:bg-white sm:w-auto">
             Quiero algo parecido
           </a>
         </div>


### PR DESCRIPTION
### Motivation

- The site is conversion-focused and needs lightweight, privacy-first event tracking to measure CTA effectiveness without adding heavyweight analytics or collecting personal data. 
- Instrumentation must be safe by default, not block navigation, and remain a no-op until an analytics provider (if any) is intentionally wired.

### Description

- Add a small analytics helper in `src/lib/analytics.ts` exposing `track(eventName, payload?)`, `toAnalyticsSlug()`, payload allowlisting/sanitization, gtag/Plausible auto-detection, and a delegated listener with `bindAnalyticsEvents()` that never throws. 
- Initialize the delegated listener from the layout by calling `bindAnalyticsEvents()` in `src/layouts/BaseLayout.astro`. 
- Instrument key conversion CTAs by adding declarative `data-analytics-*` attributes in the hero, nav, need selector, productized services, pricing, vertical demos, project cards/detail, contact CTA, and contact form so events fire with only non-sensitive fields (`source`, `service_slug`, `vertical_slug`, `project_slug`, `cta_label`). Modified files include `src/components/HeroV2.astro`, `src/components/Nav.astro`, `src/components/NeedSelector.astro`, `src/components/ProductizedServices.astro`, `src/components/PricingPlans.astro`, `src/components/ProjectCard.astro`, `src/components/VerticalDemos.astro`, `src/components/ContactCTA.astro`, `src/pages/contacto.astro`, and `src/pages/proyectos/[slug].astro`. 
- Add documentation `docs/cro-events.md` that lists event names, where they fire, allowed payload fields, runtime behavior, and examples for wiring Plausible or `gtag` later without changing instrumentation.

### Testing

- Ran `npm run build` and the Astro build completed successfully (static pages generated); non-fatal environment warnings appeared but did not break the build. 
- Verified there are no new dependencies added and the code paths are safe for SSR (no-op on server) and for environments without an analytics provider (fails silently, debug logged only in `DEV`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04b86cf3a88328b7ee67a8bc572ed6)