### PR TITLE
Prepare Vercel canonical SEO metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@ No inventar métricas: si no hay resultado medible, usar un impacto cualitativo.
 - El SEO base vive en `src/layouts/BaseLayout.astro`.
 - Cada página debe pasar `title`, `description`, `url` e `image` cuando necesite valores específicos.
 - La imagen Open Graph por defecto es `public/og-default.png`.
-- `astro.config.mjs` define `site: 'https://daegon13.github.io'` para canonical y sitemap.
-- `public/robots.txt` apunta al sitemap generado por `@astrojs/sitemap`.
+- `astro.config.mjs` define `site` desde `PUBLIC_SITE_URL` con fallback a `https://marin-dev.vercel.app` para canonical y sitemap.
+- `src/pages/robots.txt.ts` genera `robots.txt` con el sitemap canónico del sitio.
 
 ## Deploy
 

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -8,11 +8,11 @@ import tailwind from '@astrojs/tailwind';
 import mdx from '@astrojs/mdx';
 import sitemap from '@astrojs/sitemap';
 
-const site = process.env.PUBLIC_SITE_URL ?? 'https://daegon13.github.io';
+const site = process.env.PUBLIC_SITE_URL ?? "https://marin-dev.vercel.app";
 
 export default defineConfig({
-  // URL pública del sitio. Por defecto mantiene GitHub Pages; en Vercel puede
-  // sobreescribirse con PUBLIC_SITE_URL cuando exista dominio final.
+  // URL pública canónica del sitio. Vercel puede sobreescribirla con
+  // PUBLIC_SITE_URL cuando exista dominio final.
   site,
   // 3) Registro de integraciones (sin esto no compila el CSS de Tailwind ni los MDX)
   integrations: [

--- a/docs/deploy-vercel.md
+++ b/docs/deploy-vercel.md
@@ -5,7 +5,7 @@ Esta guía prepara Marin.dev para publicarse también en Vercel sin apagar el de
 ## Estrategia
 
 - **Vercel** puede importar este repo y compilarlo como un sitio Astro estático.
-- **GitHub Pages debe seguir activo** como fallback legacy porque el sitio público actual es `https://daegon13.github.io/` y proyectos o demos anteriores pueden estar enlazados con URLs de `daegon13.github.io`.
+- **GitHub Pages puede seguir activo** como fallback legacy porque proyectos, demos o enlaces anteriores todavía pueden apuntar a `https://daegon13.github.io/`. La URL canónica de producción para indexación es Vercel.
 - No hace falta migrar framework, agregar SSR ni instalar un adapter de Vercel mientras el sitio siga siendo estático.
 - No se deben romper ni reescribir links antiguos durante esta etapa: Vercel se suma como canal de deploy, no reemplaza GitHub Pages todavía.
 
@@ -32,15 +32,13 @@ Vercel instalará las dependencias desde `package-lock.json` y ejecutará el bui
 
 ## Variables de entorno
 
-No hay variables de entorno obligatorias para compilar el sitio.
-
-Opcionalmente, si más adelante se quiere que canonical, Open Graph y sitemap apunten a un dominio nuevo, configurar en Vercel:
+Para producción en Vercel, configurar la URL canónica activa:
 
 ```txt
-PUBLIC_SITE_URL=https://tu-dominio.com
+PUBLIC_SITE_URL=https://marin-dev.vercel.app
 ```
 
-Si `PUBLIC_SITE_URL` no existe, Astro usa como fallback `https://daegon13.github.io`, lo que mantiene la compatibilidad con el deploy actual de GitHub Pages.
+Si `PUBLIC_SITE_URL` no existe, Astro usa como fallback `https://marin-dev.vercel.app`. Esta variable controla canonical, Open Graph, JSON-LD, robots.txt y sitemap. Después de cambiarla en Vercel, ejecutar un nuevo deploy para regenerar la salida estática.
 
 ## Compatibilidad con GitHub Pages
 

--- a/docs/search-console.md
+++ b/docs/search-console.md
@@ -1,0 +1,33 @@
+# Google Search Console setup
+
+## Canonical production URL
+
+The canonical production URL for Marin.dev is currently:
+
+```env
+PUBLIC_SITE_URL=https://marin-dev.vercel.app
+```
+
+Set this environment variable in Vercel so Astro can generate consistent canonical URLs, Open Graph URLs, JSON-LD URLs, robots metadata, and sitemap URLs.
+
+## Future custom domain
+
+If a custom domain is added later, change the Vercel environment variable to the final HTTPS domain:
+
+```env
+PUBLIC_SITE_URL=https://your-domain.com
+```
+
+After changing environment variables in Vercel, redeploy the project so the static output is regenerated with the new canonical domain.
+
+## Search Console submission
+
+After deployment, submit the sitemap from the canonical property:
+
+```txt
+https://marin-dev.vercel.app/sitemap-index.xml
+```
+
+## Legacy GitHub Pages references
+
+`https://daegon13.github.io` can remain only where it is intentionally used as a legacy external/demo URL or historical public reference. It must not be used for canonical URLs, Open Graph URLs, JSON-LD site URLs, `robots.txt`, or generated sitemap URLs.

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,3 +1,0 @@
-User-agent: *
-Allow: /
-Sitemap: https://daegon13.github.io/sitemap-index.xml

--- a/src/lib/contact.ts
+++ b/src/lib/contact.ts
@@ -1,6 +1,7 @@
 // src/lib/contact.ts
 // Contact constants + helpers (no extra deps)
-export const SITE_URL = "https://daegon13.github.io";
+export const SITE_URL =
+  import.meta.env.PUBLIC_SITE_URL ?? "https://marin-dev.vercel.app";
 export const EMAIL = "damgmarin13@gmail.com";
 
 export const LINKEDIN_URL =

--- a/src/pages/contacto.astro
+++ b/src/pages/contacto.astro
@@ -22,7 +22,7 @@ import {
 const title = "Contacto – Marin.dev";
 const description =
   "Mandame tu Instagram, web o idea y te digo qué conviene construir primero: demo, landing, agenda o panel simple.";
-const url = "https://daegon13.github.io/contacto";
+const url = "/contacto";
 const image = "/og-default.png";
 
 const objetivos = [

--- a/src/pages/gracias.astro
+++ b/src/pages/gracias.astro
@@ -7,7 +7,7 @@ import BaseLayout from "../layouts/BaseLayout.astro";
 
 const title = "Gracias – Marin.dev";
 const description = "Tu mensaje fue enviado correctamente.";
-const url = "https://daegon13.github.io/gracias";
+const url = "/gracias";
 const image = "/og-default.png";
 ---
 <BaseLayout {title} {description} {url} {image}>

--- a/src/pages/politica-de-privacidad.astro
+++ b/src/pages/politica-de-privacidad.astro
@@ -4,7 +4,7 @@ import BaseLayout from "../layouts/BaseLayout.astro";
 const title = "Política de Privacidad – Marin.dev";
 const description =
   "Información sobre qué datos se recopilan, para qué se usan y cómo ejercer tus derechos.";
-const url = "https://daegon13.github.io/politica-de-privacidad";
+const url = "/politica-de-privacidad";
 const image = "/og-default.png";
 
 const lastUpdated = "9 de enero de 2026";

--- a/src/pages/robots.txt.ts
+++ b/src/pages/robots.txt.ts
@@ -1,0 +1,14 @@
+const siteUrl = (
+  import.meta.env.PUBLIC_SITE_URL ?? "https://marin-dev.vercel.app"
+).replace(/\/$/, "");
+
+export function GET() {
+  return new Response(
+    `User-agent: *\nAllow: /\nSitemap: ${siteUrl}/sitemap-index.xml\n`,
+    {
+      headers: {
+        "Content-Type": "text/plain; charset=utf-8",
+      },
+    },
+  );
+}

--- a/src/pages/servicios.astro
+++ b/src/pages/servicios.astro
@@ -7,7 +7,7 @@ import { DEFAULT_WHATSAPP_MESSAGE } from '../lib/contact';
 
 const title = 'Servicios productizados – Marin.dev';
 const description = 'Demos, landings, webs con WhatsApp/agenda y paneles simples para validar ofertas, recibir mejores mensajes o manejar datos básicos.';
-const url = 'https://daegon13.github.io/servicios';
+const url = '/servicios';
 const image = '/og-default.png';
 
 const serviceHighlights = [


### PR DESCRIPTION
### Motivation
- Ensure the site uses a configurable canonical base so Vercel can be the production source for Search Console and social metadata instead of the legacy GitHub Pages domain.  
- Remove hardcoded SEO-critical URLs (robots/sitemap/canonical/OG/JSON-LD) that would cause Google to index the wrong property.  
- Provide clear documentation so maintainers know to set `PUBLIC_SITE_URL` in Vercel and redeploy for canonical changes.  

### Description
- Configure Astro `site` to use `PUBLIC_SITE_URL` with `https://marin-dev.vercel.app` as the fallback by updating `astro.config.mjs`.  
- Replace the static `public/robots.txt` with a dynamic endpoint `src/pages/robots.txt.ts` that emits a `Sitemap:` line built from `import.meta.env.PUBLIC_SITE_URL` (or the Vercel fallback).  
- Centralize the site constant by changing `src/lib/contact.ts` so `SITE_URL = import.meta.env.PUBLIC_SITE_URL ?? "https://marin-dev.vercel.app"` (contact data otherwise left unchanged).  
- Normalize per-page `url` props to relative paths (`/contacto`, `/gracias`, `/servicios`, `/politica-de-privacidad`) so `BaseLayout.astro` builds canonicals from `Astro.site` instead of hardcoded legacy URLs.  
- Add documentation: new `docs/search-console.md` describing the required `PUBLIC_SITE_URL` env var, and update `docs/deploy-vercel.md` and `README.md` to reflect the new canonical strategy.  
- Keep legacy/demo references intentionally present in content (project `demoUrl` and a privacy-policy example link) but ensure they are not used for canonical/robots/sitemap generation.  

Files created/modified (high level): `astro.config.mjs`, `src/lib/contact.ts`, `src/pages/robots.txt.ts` (new), `public/robots.txt` (removed), `src/pages/{contacto,gracias,servicios,politica-de-privacidad}.astro` (url props normalized), `docs/search-console.md` (new), `docs/deploy-vercel.md`, `README.md`.

### Testing
- Ran `npm run build` and the build completed successfully (Astro static build produced `dist/` and sitemap generation ran).  
- Inspected generated `dist/robots.txt` and confirmed it contains: `Sitemap: https://marin-dev.vercel.app/sitemap-index.xml`.  
- Inspected `dist/sitemap-index.xml` and `dist/sitemap-0.xml` and confirmed all `<loc>` entries use `https://marin-dev.vercel.app/...` (or will follow `PUBLIC_SITE_URL` if overridden).  
- Verified canonical/OG/JSON-LD in built pages (`dist/index.html`, `dist/proyectos/index.html`, `dist/servicios/index.html`, `dist/proyectos/vetcare/index.html`) point to the active site URL (`https://marin-dev.vercel.app/...`) and not to `daegon13.github.io`.  
- Result: automated build and metadata checks passed.  

Notes/risks: some MDX/demo links and an example link inside the privacy policy still reference `https://daegon13.github.io` intentionally as legacy/demo external URLs; these are preserved as non-SEO-critical references per documentation and do not affect canonical/sitemap/robots outputs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a050dafd6188328829ee7c8673376d7)