### PR TITLE
Add Search Console readiness QA and lightweight `seo-check` script

### DIFF
--- a/docs/search-console-readiness.md
+++ b/docs/search-console-readiness.md
@@ -1,0 +1,69 @@
+# Search Console readiness QA
+
+## Production URL
+
+- Active production URL: `https://marin-dev.vercel.app`
+- Sitemap URL to submit: `https://marin-dev.vercel.app/sitemap-index.xml`
+
+## Verification method supported
+
+The site supports Google Search Console verification through the `PUBLIC_GOOGLE_SITE_VERIFICATION` environment variable.
+
+- When `PUBLIC_GOOGLE_SITE_VERIFICATION` is set at build time, the layout renders a `<meta name="google-site-verification">` tag.
+- When the variable is not set, the verification meta tag is intentionally omitted.
+
+## Pages expected to index
+
+The generated sitemap includes these main public pages:
+
+- `https://marin-dev.vercel.app/`
+- `https://marin-dev.vercel.app/proyectos/`
+- `https://marin-dev.vercel.app/servicios/`
+- `https://marin-dev.vercel.app/contacto/`
+- `https://marin-dev.vercel.app/sobre-mi/`
+- `https://marin-dev.vercel.app/proyectos/agencia_ariel/`
+- `https://marin-dev.vercel.app/proyectos/brasa-23/`
+- `https://marin-dev.vercel.app/proyectos/cristal-sagrado/`
+- `https://marin-dev.vercel.app/proyectos/noir-barber-studio/`
+- `https://marin-dev.vercel.app/proyectos/servicio-de-tarot/`
+- `https://marin-dev.vercel.app/proyectos/smart-stock/`
+- `https://marin-dev.vercel.app/proyectos/vetcare/`
+- `https://marin-dev.vercel.app/politica-de-privacidad/`
+- `https://marin-dev.vercel.app/gracias/`
+
+## Pages intentionally not indexed
+
+No generated page currently includes a `noindex` directive.
+
+Note: `/gracias/` is included in the generated sitemap because it is a static public page. If the site later needs to keep thank-you pages out of search results, handle that as a separate explicit SEO decision.
+
+## QA results
+
+- `robots.txt` allows crawling with `User-agent: *` and `Allow: /`.
+- `robots.txt` references `https://marin-dev.vercel.app/sitemap-index.xml`.
+- `sitemap-index.xml` and `sitemap-0.xml` are generated in `dist/`.
+- The sitemap uses the active production URL: `https://marin-dev.vercel.app`.
+- Key pages have exactly one canonical tag.
+- Key pages have title and meta description tags.
+- Key pages include Open Graph metadata.
+- JSON-LD scripts in generated HTML parse as valid JSON.
+- The generated default build does not render `google-site-verification` unless the verification env var exists.
+
+## Old-domain references result
+
+The generated SEO-critical files do not use the old GitHub Pages domain `daegon13.github.io` for canonical URLs, Open Graph URLs, robots sitemap references or sitemap URLs.
+
+A non-critical legacy text link to `https://daegon13.github.io/` remains on the privacy policy page. It is not a canonical, sitemap URL, robots directive, Open Graph URL or JSON-LD identity URL.
+
+## Manual post-deploy checklist
+
+After deploying to production:
+
+1. Open `https://marin-dev.vercel.app/robots.txt` and confirm it returns `200` with `Allow: /`.
+2. Open `https://marin-dev.vercel.app/sitemap-index.xml` and confirm it returns `200`.
+3. Open the homepage source and check the canonical is `https://marin-dev.vercel.app/`.
+4. Open one project page source and check the canonical matches that project URL.
+5. Submit `https://marin-dev.vercel.app/sitemap-index.xml` in Google Search Console.
+6. Use URL Inspection for `https://marin-dev.vercel.app/`.
+7. Request indexing for the homepage after deploy.
+8. Check the Page indexing report after a few days.

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "format": "prettier --write .",
     "lint": "eslint .",
     "check:mobile-layout": "node scripts/check-mobile-layout-contract.mjs",
