### PR TITLE
CRO QA: finalize WhatsApp CTAs, cap contact note, and add CRO QA report

### DIFF
--- a/docs/cro-final-qa.md
+++ b/docs/cro-final-qa.md
@@ -1,0 +1,89 @@
+# CRO Final QA — Patch 09
+
+Date: 2026-05-13
+
+## Scope reviewed
+
+This pass reviewed the homepage decision path and the WhatsApp-led conversion path after the addition of:
+
+- Need selector cards.
+- CTA copy updates.
+- Before/after comparison block.
+- Context-specific WhatsApp intents for global, service, vertical, project and contact flows.
+
+The patch intentionally avoids new homepage sections, pricing changes, route changes and contact data changes.
+
+## Homepage flow review
+
+| Step                            | Current role in the conversion path                                                            | QA verdict                                                                                                          |
+| ------------------------------- | ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| Hero                            | Explains the offer quickly and uses a low-commitment primary CTA: sending Instagram and rubro. | Strong. The visitor understands the offer before seeing deeper detail.                                              |
+| Social proof / capability strip | Confirms concrete delivery capabilities near the top.                                          | Useful as quick proof; keep concise.                                                                                |
+| Outcome grid                    | Frames why the site exists before asking the visitor to choose a package.                      | Useful, but should remain compact in future edits.                                                                  |
+| NeedSelector                    | Helps uncertain visitors choose by situation instead of by technical package.                  | Strong decision aid. CTAs use service-specific WhatsApp messages.                                                   |
+| BeforeAfter                     | Shows the practical transformation from scattered channels to a useful business link or panel. | Strong educational block; no extra section needed.                                                                  |
+| ConversionFlow                  | Explains the path from entry point to consultable output.                                      | Good support section, but it is the first candidate to move lower if the homepage feels too long in browser review. |
+| FeaturedCases                   | Proves capability with real cases and demos.                                                   | Strong proof point; should stay above vertical demos.                                                               |
+| VerticalDemos                   | Gives rubro-specific entry points and WhatsApp context.                                        | Useful for local lead matching.                                                                                     |
+| ProcessSteps                    | Reduces uncertainty about working process.                                                     | Keep below proof/decision sections.                                                                                 |
+| ProductizedServices             | Summarizes offers and anchors service CTAs.                                                    | Useful near the end because the selector already handles early decisions.                                           |
+| Final ContactCTA                | Ends with a clear low-commitment action.                                                       | Clear and consistent.                                                                                               |
+
+## CTA consistency review
+
+- Global CTA remains focused on sending Instagram and rubro.
+- Hero and final CTA use the same low-commitment action.
+- Service CTAs keep the package context in the WhatsApp message.
+- Vertical demo CTAs include the rubro context in the WhatsApp message.
+- Project cards include the project name in the WhatsApp message.
+- Contact form now states that submit opens WhatsApp with the provided data.
+- The fallback contact link now has a different label from the form submit action, reducing duplicate-choice confusion.
+
+## WhatsApp intent review
+
+- WhatsApp number remains unchanged: `59897316092`.
+- Static WhatsApp URLs use `encodeURIComponent` through the shared helper.
+- Form-generated WhatsApp URLs encode the assembled message before opening a new tab.
+- Default, service, vertical and project messages are short and context-specific.
+- Contact form free text is capped at 240 characters to reduce oversized WhatsApp URLs.
+
+## Mobile QA review
+
+Reviewed against the target widths: 360px, 375px, 390px and 430px.
+
+- CTA labels use full-width mobile buttons where needed.
+- Key grids stack to one column before medium breakpoints.
+- Cards include `min-w-0`, `break-words` or mobile-safe utility classes in the main risk areas.
+- Contact fallback CTA now has centered text for two-line mobile wrapping.
+- No obvious new horizontal overflow risk was introduced in this patch.
+
+Programmatic mobile contract checks were also run with the existing repo script.
+
+## Copy guardrail review
+
+- Source files were scanned for the blocked generic phrases from the Patch 09 prompt.
+- No blocked phrase was found in `src/` during this QA pass.
+- New copy added in this patch is functional and specific to WhatsApp behavior.
+
+## Performance risk review
+
+- No iframe was added.
+- No new image asset was added.
+- No animation library or heavy JavaScript dependency was added.
+- The only JavaScript change is the existing contact form submit handler limiting the optional note length before URL encoding.
+
+## Issues fixed in this patch
+
+1. Added explicit contact-form helper text explaining that submit opens WhatsApp with the form data.
+2. Added a `maxlength` of 240 characters to the optional contact note.
+3. Mirrored that cap in the contact submit script before encoding the WhatsApp message.
+4. Renamed the fallback contact link to avoid two adjacent buttons with the same label.
+5. Centered fallback contact link text for safer wrapping on narrow mobile widths.
+
+## Remaining future experiments
+
+- In browser analytics, compare hero CTA clicks against NeedSelector CTA clicks to see whether the selector should move higher or lower.
+- If scroll depth drops before cases, test moving ConversionFlow below FeaturedCases instead of removing content.
+- Test a shorter homepage variant where ProcessSteps lives only on `/servicios`.
+- Add event reporting for selected interest/rubro from the contact form if a privacy-safe analytics setup is confirmed.
+- Consider A/B testing the hero primary CTA label against a variant that mentions the first recommendation explicitly.

