### PR TITLE
Add basic JSON-LD structured data (WebSite, Organization, Breadcrumbs, CreativeWork)

### DIFF
--- a/docs/structured-data.md
+++ b/docs/structured-data.md
@@ -1,0 +1,62 @@
+# Structured data
+
+Este sitio usa JSON-LD mínimo y verificable para ayudar a Google Search Console y otros validadores a entender la identidad del sitio y la estructura de los casos de portfolio.
+
+## Schema global
+
+`src/layouts/BaseLayout.astro` emite en todas las páginas:
+
+- `WebSite`
+  - `name`: `MarinDev`
+  - `url`: valor de `PUBLIC_SITE_URL` a través de `SITE_URL`
+  - `description`: descripción general del sitio
+  - `inLanguage`: `es-UY`
+  - `publisher`: `Organization` básica de MarinDev
+- `Organization`
+  - `name`: `MarinDev`
+  - `alternateName`: `Marin.dev`
+  - `url`: valor de `PUBLIC_SITE_URL` a través de `SITE_URL`
+  - `logo`: imagen pública del sitio
+  - `description`: descripción general del sitio
+  - `founder`: `Person` con el nombre visible `Diego Marin`
+  - `sameAs`: GitHub, LinkedIn e Instagram existentes en `src/lib/contact.ts`
+
+Se eligió `Organization` porque el sitio se presenta como marca/estudio (`MarinDev` / `Marin.dev`) aunque incluya la persona fundadora.
+
+## Schema en páginas de proyecto
+
+`src/pages/proyectos/[slug].astro` agrega datos estructurados específicos para cada caso:
+
+- `BreadcrumbList`
+  - Inicio
+  - Proyectos
+  - Nombre del proyecto
+- `CreativeWork`
+  - `name`: título del proyecto desde la colección MDX
+  - `description`: resumen/impacto/capacidad/solución disponible en el contenido
+  - `url`: URL canónica del caso usando `PUBLIC_SITE_URL`
+  - `image`: imagen/thumbnail/cover disponible
+  - `inLanguage`: `es-UY`
+  - `creator`: `Organization` MarinDev
+
+## Datos que se omitieron intencionalmente
+
+No se agregaron datos que no estén confirmados o visibles en el sitio:
+
+- Reviews, ratings o testimonios.
+- Precios, ofertas comerciales con importes, disponibilidad o inventario.
+- Dirección física, teléfono de negocio, horarios de atención o datos de local comercial.
+- Métricas de rendimiento no comprobadas.
+- Schema de `LocalBusiness` con atributos incompletos.
+
+## Cómo validar
+
+Después de un build o deploy:
+
+1. Ejecutar `npm run build` y revisar el HTML generado en `dist/`.
+2. Copiar la URL pública o el HTML generado en:
+   - [Rich Results Test](https://search.google.com/test/rich-results)
+   - [Schema Markup Validator](https://validator.schema.org/)
+3. Confirmar que cada bloque JSON-LD parsea sin errores y que no aparecen campos `undefined`.
+
+Si se agregan nuevos schemas, mantener la misma regla: solo publicar datos reales, verificables y coherentes con el contenido visible.

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -5,8 +5,6 @@ import {
   LINKEDIN_URL,
   SITE_URL,
 } from "../lib/contact";
-import { faqs } from "../data/faqs";
-import { productizedServices } from "../data/services";
 import Nav from "../components/Nav.astro";
 import Footer from "../components/Footer.astro";
 
@@ -27,9 +25,10 @@ const {
   ogType = "website",
   ogTitle = title,
   ogDescription = description,
+  structuredData = [],
 } = Astro.props;
 
-const site = Astro.site?.toString() ?? SITE_URL;
+const site = SITE_URL;
 const rawPagePath =
   typeof url === "string" && url
     ? url.startsWith("http")
@@ -48,67 +47,63 @@ const ogImage = image.startsWith("http") ? image : new URL(image, site).href;
 const logoUrl = new URL("/og-default.png", site).href;
 const googleSiteVerification = import.meta.env.PUBLIC_GOOGLE_SITE_VERIFICATION;
 
-const professionalServiceJsonLd = {
+const removeEmpty = (value: unknown): unknown => {
+  if (Array.isArray(value)) {
+    const items = value
+      .map(removeEmpty)
+      .filter((item): item is NonNullable<typeof item> => item !== undefined);
+    return items.length > 0 ? items : undefined;
+  }
+
+  if (value && typeof value === "object") {
+    const entries = Object.entries(value)
+      .map(([key, item]) => [key, removeEmpty(item)])
+      .filter(([, item]) => item !== undefined && item !== "");
+
+    return entries.length > 0 ? Object.fromEntries(entries) : undefined;
+  }
+
+  return value === undefined || value === null || value === ""
+    ? undefined
+    : value;
+};
+
+const organizationJsonLd = {
   "@context": "https://schema.org",
-  "@type": "ProfessionalService",
-  name: "Marin.dev",
+  "@type": "Organization",
+  name: "MarinDev",
+  alternateName: "Marin.dev",
   url: site,
-  image: logoUrl,
   logo: logoUrl,
+  description: defaultDescription,
   founder: {
     "@type": "Person",
     name: "Diego Marin",
     url: site,
   },
-  areaServed: ["Uruguay", "Remoto"],
-  description: defaultDescription,
   sameAs: [GITHUB_URL, LINKEDIN_URL, INSTAGRAM_URL],
-};
-
-const serviceJsonLd = {
-  "@context": "https://schema.org",
-  "@type": "Service",
-  name: "Demos web, landings y sistemas simples orientados a conversión",
-  serviceType: "Diseño y desarrollo web comercial",
-  provider: {
-    "@type": "ProfessionalService",
-    name: "Marin.dev",
-    url: site,
-  },
-  areaServed: "Uruguay y remoto",
-  description:
-    "Diseño y desarrollo de demos comerciales, landings de conversión, agendas, integraciones con WhatsApp y paneles simples para negocios reales.",
-  hasOfferCatalog: {
-    "@type": "OfferCatalog",
-    name: "Servicios productizados Marin.dev",
-    itemListElement: productizedServices.map((service) => ({
-      "@type": "Offer",
-      name: service.name,
-      description: service.description,
-    })),
-  },
 };
 
 const websiteJsonLd = {
   "@context": "https://schema.org",
   "@type": "WebSite",
-  name: "Marin.dev",
+  name: "MarinDev",
   url: site,
+  description: defaultDescription,
   inLanguage: "es-UY",
+  publisher: {
+    "@type": "Organization",
+    name: "MarinDev",
+    url: site,
+  },
 };
 
-const faqJsonLd = {
-  "@context": "https://schema.org",
-  "@type": "FAQPage",
-  mainEntity: faqs.map((item) => ({
-    "@type": "Question",
-    name: item.q,
-    acceptedAnswer: {
-      "@type": "Answer",
-      text: item.a,
-    },
-  })),
-};
+const pageStructuredData = Array.isArray(structuredData)
+  ? structuredData
+  : [structuredData];
+const jsonLdItems = [websiteJsonLd, organizationJsonLd, ...pageStructuredData]
+  .map(removeEmpty)
+  .filter(Boolean);
 ---
 <html lang="es" class="dark scroll-smooth">
   <head>
@@ -140,11 +135,10 @@ const faqJsonLd = {
     <meta name="twitter:image" content={ogImage} />
     <meta name="twitter:image:alt" content="Marin.dev: demos web y sistemas simples para negocios" />
 
-    <!-- JSON-LD: identidad, sitio y servicios -->
-    <script type="application/ld+json" set:html={JSON.stringify(professionalServiceJsonLd)} />
-    <script type="application/ld+json" set:html={JSON.stringify(websiteJsonLd)} />
-    <script type="application/ld+json" set:html={JSON.stringify(serviceJsonLd)} />
-    <script type="application/ld+json" set:html={JSON.stringify(faqJsonLd)} />
+    <!-- JSON-LD: identidad del sitio y datos estructurados de página -->
+    {jsonLdItems.map((item) => (
+      <script type="application/ld+json" set:html={JSON.stringify(item)} />
+    ))}
 
     <link rel="icon" href="/favicon.svg" />
   </head>

--- a/src/pages/proyectos/[slug].astro
+++ b/src/pages/proyectos/[slug].astro
@@ -4,7 +4,7 @@ import Badge from '../../components/Badge.astro';
 import Container from '../../components/Container.astro';
 import GlowCard from '../../components/GlowCard.astro';
 import ProjectLinkPreview from '../../components/ProjectLinkPreview.astro';
-import { getProjectLeadMessage, waLink } from '../../lib/contact';
+import { SITE_URL, getProjectLeadMessage, waLink } from '../../lib/contact';
 import { toAnalyticsSlug } from '../../lib/analytics';
 import { getCollection } from 'astro:content';
 
@@ -58,8 +58,64 @@ const statusTone = {
 };
 const whatsappText = getProjectLeadMessage(title);
 const analyticsProjectSlug = toAnalyticsSlug(proyecto.slug || title);
+const projectPath = `/proyectos/${proyecto.slug}/`;
+const projectUrl = new URL(projectPath, SITE_URL).href;
+const projectsUrl = new URL('/proyectos/', SITE_URL).href;
+const homeUrl = new URL('/', SITE_URL).href;
+const projectImageUrl = previewImage
+  ? new URL(previewImage, SITE_URL).href
+  : undefined;
+
+const breadcrumbJsonLd = {
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  itemListElement: [
+    {
+      "@type": "ListItem",
+      position: 1,
+      name: "Inicio",
+      item: homeUrl,
+    },
+    {
+      "@type": "ListItem",
+      position: 2,
+      name: "Proyectos",
+      item: projectsUrl,
+    },
+    {
+      "@type": "ListItem",
+      position: 3,
+      name: title,
+      item: projectUrl,
+    },
+  ],
+};
+
+const creativeWorkJsonLd = {
+  "@context": "https://schema.org",
+  "@type": "CreativeWork",
+  name: title,
+  description: metaDescription,
+  url: projectUrl,
+  image: projectImageUrl,
+  inLanguage: "es-UY",
+  creator: {
+    "@type": "Organization",
+    name: "MarinDev",
+    url: homeUrl,
+  },
+};
 ---
-<BaseLayout title={projectSeoTitle} description={metaDescription} image={previewImage} url={`/proyectos/${proyecto.slug}`} ogType="article" ogTitle={projectSeoTitle} ogDescription={metaDescription}>
+<BaseLayout
+  title={projectSeoTitle}
+  description={metaDescription}
+  image={previewImage}
+  url={projectPath}
+  ogType="article"
+  ogTitle={projectSeoTitle}
+  ogDescription={metaDescription}
+  structuredData={[breadcrumbJsonLd, creativeWorkJsonLd]}
+>
   <Container class="py-12 sm:py-16">
     <article class="min-w-0">
       <header class="grid min-w-0 gap-8 lg:grid-cols-[minmax(0,1fr)_minmax(0,28rem)] lg:items-center">


### PR DESCRIPTION
### Motivation

- Improve technical SEO and readiness for Google Search Console by emitting minimal, honest JSON-LD that represents the site identity and project pages without inventing business data. 
- Prefer an `Organization` representation for the brand while keeping the founder `Person` entry, and avoid claims like reviews, prices, address or hours that are not present on the site.

### Description

- Update `src/layouts/BaseLayout.astro` to emit global `WebSite` and `Organization` JSON-LD using `SITE_URL` (derived from `PUBLIC_SITE_URL`) and render any page-specific structured data passed via a new `structuredData` prop, with a `removeEmpty` helper to strip undefined/empty fields. 
- Modify `src/pages/proyectos/[slug].astro` to generate and pass `BreadcrumbList` and a conservative `CreativeWork` JSON-LD for each project using existing MDX fields (`title`, `resumen`/`impacto`/`capacidad`/`solucion`, `cover`/`thumbnail`), and build canonical project URLs via `SITE_URL`. 
- Add `docs/structured-data.md` documenting what schema is emitted, what was intentionally omitted (reviews, local business data, prices, etc.), and how to validate results. 
- Ensure no visual changes, no new dependencies, and that JSON-LD uses only real data from `src/lib/contact.ts` / project content so no fake or invented business attributes are published.

### Testing

- Ran `npm run build` which completed successfully and produced static HTML in `dist/`.
- Programmatically inspected generated HTML (`dist/index.html` and `dist/proyectos/vetcare/index.html`) to confirm JSON-LD scripts are present and parseable: index pages include `WebSite` and `Organization`, project pages include `BreadcrumbList` and `CreativeWork`, and no `undefined` values were found. 
- Ran `git diff --check` and a docs file `docs/structured-data.md` was created to explain validation steps and omissions; `prettier` reported no Astro parser for `.astro` files but this did not affect the build or JSON-LD validity.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a051ad058148328a06e521e535d48b9)