-    "audit:mobile-patterns": "node scripts/audit-mobile-patterns.mjs"
+    "audit:mobile-patterns": "node scripts/audit-mobile-patterns.mjs",
+    "seo:grep": "node scripts/seo-check.mjs"
   },
   "dependencies": {
     "@astrojs/sitemap": "^3.1.4",

--- a/scripts/seo-check.mjs
+++ b/scripts/seo-check.mjs
@@ -1,0 +1,138 @@
+import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
+import { join, relative } from "node:path";
+
+const distDir = "dist";
+const productionUrl = (
+  process.env.PUBLIC_SITE_URL ?? "https://marin-dev.vercel.app"
+).replace(/\/$/, "");
+const oldDomain = "daegon13.github.io";
+const keyPages = [
+  "index.html",
+  "proyectos/index.html",
+  "servicios/index.html",
+  "contacto/index.html",
+  "sobre-mi/index.html",
+  "proyectos/vetcare/index.html",
+];
+
+const fail = (message) => {
+  throw new Error(message);
+};
+
+const read = (path) => readFileSync(path, "utf8");
+const files = [];
+
+const walk = (dir) => {
+  for (const entry of readdirSync(dir)) {
+    const path = join(dir, entry);
+    const stat = statSync(path);
+    if (stat.isDirectory()) walk(path);
+    else files.push(path);
+  }
+};
+
+if (!existsSync(distDir)) {
+  fail("dist/ does not exist. Run npm run build first.");
+}
+
+walk(distDir);
+
+const htmlFiles = files.filter((file) => file.endsWith(".html"));
+const xmlFiles = files.filter((file) => file.endsWith(".xml"));
+const robotsPath = join(distDir, "robots.txt");
+const sitemapIndexPath = join(distDir, "sitemap-index.xml");
+const sitemapPath = join(distDir, "sitemap-0.xml");
+
+if (!existsSync(robotsPath)) fail("Missing dist/robots.txt");
+if (!existsSync(sitemapIndexPath)) fail("Missing dist/sitemap-index.xml");
+if (!existsSync(sitemapPath)) fail("Missing dist/sitemap-0.xml");
+
+const robots = read(robotsPath);
+if (!/User-agent:\s*\*/i.test(robots))
+  fail("robots.txt is missing User-agent: *");
+if (!/Allow:\s*\//i.test(robots))
+  fail("robots.txt does not explicitly allow /");
+if (!robots.includes(`Sitemap: ${productionUrl}/sitemap-index.xml`)) {
+  fail(`robots.txt sitemap does not match ${productionUrl}/sitemap-index.xml`);
+}
+
+const sitemapIndex = read(sitemapIndexPath);
+const sitemap = read(sitemapPath);
+if (!sitemapIndex.includes(`${productionUrl}/sitemap-0.xml`)) {
+  fail(
+    "sitemap-index.xml does not reference the active production sitemap URL",
+  );
+}
+
+const requiredUrls = [
+  `${productionUrl}/`,
+  `${productionUrl}/proyectos/`,
+  `${productionUrl}/servicios/`,
+  `${productionUrl}/contacto/`,
+  `${productionUrl}/sobre-mi/`,
+];
+for (const url of requiredUrls) {
+  if (!sitemap.includes(`<loc>${url}</loc>`)) fail(`Sitemap is missing ${url}`);
+}
+
+for (const keyPage of keyPages) {
+  const path = join(distDir, keyPage);
+  if (!existsSync(path)) fail(`Missing key page: dist/${keyPage}`);
+  const html = read(path);
+  const canonicalCount = (html.match(/rel="canonical"/g) ?? []).length;
+  if (canonicalCount !== 1)
+    fail(`dist/${keyPage} has ${canonicalCount} canonical tags`);
+  if (!/<title>[^<]+<\/title>/.test(html))
+    fail(`dist/${keyPage} is missing a title`);
+  if (!/<meta name="description" content="[^"]+"/.test(html)) {
+    fail(`dist/${keyPage} is missing a meta description`);
+  }
+  if (
+    !/property="og:title"/.test(html) ||
+    !/property="og:description"/.test(html) ||
+    !/property="og:url"/.test(html)
+  ) {
+    fail(`dist/${keyPage} is missing required Open Graph metadata`);
+  }
+  if (/noindex/i.test(html)) fail(`dist/${keyPage} contains noindex`);
+}
+
+for (const htmlFile of htmlFiles) {
+  const html = read(htmlFile);
+  const matches = html.matchAll(
+    /<script type="application\/ld\+json">([\s\S]*?)<\/script>/g,
+  );
+  for (const match of matches) {
+    try {
+      JSON.parse(match[1]);
+    } catch (error) {
+      fail(
+        `${relative(distDir, htmlFile)} has invalid JSON-LD: ${error.message}`,
+      );
+    }
+  }
+}
+
+const criticalFiles = [robotsPath, ...xmlFiles];
+for (const file of criticalFiles) {
+  const contents = read(file);
+  const relativePath = relative(distDir, file);
+  if (contents.includes(oldDomain)) {
+    fail(`${relativePath} contains old GitHub Pages domain ${oldDomain}`);
+  }
+}
+
+for (const htmlFile of htmlFiles) {
+  const html = read(htmlFile);
+  const head = html.match(/<head>([\s\S]*?)<\/head>/i)?.[1] ?? "";
+  if (head.includes(oldDomain)) {
+    fail(
+      `${relative(distDir, htmlFile)} contains old GitHub Pages domain ${oldDomain} in SEO head metadata`,
+    );
+  }
+}
+
+console.log(`SEO dist check passed for ${productionUrl}`);
+console.log(
+  `Checked ${keyPages.length} key pages, ${htmlFiles.length} HTML files, robots.txt and sitemap files.`,
+);


### PR DESCRIPTION
### Motivation

- Provide an automated, repeatable technical SEO QA for Search Console readiness before deployment.
- Ensure sitemaps, robots, canonicals, OG tags and JSON-LD are valid and that no critical SEO metadata points to the old GitHub Pages domain.

### Description

- Add a lightweight, dependency-free QA script at `scripts/seo-check.mjs` that validates `dist/` for `robots.txt`, `sitemap-index.xml`/`sitemap-0.xml`, required sitemap entries, exactly one canonical per key page, presence of `title` and `meta description`, required Open Graph properties, no accidental `noindex`, and valid JSON-LD parsing.
- The script also checks SEO-critical files and `<head>` metadata for occurrences of the old domain `daegon13.github.io` and fails only when those occurrences are relevant to indexing or discovery.
- Add `docs/search-console-readiness.md` documenting the production URL, verification method supported, sitemap URL to submit, pages expected to index, pages intentionally not indexed, old-domain findings, and a post-deploy checklist.
- Register the script in `package.json` as `seo:grep` and format added files with Prettier.

### Testing

- Ran `npm run build` and the build completed successfully.
- Ran `PUBLIC_GOOGLE_SITE_VERIFICATION=seo-test-token npm run build` to confirm the verification meta tag is rendered when the env var is set and this succeeded.
- Ran the new QA script with `npm run seo:grep` against the generated `dist/` and it passed, reporting no critical SEO issues.
- Ran `npx prettier --check` to verify formatting of `package.json`, `scripts/seo-check.mjs` and `docs/search-console-readiness.md` and the files are formatted correctly.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a051de0a70c8328bedd87d2d38f6e54)