--- a/src/pages/contacto.astro
+++ b/src/pages/contacto.astro
@@ -206,7 +206,8 @@ const contactCards = [
 
           <div class="mt-4">
             <label for="mensaje" class="block text-sm font-medium text-slate-100">Mensaje libre</label>
-            <textarea id="mensaje" name="mensaje" rows="5" class="mt-2 w-full rounded-2xl border border-line bg-surface/75 px-4 py-3 text-slate-50 outline-none transition placeholder:text-muted focus:border-cyan-electric/60 focus:ring-2 focus:ring-cyan-electric/20" placeholder="Contame qué vendés, qué querés conseguir o qué referencia querés imitar."></textarea>
+            <textarea id="mensaje" name="mensaje" rows="5" maxlength="240" class="mt-2 w-full rounded-2xl border border-line bg-surface/75 px-4 py-3 text-slate-50 outline-none transition placeholder:text-muted focus:border-cyan-electric/60 focus:ring-2 focus:ring-cyan-electric/20" placeholder="Contame qué vendés, qué querés conseguir o qué referencia querés imitar."></textarea>
+            <p class="mt-2 text-xs leading-5 text-muted-soft">Al enviar, se abre WhatsApp con estos datos. El mensaje libre está limitado a 240 caracteres.</p>
           </div>
 
           <div class="mt-6 rounded-[1.5rem] border border-line bg-white/[0.04] p-4 sm:p-5">
@@ -242,8 +243,8 @@ const contactCards = [
             <button type="submit" class="inline-flex w-full items-center justify-center rounded-2xl bg-brand-gradient px-6 py-3 text-sm font-semibold text-white shadow-glow transition hover:-translate-y-0.5 hover:shadow-premium-hover sm:w-auto">
               Mandar Instagram y rubro
             </button>
-            <a class="inline-flex w-full items-center justify-center rounded-2xl border border-line bg-white/[0.04] px-6 py-3 text-sm font-semibold text-slate-100 transition hover:border-cyan-electric/40 hover:bg-white/[0.07] sm:w-auto" href={makeWhatsAppUrl(DEFAULT_WHATSAPP_MESSAGE)} target="_blank" rel="noopener noreferrer" data-analytics-event="contact_whatsapp_submit" data-analytics-source="contact_page_fallback_link" data-analytics-cta-label="Mandar Instagram y rubro">
-              Mandar Instagram y rubro
+            <a class="inline-flex w-full items-center justify-center rounded-2xl border border-line bg-white/[0.04] px-6 py-3 text-center text-sm font-semibold text-slate-100 transition hover:border-cyan-electric/40 hover:bg-white/[0.07] sm:w-auto" href={makeWhatsAppUrl(DEFAULT_WHATSAPP_MESSAGE)} target="_blank" rel="noopener noreferrer" data-analytics-event="contact_whatsapp_submit" data-analytics-source="contact_page_fallback_link" data-analytics-cta-label="Abrir WhatsApp sin formulario">
+              Abrir WhatsApp sin formulario
             </a>
           </div>
 
@@ -286,8 +287,10 @@ const contactCards = [
         presupuesto && presupuesto !== 'Todavía no lo sé' ? `Presupuesto: ${presupuesto}` : null,
       ].filter((line) => line !== null);
 
-      if (mensaje) {
-        lines.push(`Nota: ${mensaje}`);
+      const nota = mensaje.slice(0, 240);
+
+      if (nota) {
+        lines.push(`Nota: ${nota}`);
       }
 
       const text = lines.join(String.fromCharCode(10));


### PR DESCRIPTION
### Motivation
- Finalize Patch 09 CRO pass to ensure the homepage decision flow and WhatsApp-first CTAs convert without causing mobile or performance regressions. 
- Make small, safe fixes to the contact flow to reduce ambiguous CTAs and oversized WhatsApp messages. 

### Description
- Added `docs/cro-final-qa.md` with the Patch 09 QA scope, rationale for the decision path, CTA consistency checks, WhatsApp intent summary, mobile observations and recommended experiments. 
- Tightened the contact form in `src/pages/contacto.astro` by adding `maxlength="240"` to the optional free-text `mensaje`, visible helper copy explaining that submit opens WhatsApp, and trimming the message in the submit script (`mensaje.slice(0, 240)`) before encoding. 
- Changed the contact fallback link label from the duplicate “Mandar Instagram y rubro” to `Abrir WhatsApp sin formulario` and adjusted its markup to improve mobile wrapping. 

### Testing
- Ran `npm run check:mobile-layout` which passed the mobile layout contract checks. 
- Ran `npm run build` which completed successfully and produced the static site in `dist/` (14 pages built). 
- Verified generated WhatsApp links in `dist` are encoded, use the same number (`59897316092`), and include the context-specific messages for hero, services, verticals and projects. 
- Ran `npm run audit:mobile-patterns` (warnings only); audit reported existing manual-review notes but no blocking failures. 
- Performed a grep/copy-guard scan for blocked generic phrases (none reintroduced).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04bc4af4088328bbf7a2cd6bc1bf3c)