### PR TITLE
Improve page-level SEO metadata

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -24,6 +24,9 @@ const {
   image = "/og-default.png",
   url = "",
   noindex = false,
+  ogType = "website",
+  ogTitle = title,
+  ogDescription = description,
 } = Astro.props;
 
 const site = Astro.site?.toString() ?? SITE_URL;
@@ -121,19 +124,19 @@ const faqJsonLd = {
     <link rel="canonical" href={canonical} />
 
     <!-- Open Graph -->
-    <meta property="og:type" content="website" />
+    <meta property="og:type" content={ogType} />
     <meta property="og:site_name" content="Marin.dev" />
     <meta property="og:locale" content="es_UY" />
-    <meta property="og:title" content={title} />
-    <meta property="og:description" content={description} />
+    <meta property="og:title" content={ogTitle} />
+    <meta property="og:description" content={ogDescription} />
     <meta property="og:image" content={ogImage} />
     <meta property="og:image:alt" content="Marin.dev: demos web y sistemas simples para negocios" />
     <meta property="og:url" content={canonical} />
 
     <!-- Twitter / X -->
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content={title} />
-    <meta name="twitter:description" content={description} />
+    <meta name="twitter:title" content={ogTitle} />
+    <meta name="twitter:description" content={ogDescription} />
     <meta name="twitter:image" content={ogImage} />
     <meta name="twitter:image:alt" content="Marin.dev: demos web y sistemas simples para negocios" />
 

--- a/src/pages/contacto.astro
+++ b/src/pages/contacto.astro
@@ -19,9 +19,9 @@ import {
   waLink,
 } from "../lib/contact";
 
-const title = "Contacto – Marin.dev";
+const title = "Contacto — MarinDev";
 const description =
-  "Mandame tu Instagram, web o idea y te digo qué conviene construir primero: demo, landing, agenda o panel simple.";
+  "Mandá tu Instagram, web o idea por WhatsApp y recibí una recomendación inicial: demo, landing, agenda o panel simple.";
 const url = "/contacto";
 const image = "/og-default.png";
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -29,8 +29,8 @@ const homeCases = destacados.length > 0 ? destacados : proyectos.slice(0, HOME_C
 
 ---
 <BaseLayout
-  title="Marin.dev | Webs, demos y sistemas simples"
-  description="Demos y webs para negocios que quieren recibir consultas, reservas o ventas con WhatsApp preparado, SEO base y deploy publicado."
+  title="MarinDev — Webs, demos y paneles simples para negocios"
+  description="Landings, demos navegables, WhatsApp preparado, agenda y paneles livianos para negocios que necesitan mostrar mejor su oferta y recibir mensajes con contexto."
 >
   <HeroV2 />
   <SocialProofStrip />

--- a/src/pages/proyectos/[slug].astro
+++ b/src/pages/proyectos/[slug].astro
@@ -41,6 +41,9 @@ const {
 } = proyecto.data;
 
 const previewImage = image || thumbnail || cover;
+const cleanMetaText = (value = "") => value.replace(/\s+/g, " ").trim();
+const metaDescription = cleanMetaText(resumen || impacto || capacidad || solucion);
+const projectSeoTitle = `${title} — MarinDev`;
 
 const { Content } = await proyecto.render();
 const statusLabels = {
@@ -56,7 +59,7 @@ const statusTone = {
 const whatsappText = getProjectLeadMessage(title);
 const analyticsProjectSlug = toAnalyticsSlug(proyecto.slug || title);
 ---
-<BaseLayout title={`${title} | Caso Marin.dev`} description={resumen} image={previewImage} url={`/proyectos/${proyecto.slug}`}>
+<BaseLayout title={projectSeoTitle} description={metaDescription} image={previewImage} url={`/proyectos/${proyecto.slug}`} ogType="article" ogTitle={projectSeoTitle} ogDescription={metaDescription}>
   <Container class="py-12 sm:py-16">
     <article class="min-w-0">
       <header class="grid min-w-0 gap-8 lg:grid-cols-[minmax(0,1fr)_minmax(0,28rem)] lg:items-center">

--- a/src/pages/proyectos/index.astro
+++ b/src/pages/proyectos/index.astro
@@ -20,8 +20,8 @@ const byCommercialPriority = (a, b) => {
 const proyectos = (await getCollection('proyectos')).sort(byCommercialPriority);
 ---
 <BaseLayout
-  title="Casos, demos y herramientas | Marin.dev"
-  description="Portfolio comercial de Marin.dev: demos, webs y herramientas simples con agenda, WhatsApp, carta digital, panel, catálogo o web corporativa."
+  title="Proyectos y demos web — MarinDev"
+  description="Portfolio de demos, landings, webs corporativas y paneles simples: veterinarias, barberías, restaurantes, inventario, servicios personales y logística."
 >
   <Container class="py-14 sm:py-20">
     <div class="grid min-w-0 gap-8 lg:grid-cols-[minmax(0,1fr)_minmax(0,22rem)] lg:items-end">

--- a/src/pages/servicios.astro
+++ b/src/pages/servicios.astro
@@ -5,8 +5,8 @@ import FAQs from '../components/FAQs.astro';
 import PricingPlans from '../components/PricingPlans.astro';
 import { DEFAULT_WHATSAPP_MESSAGE } from '../lib/contact';
 
-const title = 'Servicios productizados – Marin.dev';
-const description = 'Demos, landings, webs con WhatsApp/agenda y paneles simples para validar ofertas, recibir mejores mensajes o manejar datos básicos.';
+const title = 'Servicios web y demos comerciales — MarinDev';
+const description = 'Demo Comercial Express, Landing de Conversión, Web con WhatsApp/Agenda y Sistema simple/Panel Admin con alcance, entregables y límites definidos.';
 const url = '/servicios';
 const image = '/og-default.png';
 

--- a/src/pages/sobre-mi.astro
+++ b/src/pages/sobre-mi.astro
@@ -68,8 +68,8 @@ const stack = [
 ];
 ---
 <BaseLayout
-  title="Sobre mí | Marin.dev"
-  description="Conocé cómo Diego Marin piensa y construye webs, demos comerciales, agendas y paneles simples con decisiones prácticas de producto."
+  title="Sobre MarinDev — Diego Marin"
+  description="Desarrollo landings, demos navegables y paneles simples con foco en servicios visibles, WhatsApp preparado, deploy y entregables concretos."
 >
   <section class="relative overflow-hidden py-16 md:py-24">
     <div class="pointer-events-none absolute left-1/2 top-10 h-64 w-64 -translate-x-1/2 rounded-full bg-cyan-electric/15 blur-3xl" aria-hidden="true"></div>


### PR DESCRIPTION
### Motivation
- Ensure Search Console–friendly metadata across the site with unique, concise Spanish titles and descriptions for main pages. 
- Provide consistent canonicals and absolute Open Graph values that point to the production URL to avoid duplicate-content and sharing issues. 
- Give project detail pages meaningful, project-specific metadata so individual cases surface properly in search and social previews.

### Description
- Extended `BaseLayout` to accept `ogType`, `ogTitle`, and `ogDescription` props and continued centralizing canonical generation and absolute Open Graph image resolution there. 
- Updated page-level SEO values (title/description) for the Home, Proyectos, Servicios, Contacto, and Sobre mí pages to unique, Spanish, Search Console–friendly strings. 
- Improved project detail metadata in `src/pages/proyectos/[slug].astro` by computing a cleaned `metaDescription` from the project content, composing a `Title — MarinDev` pattern, and passing `ogType="article"`, `ogTitle`, and `ogDescription` into the shared layout. 
- Kept all visible content, layout, routes, CTAs, WhatsApp number and pricing unchanged and preserved the existing image fallback chain for OG images.

### Testing
- Ran `npm run build` and the static build completed successfully with generated pages under `dist/`. 
- Inspected generated HTML for `/`, `/proyectos/`, `/servicios/`, `/contacto/`, `/sobre-mi/` and a project detail (`/proyectos/vetcare/`) and confirmed each page contains a single canonical, unique title and description, `og:url`/canonical that use the production URL, and OG/Twitter metadata populated. 
- No visual or layout changes were introduced by these metadata updates and the site build artifacts were validated as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0516cf73948328b4b65935b586198f)