### PR TITLE
Add optional Google Search Console verification support

### DIFF
--- a/docs/search-console.md
+++ b/docs/search-console.md
@@ -10,7 +10,66 @@ PUBLIC_SITE_URL=https://marin-dev.vercel.app
 
 Set this environment variable in Vercel so Astro can generate consistent canonical URLs, Open Graph URLs, JSON-LD URLs, robots metadata, and sitemap URLs.
 
-## Future custom domain
+## Verification methods
+
+For the current Vercel subdomain, create a **URL-prefix property** in Google Search Console for:
+
+```txt
+https://marin-dev.vercel.app/
+```
+
+Then choose one of these verification options.
+
+### Option A — URL-prefix + HTML file
+
+1. Download the HTML verification file from Search Console.
+2. Put the downloaded `googleXXXX.html` file in `public/`.
+3. Deploy the site.
+4. Visit the deployed file URL, replacing `googleXXXX.html` with the exact filename Google provided:
+
+   ```txt
+   https://marin-dev.vercel.app/googleXXXX.html
+   ```
+
+5. Click **Verify** in Search Console.
+
+### Option B — URL-prefix + meta tag
+
+1. Copy only the `content` token from the Search Console meta tag.
+2. Set this environment variable in Vercel:
+
+   ```env
+   PUBLIC_GOOGLE_SITE_VERIFICATION=...
+   ```
+
+3. Redeploy the site so Astro includes the optional verification meta tag in the static HTML.
+4. Click **Verify** in Search Console.
+
+Do not hardcode the verification token in the repository. The site builds without this environment variable, and when it is missing no Google verification meta tag is rendered.
+
+### Option C — future custom domain
+
+When Marin.dev moves to a custom domain, prefer a **Domain property** in Search Console.
+
+1. Create the Domain property for the final domain.
+2. Add the TXT record at the DNS provider.
+3. If Vercel manages DNS, add the TXT record in **Vercel Domains**.
+4. If an external registrar or DNS provider manages DNS, add the TXT record there.
+5. Wait for DNS propagation, then click **Verify** in Search Console.
+
+## Ownership reminder
+
+Do not remove the verification file or meta tag after verification unless you know ownership is maintained by another verification method. Google may periodically re-check ownership.
+
+## Search Console submission
+
+After deployment and verification, submit the sitemap from the canonical property:
+
+```txt
+https://marin-dev.vercel.app/sitemap-index.xml
+```
+
+## Future custom domain canonical URL
 
 If a custom domain is added later, change the Vercel environment variable to the final HTTPS domain:
 
@@ -19,14 +78,6 @@ PUBLIC_SITE_URL=https://your-domain.com
 ```
 
 After changing environment variables in Vercel, redeploy the project so the static output is regenerated with the new canonical domain.
-
-## Search Console submission
-
-After deployment, submit the sitemap from the canonical property:
-
-```txt
-https://marin-dev.vercel.app/sitemap-index.xml
-```
 
 ## Legacy GitHub Pages references
 

--- a/public/googled587ea19409db2ba.html
+++ b/public/googled587ea19409db2ba.html
@@ -1,1 +1,0 @@
-google-site-verification: googled587ea19409db2ba.html

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -43,6 +43,7 @@ const normalizeCanonicalPath = (path: string) => {
 const canonical = new URL(normalizeCanonicalPath(rawPagePath), site).href;
 const ogImage = image.startsWith("http") ? image : new URL(image, site).href;
 const logoUrl = new URL("/og-default.png", site).href;
+const googleSiteVerification = import.meta.env.PUBLIC_GOOGLE_SITE_VERIFICATION;
 
 const professionalServiceJsonLd = {
   "@context": "https://schema.org",
@@ -114,6 +115,7 @@ const faqJsonLd = {
     <title>{title}</title>
     <meta name="description" content={description} />
     {noindex && <meta name="robots" content="noindex, nofollow" />}
+    {googleSiteVerification && <meta name="google-site-verification" content={googleSiteVerification} />}
 
     <!-- Canonical -->
     <link rel="canonical" href={canonical} />


### PR DESCRIPTION
### Motivation
- Allow site owners to verify ownership in Google Search Console without committing user-specific tokens to the repo. 
- Support common URL-prefix verification flows (HTML file or meta tag) while keeping the static site build working if no verification token is provided. 
- Provide clear documentation on verification options and safe handling of verification files/tokens. 

### Description
- Read `PUBLIC_GOOGLE_SITE_VERIFICATION` from `import.meta.env` and render `<meta name="google-site-verification" content={...} />` only when the variable is present in `src/layouts/BaseLayout.astro`. 
- Remove the previously committed verification HTML file from `public/` so no hardcoded token remains in the repository. 
- Add/update `docs/search-console.md` with step-by-step guidance for Option A (HTML file in `public/`), Option B (meta tag via `PUBLIC_GOOGLE_SITE_VERIFICATION` on Vercel), Option C (Domain property via DNS TXT), and an ownership reminder not to remove verification artefacts unless ownership is maintained by alternate methods. 

### Testing
- Ran `npm run build` with `PUBLIC_GOOGLE_SITE_VERIFICATION` unset and confirmed the build completes and no `<meta name="google-site-verification">` tag is present in `dist/`. 
- Ran `PUBLIC_GOOGLE_SITE_VERIFICATION=example-token npm run build` and confirmed the `<meta name="google-site-verification" content="example-token" />` tag appears in the generated `dist` HTML. 
- Confirmed the previously committed `public/googled*.html` file was removed and the documentation explains how to add it intentionally when using the HTML-file verification method.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0511db74f88328837693932128b1e5)